### PR TITLE
Fix typo in species column name in conditional SQL upgrade script

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr-20.000-20.001.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr-20.000-20.001.sql
@@ -77,7 +77,7 @@ BEGIN
     IF NOT EXISTS (
             SELECT column_name
             FROM information_schema.columns
-            WHERE table_name='supplemental_pedigree' and table_schema='ehr' and column_name='spcies'
+            WHERE table_name='supplemental_pedigree' and table_schema='ehr' and column_name='species'
         )
     THEN
         ALTER TABLE ehr.supplemental_pedigree ADD species VARCHAR(4000);


### PR DESCRIPTION
#### Rationale
A conditional upgrade check is trying to add the species column if it doesn't already exist, but checking for the wrong name


#### Changes
* Fix typo