### PR TITLE
Update api and internal packages to gradle 7-compatible configurations

### DIFF
--- a/ehr/build.gradle
+++ b/ehr/build.gradle
@@ -1,6 +1,7 @@
-import org.labkey.gradle.util.BuildUtils;
+import org.labkey.gradle.util.BuildUtils
 
 dependencies {
+   apiImplementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "apiImplementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")


### PR DESCRIPTION

#### Rationale
When updating the api and internal modules to remove use of the deprecated compile configuration, we expose some missing dependency declarations for other modules.  Previously, these dependencies were leaking through from the api module, so we need to declare explicit dependencies when they are not actually a result of reliance on api.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1247

#### Changes
* add dependency on tomcat-jsp-api
