### PR TITLE
Issue 37705: Animal history returning whole database when invalid ID …

### DIFF
--- a/ehr/resources/views/animalHistory.view.xml
+++ b/ehr/resources/views/animalHistory.view.xml
@@ -6,6 +6,7 @@
         <dependency path="ehr/form/field/CageField.js"/>
 
         <dependency path="ehr/panel/MultiAnimalFilterType.js"/>
+        <dependency path="ehr/panel/SingleAnimalFilterType.js"/>
         <dependency path="ehr/panel/LocationFilterType.js"/>
 
         <dependency path="ehr/panel/AnimalHistoryPanel.js"/>

--- a/ehr/resources/views/participantView.view.xml
+++ b/ehr/resources/views/participantView.view.xml
@@ -6,6 +6,7 @@
         <dependency path="ehr/form/field/CageField.js"/>
 
         <dependency path="ehr/panel/MultiAnimalFilterType.js"/>
+        <dependency path="ehr/panel/SingleAnimalFilterType.js"/>
         <dependency path="ehr/panel/LocationFilterType.js"/>
         <dependency path="ehr/panel/HiddenSingleSubjectFilterType.js"/>
 

--- a/ehr/resources/web/ehr/panel/AnimalHistoryPanel.js
+++ b/ehr/resources/web/ehr/panel/AnimalHistoryPanel.js
@@ -151,7 +151,7 @@ Ext4.define('EHR.panel.AnimalHistoryPanel', {
 
     filterTypes: [{
         xtype: 'ehr-singleanimalfiltertype',
-        inputValue: EHR.panel.SingleAnimalFilterType.filterName,
+        inputValue: LDK.panel.SingleSubjectFilterType.filterName,
         label: 'Single Animal',
         nounSingular: 'Animal',
         aliasTable: {

--- a/ehr/resources/web/ehr/panel/AnimalHistoryPanel.js
+++ b/ehr/resources/web/ehr/panel/AnimalHistoryPanel.js
@@ -82,6 +82,58 @@ Ext4.define('EHR.panel.AnimalHistoryPanel', {
         this.createTabPanel();
     },
 
+    displayWarning: function(tab){
+        var status = Ext4.create('Ext.Component',{
+            itemId: 'reportMessage',
+            html: '<div class="alert alert-warning">' + tab.report.warning + '</div>'
+        });
+
+        tab.add(status);
+    },
+
+    displayReport: function(tab){
+        // If we have a status to show the user to help set expectations, display it at the top
+        if (tab.report.reportStatus) {
+            var status = Ext4.create('Ext.Component',{
+                itemId: 'reportStatus',
+                html: '<div class="alert alert-warning" role="alert">Report Status: <strong>'
+                        + Ext4.util.Format.htmlEncode(tab.report.reportStatus)
+                        + '</strong></div>'
+            });
+
+            tab.add(status);
+        }
+
+        if (tab.report.warning) {
+            this.displayWarning(tab);
+        }
+        else {
+            switch (tab.report.reportType) {
+                case 'query':
+                    this.loadQuery(tab);
+                    break;
+                case 'details':
+                    this.loadDetails(tab);
+                    break;
+                case 'report':
+                    this.loadReport(tab);
+                    break;
+                case 'js':
+                    this.loadJS(tab);
+                    break;
+                default:
+                    LDK.Utils.getErrorCallback()({
+                        message: 'Improper Report Type'
+                    });
+            }
+        }
+
+        tab.add({
+            html:"<div id='reporttype-" + tab.report.reportType + "' style=\"display: none;\"/>",
+            hidden:true
+        });
+    },
+
     //override
     getFilterArray: function(tab){
         var report = tab.report;
@@ -98,8 +150,8 @@ Ext4.define('EHR.panel.AnimalHistoryPanel', {
     },
 
     filterTypes: [{
-        xtype: 'ldk-singlesubjectfiltertype',
-        inputValue: LDK.panel.SingleSubjectFilterType.filterName,
+        xtype: 'ehr-singleanimalfiltertype',
+        inputValue: EHR.panel.SingleAnimalFilterType.filterName,
         label: 'Single Animal',
         nounSingular: 'Animal',
         aliasTable: {

--- a/ehr/resources/web/ehr/panel/SingleAnimalFilterType.js
+++ b/ehr/resources/web/ehr/panel/SingleAnimalFilterType.js
@@ -1,0 +1,31 @@
+
+Ext4.define('EHR.panel.SingleAnimalFilterType', {
+    extend: 'LDK.panel.SingleSubjectFilterType',
+    alias: 'widget.ehr-singleanimalfiltertype',
+
+
+    validateAlias: function(tab) {
+        if (!this.isValid()) {
+            tab.items[0].report.warning = 'Animal ID not found';
+        }
+        else {
+            tab.items[0].report.warning = undefined;
+        }
+
+        return tab;
+    },
+
+    getAlias: function (subjectArray, callback, panel, tab, forceRefresh) {
+        this.aliasTableConfig(subjectArray);
+
+        this.aliasTable.success = function (results) {
+            this.handleAliases(results);
+            this.getSubjectMessages();
+            this.validateAlias(tab);
+            callback.call(panel, this.handleFilters(tab, this.subjects), forceRefresh);
+        };
+
+        LABKEY.Query.selectRows(this.aliasTable);
+    }
+
+});

--- a/ehr/resources/web/ehr/panel/SingleAnimalFilterType.js
+++ b/ehr/resources/web/ehr/panel/SingleAnimalFilterType.js
@@ -3,6 +3,10 @@ Ext4.define('EHR.panel.SingleAnimalFilterType', {
     extend: 'LDK.panel.SingleSubjectFilterType',
     alias: 'widget.ehr-singleanimalfiltertype',
 
+    statics: {
+        filterName: 'singleSubject',
+        DEFAULT_LABEL: 'Single Animal'
+    },
 
     validateAlias: function(tab) {
         if (!this.isValid()) {

--- a/ehr/test/src/org/labkey/test/components/ehr/panel/SingleAnimalFilterType.java
+++ b/ehr/test/src/org/labkey/test/components/ehr/panel/SingleAnimalFilterType.java
@@ -1,0 +1,19 @@
+package org.labkey.test.components.ehr.panel;
+
+import org.labkey.test.components.ldk.panel.SingleSubjectFilterType;
+import org.labkey.test.pages.ehr.AnimalHistoryPage;
+
+public class SingleAnimalFilterType<A extends AnimalHistoryPage> extends SingleSubjectFilterType<A>
+{
+
+    public SingleAnimalFilterType(A sourcePage)
+    {
+        super(sourcePage);
+    }
+
+    @Override
+    protected String getIdPrefix()
+    {
+        return "ehr-singleanimalfiltertype";
+    }
+}

--- a/ehr/test/src/org/labkey/test/pages/ehr/AnimalHistoryPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/AnimalHistoryPage.java
@@ -20,6 +20,7 @@ import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.ehr.panel.LocationFilterType;
 import org.labkey.test.components.ehr.panel.MultiAnimalFilterType;
+import org.labkey.test.components.ehr.panel.SingleAnimalFilterType;
 import org.labkey.test.components.ext4.Window;
 import org.labkey.test.components.ldk.panel.NoFiltersFilterType;
 import org.labkey.test.components.ldk.panel.SingleSubjectFilterType;
@@ -104,9 +105,9 @@ public class AnimalHistoryPage<A extends AnimalHistoryPage> extends ParticipantV
         refreshReport();
     }
 
-    public SingleSubjectFilterType<A> selectSingleAnimalSearch()
+    public SingleAnimalFilterType<A> selectSingleAnimalSearch()
     {
-        return new SingleSubjectFilterType<>((A)this).select();
+        return new SingleAnimalFilterType<>((A)this).select();
     }
 
     public MultiAnimalFilterType<A> selectMultiAnimalSearch()


### PR DESCRIPTION
…entered

Invalid ID entered in single animal filter caused whole database to be returned in most reports.  This change will validate ID's returned from the ID/Alias check and display "Animal ID not found" message in report window if ID is not valid.