### PR TITLE
Improve load time for data entry forms, from 10+ seconds to ~1 sec

### DIFF
--- a/ehr/resources/web/ehr/panel/RequestDataEntryPanel.js
+++ b/ehr/resources/web/ehr/panel/RequestDataEntryPanel.js
@@ -18,6 +18,10 @@ Ext4.define('EHR.panel.RequestDataEntryPanel', {
         cfg = this.callParent(arguments);
         cfg.filterArray = cfg.filterArray || [];
         cfg.filterArray.push(LABKEY.Filter.create('requestId', this.requestId, LABKEY.Filter.Types.EQUALS));
+        // A redundant filter that can help the DB choose a more efficient query plan. SQLServer does better with this
+        // filter in choosing to use the index on the RequestId column, even if the value is being passed as a JDBC
+        // parameter instead of being embedded in the SQL as a string literal.
+        cfg.filterArray.push(LABKEY.Filter.create('requestId', this.requestId, LABKEY.Filter.Types.NOT_MISSING));
 
         return cfg;
     }

--- a/ehr/resources/web/ehr/panel/TaskDataEntryPanel.js
+++ b/ehr/resources/web/ehr/panel/TaskDataEntryPanel.js
@@ -20,6 +20,10 @@ Ext4.define('EHR.panel.TaskDataEntryPanel', {
         cfg = this.callParent(arguments);
         cfg.filterArray = cfg.filterArray || [];
         cfg.filterArray.push(LABKEY.Filter.create('taskid', this.taskId, LABKEY.Filter.Types.EQUALS));
+        // A redundant filter that can help the DB choose a more efficient query plan. SQLServer does better with this
+        // filter in choosing to use the index on the TaskId column, even if the value is being passed as a JDBC
+        // parameter instead of being embedded in the SQL as a string literal.
+        cfg.filterArray.push(LABKEY.Filter.create('taskid', this.requestId, LABKEY.Filter.Types.NOT_MISSING));
 
         return cfg;
     }

--- a/ehr/resources/web/ehr/panel/TaskDataEntryPanel.js
+++ b/ehr/resources/web/ehr/panel/TaskDataEntryPanel.js
@@ -23,7 +23,7 @@ Ext4.define('EHR.panel.TaskDataEntryPanel', {
         // A redundant filter that can help the DB choose a more efficient query plan. SQLServer does better with this
         // filter in choosing to use the index on the TaskId column, even if the value is being passed as a JDBC
         // parameter instead of being embedded in the SQL as a string literal.
-        cfg.filterArray.push(LABKEY.Filter.create('taskid', this.requestId, LABKEY.Filter.Types.NOT_MISSING));
+        cfg.filterArray.push(LABKEY.Filter.create('taskid', this.taskId, LABKEY.Filter.Types.NOT_MISSING));
 
         return cfg;
     }


### PR DESCRIPTION
#### Rationale
EHR data entry forms sometimes take a long time to load, even though the datasets have indices on the columns that are being used to filter the big tables (requestId, taskId). The problem is that SQL Server isn't choosing to use the index when the value is being passed as a JDBC parameter instead of a string literal in the SQL

#### Changes
* Add a redundant filter, which makes SQL Server choose a much faster execution plan