### PR TITLE
Remove external modules path

### DIFF
--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -173,11 +173,6 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         return null;
     }
 
-    public String getExternalModulePath()
-    {
-        return "/externalModules/" + getModuleDirectory();
-    }
-
     public String getFolderName() { return FOLDER_NAME; }
 
     @Override


### PR DESCRIPTION
#### Rationale
Remove reference to externalModules path.  No longer needed.

#### Related Pull Requests


#### Changes
Delete getExternalModulePath()