### PR TITLE
ehr_lookups display width and typo fix

### DIFF
--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -588,7 +588,6 @@
             </column>
             <column columnName="meaning">
                 <nullable>true</nullable>
-                <displayWidth>75</displayWidth>
             </column>
             <column columnName="origGender">
                 <columnTitle>Original Gender</columnTitle>

--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -588,7 +588,7 @@
             </column>
             <column columnName="meaning">
                 <nullable>true</nullable>
-                <displayWidth>50</displayWidth>
+                <displayWidth>75</displayWidth>
             </column>
             <column columnName="origGender">
                 <columnTitle>Original Gender</columnTitle>

--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -2770,7 +2770,7 @@
                 <shownInUpdateView>false</shownInUpdateView>
                 <shownInInsertView>false</shownInInsertView>
             </column>
-            <column columnName="category">                               `
+            <column columnName="category">                               
                 <columnTitle>Category</columnTitle>
                 <fk>
                     <fkDbSchema>ehr_lookups</fkDbSchema>


### PR DESCRIPTION
#### Rationale
The gender meaning (Male/Female/Unknown), used in most reports with demographic data is wrapping into two lines with Female and Unknown.  Remove displayWidth so these will automatically be on one line. Also fix typo in ehr_lookups.xml. These changes look relevant for all centers so making changes here.

#### Changes
- Update ehr_lookups.xml with described changes.