### PR TITLE
Ignore generated dependencies.txt files in any of the EHR modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 ehr/.project
 ehr/resources/web/ehr/backup
-/hidra
-/hidra_uw_intake
+*/resources/credits/dependencies.txt


### PR DESCRIPTION
#### Rationale
dependencies.txt are auto-generated by the build and don't need to be committed to Git. As originally proposed in https://github.com/LabKey/ehrModules/pull/127

#### Changes
* Ignore dependencies.txt
* Hidra is long gone, no need to keep ignoring it