### PR TITLE
ColumnDecorator -> ColumnInfoTransformer

### DIFF
--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -350,7 +350,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         }
     }
 
-    private void customizeRoomCol(AbstractTableInfo ti, BaseColumnInfo room, Container ehrContainer)
+    private void customizeRoomCol(AbstractTableInfo ti, MutableColumnInfo room, Container ehrContainer)
     {
         ensureSortColumn(ti, room);
 
@@ -393,7 +393,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         }
     }
 
-    private void customizeCageCol(AbstractTableInfo ti, BaseColumnInfo cage)
+    private void customizeCageCol(AbstractTableInfo ti, MutableColumnInfo cage)
     {
         ensureSortColumn(ti, cage);
 


### PR DESCRIPTION
#### Rationale
We inconsistently set up certain common "column types" e.g. ParticipantId or Container.  Use the existing ConceptURI property to register ColumnDecorators that configure these columns.

#### Related Pull Requests
https://github.com/LabKey/accounts/pull/142
https://github.com/LabKey/commonAssays/pull/316
https://github.com/LabKey/dataintegration/pull/98
https://github.com/LabKey/DiscvrLabKeyModules/pull/98
https://github.com/LabKey/MaxQuant/pull/37
https://github.com/LabKey/platform/pull/2121
https://github.com/LabKey/sampleManagement/pull/528