### PR TITLE
Clinical history not HTML encoding database values

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/history/AbstractDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/AbstractDataSource.java
@@ -39,6 +39,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.util.DateUtil;
 import org.labkey.api.util.Formats;
+import org.labkey.api.util.PageFlowUtil;
 
 import java.sql.SQLException;
 import java.text.DecimalFormat;
@@ -358,11 +359,13 @@ abstract public class AbstractDataSource extends EHROwnable implements HistoryDa
     protected String safeAppend(Results rs, String label, String field, String suffix) throws SQLException
     {
         FieldKey fk = FieldKey.fromString(field);
+        String result = "";
         if (rs.hasColumn(fk) && rs.getObject(fk) != null)
         {
-            return (label == null ? "" : label + ": ") + rs.getString(fk) + (suffix == null ? "" : suffix) + "\n";
+            result = (label == null ? "" : label + ": ") + rs.getString(fk) + (suffix == null ? "" : suffix) + "\n";
         }
-        return "";
+
+        return PageFlowUtil.filter(result);
     }
 
     protected void addDateField(Container c, Results rs, StringBuilder sb, String columnName, String displayLabel) throws SQLException

--- a/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
@@ -67,7 +67,7 @@ public class DefaultLabworkDataSource extends AbstractDataSource
         {
             sb.append(safeAppend(rs, "Performed By", "performedby"));
             //Modified 10-13-2017 Blasa
-            sb.append(safeAppend(rs, "Testing Performed by", "createdby/DisplayName"));
+//            sb.append(safeAppend(rs, "Testing Performed by", "createdby/DisplayName"));
         }
 
         sb.append(safeAppend(rs, "Service/Panel", "servicerequested"));

--- a/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
@@ -67,7 +67,7 @@ public class DefaultLabworkDataSource extends AbstractDataSource
         {
             sb.append(safeAppend(rs, "Performed By", "performedby"));
             //Modified 10-13-2017 Blasa
-//            sb.append(safeAppend(rs, "Testing Performed by", "createdby/DisplayName"));
+            sb.append(safeAppend(rs, "Testing Performed by", "createdby/DisplayName"));
         }
 
         sb.append(safeAppend(rs, "Service/Panel", "servicerequested"));


### PR DESCRIPTION
#### Rationale
HTML generated from data sources used for clinical history is not encoding values.

#### Changes
- Call PageFlowUtil.filter on results in AbstractDataSource.safeAppend.  safeAppend used consistently across data sources.
