### PR TITLE
Propagate SNOMED filtering when doing row editing

### DIFF
--- a/ehr/resources/web/ehr/form/field/SnomedCodesEditor.js
+++ b/ehr/resources/web/ehr/form/field/SnomedCodesEditor.js
@@ -27,7 +27,8 @@ Ext4.define('EHR.form.field.SnomedCodesEditor', {
 
         Ext4.create('EHR.window.SnomedCodeWindow', {
             boundRec: boundRec,
-            boundColumn: this.dataIndex
+            boundColumn: this.dataIndex,
+            defaultSubset: this.initialConfig && this.initialConfig.originalConfig && this.initialConfig.originalConfig.columnConfig ? this.initialConfig.originalConfig.columnConfig.defaultSubset : null
         }).show();
     },
 


### PR DESCRIPTION
#### Rationale
The SNOMED editor dialog is supposed to support filtering based on the category but this doesn't get applied when using the row editor view (instead of editing directly in the grid)

#### Changes
* Propagate the defaultSubset when it's configured, otherwise leave unfiltered