### PR TITLE
Bugfix to EHR Index Creation When Column Does not Exist

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -864,7 +864,20 @@ public class EHRManager
 
                     if (!exists)
                     {
-                        if (commitChanges)
+                        Set<String> missing = new HashSet<>();
+                        for (String name : cols)
+                        {
+                            if (realTable.getColumn(name) == null)
+                            {
+                                missing.add(name);
+                            }
+                        }
+
+                        if (!missing.isEmpty())
+                        {
+                            messages.add("Columns mising on table " + d.getLabel() + ": " + StringUtils.join(missing, ",")+ ".  Will not add index for: " + StringUtils.join(indexCols, ", ") + " for dataset: " + d.getLabel());
+                        }
+                        else if (commitChanges)
                         {
                             List<String> columns = new ArrayList<>();
                             for (String name : cols)

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -828,6 +828,15 @@ public class EHRManager
                         }
                     }
 
+                    for (String col : includedCols)
+                    {
+                        if (realTable.getColumn(col) == null)
+                        {
+                            //messages.add("Dataset: " + d.getName() + " does not have column " + col + ", so indexing will be skipped");
+                            missingCols = true;
+                        }
+                    }
+
                     if (missingCols)
                         continue;
 
@@ -864,20 +873,7 @@ public class EHRManager
 
                     if (!exists)
                     {
-                        Set<String> missing = new HashSet<>();
-                        for (String name : cols)
-                        {
-                            if (realTable.getColumn(name) == null)
-                            {
-                                missing.add(name);
-                            }
-                        }
-
-                        if (!missing.isEmpty())
-                        {
-                            messages.add("Columns mising on table " + d.getLabel() + ": " + StringUtils.join(missing, ",")+ ".  Will not add index for: " + StringUtils.join(indexCols, ", ") + " for dataset: " + d.getLabel());
-                        }
-                        else if (commitChanges)
+                        if (commitChanges)
                         {
                             List<String> columns = new ArrayList<>();
                             for (String name : cols)


### PR DESCRIPTION
I may or may not be targeting the right branch here. 

EHR modules can register indexes they expect EHR to create on datasets. The intent of this code is to be tolerant and skip that index if the target columns dont exist, which could have wither different center-specific studies. The problem is that this check doesnt currently account for the 'include' columns. This PR extends the code to abort if the 'include' columns are not found.