### PR TITLE
Fix timing on 'enter results' page

### DIFF
--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -635,6 +635,8 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         DataRegionTable templates = new DataRegionTable("query", this);
         clickAndWait(templates.link(0, 0)); // the 'enter results' link
 
+        _ext4Helper.waitForMaskToDisappear();
+
         //use the same data included with this assay
         Locator btn = Locator.linkContainingText("Download Example Data");
         waitForElement(btn);

--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -806,6 +806,8 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         DataRegionTable templates = new DataRegionTable("query", this);
         clickAndWait(Locator.linkWithText("Enter Results"));
 
+        _ext4Helper.waitForMaskToDisappear();
+
         //use the same data included with this assay
         Locator btn = Locator.linkContainingText("Download Example Data");
         waitForElement(btn);

--- a/ehr/test/src/org/labkey/test/pages/ehr/ParticipantViewPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/ParticipantViewPage.java
@@ -24,8 +24,6 @@ import org.labkey.test.pages.LabKeyPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Maps;
 import org.openqa.selenium.By;
-import org.openqa.selenium.StaleElementReferenceException;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -386,14 +384,7 @@ public class ParticipantViewPage<EC extends ParticipantViewPage.ElementCache> ex
             {
                 log("Selecting Report: " + getLabel());
                 scrollIntoView(_el);
-                try
-                {
-                    doAndWaitForRepeatedPageSignal(_el::click, REPORT_TAB_SIGNAL, Duration.ofSeconds(2));
-                }
-                catch (StaleElementReferenceException | TimeoutException ignore) // Tab signal might fire more than once
-                {
-                    _el.isDisplayed(); // Make sure it was actually the signal that was stale
-                }
+                doAndWaitForRepeatedPageSignal(_el::click, REPORT_TAB_SIGNAL, Duration.ofSeconds(2));
                 _ext4Helper.waitForMaskToDisappear(30000);
                 activeReportPanelContainer.waitForElement(getDriver(), 10000);
                 sleep(5000);


### PR DESCRIPTION
#### Rationale
ViralLoadAssayTest attempts to inspect this form before it has fully loaded

#### Changes
* Wait for form to load
* Remove try/catch. Made unnecessary by https://github.com/LabKey/ehrModules/commit/3eeb93f49b8c1c15a48d3a8530b11b0afd60adac
