### PR TITLE
Allow center-specific modules to override the default EHR blood volume validation

### DIFF
--- a/ehr/resources/queries/study/blood.js
+++ b/ehr/resources/queries/study/blood.js
@@ -58,7 +58,7 @@ function onInit(event, helper){
     });
 }
 
-function onUpsert(helper, scriptErrors, row, oldRow){
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'blood', function (helper, scriptErrors, row, oldRow) {
     if (!helper.isETL() && row.date && !row.daterequested){
         if (!oldRow || !oldRow.daterequested){
             row.daterequested = row.date;
@@ -136,4 +136,4 @@ function onUpsert(helper, scriptErrors, row, oldRow){
             }
         }
     }
-}
+});


### PR DESCRIPTION
#### Rationale
Some centers want to opt out of the shared blood validation and use their own algorithms for allowable volume

#### Changes
* Register function via TriggerManager.registerHandlerForQuery() instead of using onUpsert()