### PR TITLE
EHR module fixes

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -334,10 +334,10 @@ public class EHRManager
                     }
                     else
                     {
-                        if (rs.getInt("DefaultAssayQCState") != completedQCState)
+                        if (rs.getInt("DefaultPublishDataQCState") != completedQCState)
                         {
-                            messages.add("Set DefaultAssayQCState to Completed");
-                            toUpdate.put("DefaultAssayQCState", completedQCState);
+                            messages.add("Set DefaultPublishDataQCState to Completed");
+                            toUpdate.put("DefaultPublishDataQCState", completedQCState);
                         }
 
                         if (rs.getInt("DefaultDirectEntryQCState") != completedQCState)


### PR DESCRIPTION
#### Rationale
The study.study table was recently modified to rename the defaultAssayQCState field to : defaultPublishDataQCState. This PR propagates the change into the EHR code.