### PR TITLE
We use the column width from the lookup target's display column

### DIFF
--- a/ehr/resources/queries/study/studyData.query.xml
+++ b/ehr/resources/queries/study/studyData.query.xml
@@ -122,7 +122,6 @@
                         <isHidden>false</isHidden>
                         <shownInDetailsView>true</shownInDetailsView>
                         <columnTitle>Status</columnTitle>
-                        <displayWidth>50</displayWidth>
                         <conditionalFormats>
                             <conditionalFormat>
                                 <filters>


### PR DESCRIPTION
No need to set it on the raw column