### PR TITLE
Issue 94: Birth entry screen not offering an unlock

### DIFF
--- a/ehr/resources/web/ehr/panel/LockAnimalsPanel.js
+++ b/ehr/resources/web/ehr/panel/LockAnimalsPanel.js
@@ -90,6 +90,8 @@ Ext4.define('EHR.panel.LockAnimalsPanel', {
 
         }
 
+        var btn = this.down('#lockBtn');
+
         //If the screen is locked by some one: display the Locked details
         if (results.locked)  {
 
@@ -99,9 +101,11 @@ Ext4.define('EHR.panel.LockAnimalsPanel', {
                 style: 'padding-bottom: 10px;',
                 border: false
             });
+            btn.setText("Unlock Entry");
         }
         else {
             this.locked_person = null;
+            btn.setText("Lock Entry");
         }
 
         this.togglePanel(!!results.locked);


### PR DESCRIPTION
#### Rationale
To prevent double-entry, the birth and arrival forms offer a "lock" feature that ensures a single user is doing entry at time. They should unlock when they're done. The button isn't clear at the moment

#### Changes
* Change button text to "Unlock" when it's locked and you're able to unlock