### PR TITLE
Add gitignore for dependencies.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ehr/.project
 ehr/resources/web/ehr/backup
 /hidra
 /hidra_uw_intake
+**/dependencies.txt


### PR DESCRIPTION
LabKey seems to dislike dependencies.txt files getting checked in. Therefore it seems like a good idea to add them to .gitignore, so they're not sitting in the 'unversioned files' list. This does this for ehrModules, which creates a dependencies file for Viral_Load_Assay