### PR TITLE
Fix ONPRC_BillingTest

### DIFF
--- a/ehr/test/src/org/labkey/test/tests/external/onprc/ONPRC_BillingTest.java
+++ b/ehr/test/src/org/labkey/test/tests/external/onprc/ONPRC_BillingTest.java
@@ -62,18 +62,6 @@ public class ONPRC_BillingTest extends AbstractONPRC_EHRTest
         initTest.initProject();
     }
 
-    @Override
-    @LogMethod
-    protected void initProject() throws Exception
-    {
-        super.initProject();
-
-        SchemaHelper schemaHelper = new SchemaHelper(this);
-        // let's try moving the linked schema here, since it may be causing an error during study import (see issue #36061)
-        // TODO: revisit this after monitoring success on TeamCity for some time (> 1 week)
-        schemaHelper.createLinkedSchema(this.getProjectName(), null, "onprc_billing_public", "/" + this.getContainerPath(), "onprc_billing_public", null, null, null);
-    }
-
     @Test
     public void testNotifications()
     {


### PR DESCRIPTION
#### Rationale
We are now creating the linked schema already in the base class's setup. Not sure if there was another failure that had caused the test to be muted, but this is the only fix needed.

#### Changes
* Remove second creation of the onprc_billing_public schema