### PR TITLE
Add plugins block in anticipation of removal of modules/build.gradle

### DIFF
--- a/EHR_ComplianceDB/build.gradle
+++ b/EHR_ComplianceDB/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: 'published', depExtension: 'module')

--- a/EHR_Purchasing/build.gradle
+++ b/EHR_Purchasing/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr_billing", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"), depProjectConfig: 'published', depExtension: 'module')

--- a/Viral_Load_Assay/build.gradle
+++ b/Viral_Load_Assay/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    external "org.apache.commons:commons-math3:${commonsMath3Version}"
    implementation "net.sf.opencsv:opencsv:${opencsvVersion}"

--- a/ehr/build.gradle
+++ b/ehr/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils
 
+plugins {
+   id 'org.labkey.build.module'
+}
+
 dependencies {
    apiImplementation "org.apache.tomcat:tomcat-jsp-api:${apacheTomcatVersion}"
    implementation "com.sun.mail:jakarta.mail:${javaMailVersion}"

--- a/ehr_billing/build.gradle
+++ b/ehr_billing/build.gradle
@@ -1,5 +1,9 @@
 import org.labkey.gradle.util.BuildUtils;
 
+plugins {
+    id 'org.labkey.build.module'
+}
+
 dependencies {
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "apiJarFile")


### PR DESCRIPTION
#### Rationale
We plan to remove the `server/modules/build.gradle` file that has logic to apply plugins for subprojects since that logic is only a heuristic and fails to do the right thing for file-based modules that include only client source code.  Instead, we will update each module's own `build.gradle` file so it applies the appropriate plugins (and add `build.gradle` files where there are none).  

#### Changes
* apply module plugin in build.gradle file
