### PR TITLE
Make a minimal dev build easier via Artifactory

### DIFF
--- a/EHR_ComplianceDB/build.gradle
+++ b/EHR_ComplianceDB/build.gradle
@@ -1,9 +1,5 @@
 import org.labkey.gradle.util.BuildUtils;
 
-repositories {
-   flatDir dirs: project(":server:modules:LabDevKitModules:LDK").file("lib")
-}
-
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 }


### PR DESCRIPTION
#### Rationale
We want devs to be building just the modules they're editing, but that requires improved dependency declarations

#### Changes
* Don't depend on a lib directory that doesn't exist