### PR TITLE
Rename LabkeyScriptEngineManager -> LabKeyScriptEngineManager

### DIFF
--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
@@ -155,7 +155,7 @@ public class GeneticCalculationsRTask extends WorkDirectoryTask<GeneticCalculati
         //preferentially use R config setup in scripting props.  only works if running locally.
         if (PipelineJobService.get().getLocationType() == PipelineJobService.LocationType.WebServer)
         {
-            LabKeyScriptEngineManager svc = ServiceRegistry.get().getService(LabKeyScriptEngineManager.class);
+            LabKeyScriptEngineManager svc = LabKeyScriptEngineManager.get();
             for (ExternalScriptEngineDefinition def : svc.getEngineDefinitions())
             {
                 if (RScriptEngineFactory.isRScriptEngine(def.getExtensions()))

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
@@ -29,7 +29,7 @@ import org.labkey.api.pipeline.RecordedActionSet;
 import org.labkey.api.pipeline.WorkDirectoryTask;
 import org.labkey.api.pipeline.file.FileAnalysisJobSupport;
 import org.labkey.api.reports.ExternalScriptEngineDefinition;
-import org.labkey.api.reports.LabkeyScriptEngineManager;
+import org.labkey.api.reports.LabKeyScriptEngineManager;
 import org.labkey.api.reports.RScriptEngineFactory;
 import org.labkey.api.resource.FileResource;
 import org.labkey.api.resource.Resource;
@@ -155,7 +155,7 @@ public class GeneticCalculationsRTask extends WorkDirectoryTask<GeneticCalculati
         //preferentially use R config setup in scripting props.  only works if running locally.
         if (PipelineJobService.get().getLocationType() == PipelineJobService.LocationType.WebServer)
         {
-            LabkeyScriptEngineManager svc = ServiceRegistry.get().getService(LabkeyScriptEngineManager.class);
+            LabKeyScriptEngineManager svc = ServiceRegistry.get().getService(LabKeyScriptEngineManager.class);
             for (ExternalScriptEngineDefinition def : svc.getEngineDefinitions())
             {
                 if (RScriptEngineFactory.isRScriptEngine(def.getExtensions()))


### PR DESCRIPTION
#### Rationale
Correct casing of `LabkeyScriptEngineManager`

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1704
