### PR TITLE
Remove EHR/laboratory dependency

### DIFF
--- a/ehr/build.gradle
+++ b/ehr/build.gradle
@@ -1,7 +1,6 @@
 import org.labkey.gradle.util.BuildUtils;
 
 dependencies {
-   BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":externalModules:labModules:laboratory", depProjectConfig: "apiCompile")
    BuildUtils.addLabKeyDependency(project: project, config: "compile", depProjectPath: ":externalModules:labModules:LDK", depProjectConfig: "apiCompile")
    BuildUtils.addLabKeyDependency(project: project, config: "apiCompile", depProjectPath: ":externalModules:labModules:LDK", depProjectConfig: "apiCompile")
 }

--- a/ehr/src/org/labkey/ehr/table/WrappingTableCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/WrappingTableCustomizer.java
@@ -24,7 +24,6 @@ import org.labkey.api.data.TableCustomizer;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.WrappedColumn;
 import org.labkey.api.ehr.EHRService;
-import org.labkey.api.laboratory.LaboratoryService;
 import org.labkey.api.ldk.LDKService;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryService;
@@ -66,7 +65,7 @@ public class WrappingTableCustomizer implements TableCustomizer
         {
             if (col.getConceptURI() == null)
             {
-                ((BaseColumnInfo)col).setConceptURI(LaboratoryService.PARTICIPANT_CONCEPT_URI);
+                ((BaseColumnInfo)col).setConceptURI(DefaultEHRCustomizer.PARTICIPANT_CONCEPT_URI);
             }
 
             String name = "EHR";
@@ -96,7 +95,7 @@ public class WrappingTableCustomizer implements TableCustomizer
         //preferentially guess based on conceptURI
         for (ColumnInfo col : ti.getColumns())
         {
-            if (LaboratoryService.PARTICIPANT_CONCEPT_URI.equals(col.getConceptURI()) && col.getJdbcType().equals(JdbcType.VARCHAR) && col.getFk() == null)
+            if (DefaultEHRCustomizer.PARTICIPANT_CONCEPT_URI.equals(col.getConceptURI()) && col.getJdbcType().equals(JdbcType.VARCHAR) && col.getFk() == null)
             {
                 return col;
             }


### PR DESCRIPTION
@labkey-jeckels so far as I can tell, this is the only reason EHR actually depends on laboratory module.  if you do a string search for 'laboratory' in the code, it returns nothing, so I'm relatively confident we dont have any JS or HTML views being referenced either.  This is an easy switch.