### PR TITLE
avoid calls to ColumnInfo.getSelectName()

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/table/AssignedAtTimeForeignKey.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/AssignedAtTimeForeignKey.java
@@ -55,7 +55,7 @@ public class AssignedAtTimeForeignKey extends LookupForeignKey
         String name = tableName + "_assignedAtTime";
         QueryDefinition qd = QueryService.get().createQueryDef(targetSchema.getUser(), targetSchema.getContainer(), targetSchema, name);
         qd.setSql("SELECT\n" +
-                "sd." + _pkCol.getSelectName() + ",\n" +
+                "sd." + _pkCol.getFieldKey().toSQLString() + ",\n" +
                 "CASE " +
                 " WHEN (sd.project IS NULL) THEN NULL " +
                 " WHEN (sd.project IN (SELECT a.project FROM \"" + _ehrSchema.getContainer().getPath() + "\".study.assignment a WHERE a.participantid = sd.participantid AND a.date <= sd.date AND (a.enddate IS NULL OR a.enddate >= sd.date))) THEN TRUE" +

--- a/ehr/api-src/org/labkey/api/ehr/table/AssignmentAtTimeForeignKey.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/AssignmentAtTimeForeignKey.java
@@ -59,7 +59,7 @@ public class AssignmentAtTimeForeignKey extends LookupForeignKey
         String name = tableName + "_assignmentsAtTime";
         QueryDefinition qd = QueryService.get().createQueryDef(targetSchema.getUser(), targetSchema.getContainer(), targetSchema, name);
         qd.setSql("SELECT\n" +
-                "sd." + _pkCol.getSelectName() + ",\n" +
+                "sd." + _pkCol.getFieldKey().toSQLString() + ",\n" +
                 "group_concat(DISTINCT h.project.displayName, chr(10)) as projectsAtTime,\n" +
                 "group_concat(DISTINCT h.project.protocol.displayName, chr(10)) as protocolsAtTime,\n" +
                 "group_concat(DISTINCT h.project." + _investLastNameCol + ", chr(10)) as investigatorsAtTime,\n" +
@@ -67,7 +67,7 @@ public class AssignmentAtTimeForeignKey extends LookupForeignKey
                 "FROM \"" + schemaName + "\".\"" + queryName + "\" sd\n" +
                 "JOIN \"" + _ehrSchema.getContainer().getPath() + "\".study.assignment h\n" +
                 "  ON (sd.id = h.id AND h.dateOnly <= CAST(sd." + _dateColName + " AS DATE) AND (CAST(sd." + _dateColName + " AS DATE) <= h.enddateCoalesced) AND h.qcstate.publicdata = true)\n" +
-                "group by sd." + _pkCol.getSelectName());
+                "group by sd." + _pkCol.getFieldKey().toSQLString());
         qd.setIsTemporary(true);
 
         List<QueryException> errors = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
fix usages of ColumnInfo.getSelectName()
usually getValueSql() or getFieldKey().toSQLString() is more correct.