### PR TITLE
Don't allow duplicate account alias values

### DIFF
--- a/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-20.001-20.002.sql
+++ b/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-20.001-20.002.sql
@@ -1,0 +1,4 @@
+-- Convert from a plain index to a unique constraint
+SELECT core.fn_dropifexists ('aliases', 'ehr_billing', 'INDEX', 'EHR_BILLING_ALIASES_INDEX');
+
+ALTER TABLE ehr_billing.aliases ADD CONSTRAINT UNIQUE_ALIAS UNIQUE (Container, alias);

--- a/ehr_billing/resources/schemas/dbscripts/sqlserver/ehr_billing-20.001-20.002.sql
+++ b/ehr_billing/resources/schemas/dbscripts/sqlserver/ehr_billing-20.001-20.002.sql
@@ -1,0 +1,5 @@
+-- Convert from a plain index to a unique constraint
+EXEC core.fn_dropifexists 'aliases', 'ehr_billing', 'INDEX', 'EHR_BILLING_ALIASES_INDEX';
+GO
+
+ALTER TABLE ehr_billing.aliases ADD CONSTRAINT UNIQUE_ALIAS UNIQUE (alias, Container);

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingModule.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingModule.java
@@ -64,7 +64,7 @@ public class EHR_BillingModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.001;
+        return 20.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Having duplicate account records will break many billing queries. No existing centers have duplicate values in use.

#### Related Pull Requests
* https://github.com/LabKey/tnprc_billing/pull/96

#### Changes
* Change from standard index to a unique constraint