### PR TITLE
Change dosage column type in treatment_codes table for the ETL

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-20.001-20.002.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-20.001-20.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_lookups.treatment_codes ALTER COLUMN dosage DECIMAL(13,2);

--- a/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-20.001-20.002.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-20.001-20.002.sql
@@ -1,1 +1,1 @@
-ALTER TABLE ehr_lookups.treatment_codes ALTER COLUMN dosage DECIMAL(13,2);
+ALTER TABLE ehr_lookups.treatment_codes ALTER COLUMN dosage TYPE DECIMAL(13,2);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-20.001-20.002.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-20.001-20.002.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ehr_lookups.treatment_codes ALTER COLUMN dosage DECIMAL(13,2);
+GO

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -132,7 +132,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 20.001;
+        return 20.002;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
I changed the datatype of this field in tnprc module scripts but this needs to go in the owning module scripts.

#### Related Pull Requests
* https://github.com/LabKey/tnprc_ehr/pull/355
* https://github.com/LabKey/platform/pull/1608

#### Changes
* ALTER COLUMN dosage from Numeric(18,0) to Decimal(13,2)
