### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/EHR_ComplianceDB/build.gradle
+++ b/EHR_ComplianceDB/build.gradle
@@ -1,9 +1,6 @@
 import org.labkey.gradle.util.BuildUtils;
 
-repositories {
-   flatDir dirs: project(":server:modules:LabDevKitModules:LDK").file("lib")
-}
-
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/EHR_ComplianceDB/module.properties
+++ b/EHR_ComplianceDB/module.properties
@@ -1,5 +1,4 @@
 ModuleClass: org.labkey.ehr_compliancedb.EHR_ComplianceDBModule
-ModuleDependencies: LDK
 ManageVersion: false
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/Viral_Load_Assay/build.gradle
+++ b/Viral_Load_Assay/build.gradle
@@ -5,4 +5,6 @@ dependencies {
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:laboratory", depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/Viral_Load_Assay/module.properties
+++ b/Viral_Load_Assay/module.properties
@@ -1,3 +1,2 @@
 ModuleClass: org.labkey.viral_load_assay.Viral_Load_AssayModule
-ModuleDependencies: LDK, Laboratory
 ManageVersion: false

--- a/ehr/build.gradle
+++ b/ehr/build.gradle
@@ -6,4 +6,9 @@ dependencies {
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "apiImplementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"), depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "study"), depProjectConfig: 'published', depExtension: 'module')
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
+
 }

--- a/ehr/module.properties
+++ b/ehr/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.ehr.EHRModule
-ModuleDependencies: Study, Experiment, Query, LDK
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/ehr_billing/build.gradle
+++ b/ehr_billing/build.gradle
@@ -3,4 +3,7 @@ import org.labkey.gradle.util.BuildUtils;
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"), depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: 'published', depExtension: 'module')
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')
 }

--- a/ehr_billing/module.properties
+++ b/ehr_billing/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.ehr_billing.EHR_BillingModule
-ModuleDependencies: EHR, Query, LDK
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
#### Rationale
If a module takes a dependency on another module's jar file, we want to also declare a dependency on the module file so when not building everything from source we'll bring in the requisite modules and their jar files to the distribution.  Only in the rare case where we depend on an API jar and also check for the existence of corresponding module will we not also include the module dependency, and in that case we would declare the dependency on the jar file using the `labkey` configuration so the jar file will get copied to the `lib` directory of the module declaring the dependency and thus be available without the module.

We have also deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add missing module dependencies
* Move module dependency declarations from `module.properties` files to `build.gradle` files