### PR TITLE
Issue 39664: Key field for custom permission tables

### DIFF
--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -63,7 +63,6 @@
                 <shownInDetailsView>false</shownInDetailsView>
                 <shownInInsertView>false</shownInInsertView>
                 <isHidden>true</isHidden>
-                <isKeyField>false</isKeyField>
             </column>
             <column columnName="requirementset">
                 <nullable>true</nullable>
@@ -997,7 +996,6 @@
             </column>
             <column columnName="rowid">
                 <isAutoInc>true</isAutoInc>
-                <isKeyField>false</isKeyField>
                 <shownInInsertView>false</shownInInsertView>
                 <shownInUpdateView>false</shownInUpdateView>
             </column>
@@ -1232,7 +1230,7 @@
                 <isKeyField>false</isKeyField>
             </column>
             <column columnName="subset">
-
+                <isKeyField>true</isKeyField>
             </column>
             <column columnName="description">
 


### PR DESCRIPTION
- Key field can be rowId for custom permission ehr_lookup tables.
- Originally this was required to create these tables as custom permissions table in EHRLookupUserSchema, but special handling for rowId being pk was added.
- Other tables in ehr_lookups.xml have specific columns defined as key field, so they do not need to be updated.