### PR TITLE
Allow inputting SNOMED via separate columns based on type, propagate more parent/child form values

### DIFF
--- a/ehr/resources/scripts/ehr/ScriptHelper.js
+++ b/ehr/resources/scripts/ehr/ScriptHelper.js
@@ -616,6 +616,14 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
             return scriptOptions.snomedCodeFieldName;
         },
 
+        /**
+         * Some EHR implementations split the entry of SNOMED codes into separate virtual fields.
+         * They may configure an array of fields that should be combined to represent the full set of SNOMED values.
+         */
+        getSNOMEDSubsetCodeFieldNames: function(){
+            return scriptOptions.snomedSubsetCodeFieldNames;
+        },
+
         doCacheAccount: function(){
             return scriptOptions.cacheAccount;
         },

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -761,6 +761,19 @@ EHR.Server.Triggers.rowInit = function(helper, scriptErrors, row, oldRow){
         }
     }
 
+    if (row && helper.getSNOMEDSubsetCodeFieldNames() && helper.getSNOMEDSubsetCodeFieldNames().length) {
+        var newCodes = [];
+        for (var i = 0; i < helper.getSNOMEDSubsetCodeFieldNames().length; i++) {
+            var fieldName =  helper.getSNOMEDSubsetCodeFieldNames()[i];
+            if (row[fieldName]) {
+                newCodes.push(row[fieldName]);
+            }
+            row.codesRaw = newCodes.join(';');
+            console.log('new codes: ' + row.codesRaw);
+        }
+    }
+
+
     //update SNOMED tags if necessary.  note: this must occur prior to actual insert, since LK strips out properties that do not match actual fields
     if (!helper.isETL() && helper.getSNOMEDCodeFieldName() && !helper.isValidateOnly()){
         if (row && oldRow && row.codesRaw === oldRow.codesRaw){

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -769,7 +769,6 @@ EHR.Server.Triggers.rowInit = function(helper, scriptErrors, row, oldRow){
                 newCodes.push(row[fieldName]);
             }
             row.codesRaw = newCodes.join(';');
-            console.log('new codes: ' + row.codesRaw);
         }
     }
 

--- a/ehr/resources/web/ehr/data/ParentAndChildClientStore.js
+++ b/ehr/resources/web/ehr/data/ParentAndChildClientStore.js
@@ -1,0 +1,40 @@
+/**
+ * Some forms have a procedure as their top-level entity, with a child entity that itself has children. For example,
+ * a bacterial culture might be modeled via a procedure with a row in the Bacterial Culture dataset, with SNOMED coding
+ * and other results. This section is appropriate for the middle tier of the hierarchy, and ensures that the animal
+ * ID, date, and other fields entered at the procedure level are propagated through all the tiers.
+ */
+Ext4.define('EHR.data.ParentAndChildClientStore', {
+    extend: 'EHR.data.ParentClientStore',
+
+    insert: function(index, records) {
+        var ret = this.callParent(arguments);
+
+        // after insert of a new, track down the parent record to get the fields to inherit
+        if (this.sectionCfg && this.sectionCfg.extraProperties && this.sectionCfg.extraProperties.parentQueryName) {
+            var parentQuery = this.sectionCfg.extraProperties.parentQueryName;
+            var parentStore = this.storeCollection.getClientStoreByName(parentQuery);
+            var parentRecord = parentStore ? parentStore.getAt(0) : null;
+            if (parentRecord && Ext4.isFunction(parentStore.onRecordUpdate)) {
+                // get the set of inherited field names
+                var inheritFieldNames = [];
+                Ext4.each(this.getFields().items, function(field) {
+                    if (field.inheritFromParent) {
+                        inheritFieldNames.push(field.name);
+                    }
+                });
+
+                parentStore.onRecordUpdate(parentRecord, inheritFieldNames);
+            }
+        }
+
+        return ret;
+    },
+
+    shouldSetParentId: function(childRecord, parentFieldName, parentId) {
+        // Only used for 1:1 connections to the parent record (since both are using a form panel instead of a grid),
+        // so we always want to keep in sync
+        return childRecord.get(parentFieldName) !== parentId;
+    }
+});
+

--- a/ehr/resources/web/ehr/form/field/SnomedCodesEditor.js
+++ b/ehr/resources/web/ehr/form/field/SnomedCodesEditor.js
@@ -26,7 +26,8 @@ Ext4.define('EHR.form.field.SnomedCodesEditor', {
         LDK.Assert.assertNotEmpty('Unable to find bound record in SnomedCodesEditor.js', boundRec);
 
         Ext4.create('EHR.window.SnomedCodeWindow', {
-            boundRec: boundRec
+            boundRec: boundRec,
+            boundColumn: this.dataIndex
         }).show();
     },
 
@@ -65,6 +66,9 @@ Ext4.define('EHR.form.field.SnomedCodesEditor', {
 Ext4.define('EHR.window.SnomedCodeWindow', {
     extend: 'Ext.window.Window',
 
+    // Default to codesRaw as our backing column, but allow config to point at an alternative
+    boundColumn : 'codesRaw',
+
     initComponent: function(){
         this.snomedStore = EHR.DataEntryUtils.getSnomedStore();
 
@@ -102,7 +106,7 @@ Ext4.define('EHR.window.SnomedCodeWindow', {
                         }
                     }
 
-                    win.boundRec.set('codesRaw', codes.length ? codes.join(';') : null);
+                    win.boundRec.set(win.boundColumn, codes.length ? codes.join(';') : null);
                     win.close();
                 }
             },{
@@ -115,7 +119,7 @@ Ext4.define('EHR.window.SnomedCodeWindow', {
 
         this.callParent(arguments);
 
-        this.applyCodes(this.boundRec.get('codesRaw'));
+        this.applyCodes(this.boundRec.get(this.boundColumn));
 
         this.on('show', function(win){
             win.down('ehr-snomedcombo').focus();

--- a/ehr/resources/web/ehr/grid/SnomedColumn.js
+++ b/ehr/resources/web/ehr/grid/SnomedColumn.js
@@ -77,7 +77,7 @@ Ext4.define('EHR.grid.column.SnomedColumn', {
     handler: function(view, rowIndex, colIndex, item, e, rec) {
         Ext4.create('EHR.window.SnomedCodeWindow', {
             defaultSubset: this.defaultSubset,
-            boundColumn: this.boundColumn,
+            boundColumn: this.boundColumn ? this.boundColumn : 'codesRaw',
             boundRec: rec
         }).show();
     }

--- a/ehr/resources/web/ehr/grid/SnomedColumn.js
+++ b/ehr/resources/web/ehr/grid/SnomedColumn.js
@@ -77,6 +77,7 @@ Ext4.define('EHR.grid.column.SnomedColumn', {
     handler: function(view, rowIndex, colIndex, item, e, rec) {
         Ext4.create('EHR.window.SnomedCodeWindow', {
             defaultSubset: this.defaultSubset,
+            boundColumn: this.boundColumn,
             boundRec: rec
         }).show();
     }


### PR DESCRIPTION
#### Rationale
TNPRC wants to enter SNOMED codes separately based on category. Additionally, we need to do better in pushing shared columns across datasets in data entry forms to ensure robust support for entering the animal ID, date, etc once and making sure it is updated for all of the other tables

#### Changes
* Don't assume that the SNOMED codes are solely in a "codesRaw" field.
* New store that handles being the middle node in a parent->child->grandchild hierarchy in a single data entry form