### PR TITLE
Ticket 42449: Fix for index creation when a column doesn't exist

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -818,7 +818,6 @@ public class EHRManager
                     {
                         if (realTable.getColumn(col) == null)
                         {
-                            //messages.add("Dataset: " + d.getName() + " does not have column " + col + ", so indexing will be skipped");
                             missingCols = true;
                         }
                     }
@@ -829,7 +828,6 @@ public class EHRManager
                         {
                             if (realTable.getColumn(col) == null)
                             {
-                                //messages.add("Dataset: " + d.getName() + " does not have column " + col + ", so indexing will be skipped");
                                 missingCols = true;
                             }
                         }

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -633,15 +633,10 @@ public class EHRManager
             String[][] idxToRemove = new String[][]{{"date"}, {"parentid"}, {"objectid"}, {"runId"}, {"requestid"}};
 
             Set<String> distinctIndexes = new HashSet<>();
-            for (Dataset d : study.getDatasets())
+            for (Dataset<?> d : study.getDatasets())
             {
                 String tableName = d.getDomain().getStorageTableName();
                 TableInfo realTable = StorageProvisioner.createTableInfo(d.getDomain());
-                if (realTable == null)
-                {
-                    _log.error("Table not found for dataset: " + d.getLabel() + " / " + d.getTypeURI());
-                    continue;
-                }
 
                 List<String[]> toAdd = new ArrayList<>();
                 Collections.addAll(toAdd, toIndex);
@@ -825,6 +820,18 @@ public class EHRManager
                         {
                             //messages.add("Dataset: " + d.getName() + " does not have column " + col + ", so indexing will be skipped");
                             missingCols = true;
+                        }
+                    }
+
+                    if (includedCols != null)
+                    {
+                        for (String col : includedCols)
+                        {
+                            if (realTable.getColumn(col) == null)
+                            {
+                                //messages.add("Dataset: " + d.getName() + " does not have column " + col + ", so indexing will be skipped");
+                                missingCols = true;
+                            }
                         }
                     }
 


### PR DESCRIPTION
#### Rationale
The EHR code creates indices on certain columns which may not be present in some configurations

#### Changes
* Don't create the index if the column doesn't exist