### PR TITLE
Fix ehr sql script version numbering to get in sync with 21.00x module version.

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr-21.002-21.003.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr-21.002-21.003.sql
@@ -1,4 +1,9 @@
--- contents of ehr-20.001-20.002.sql
+-- same contents as ehr-20.001-20.002.sql.
+-- Rationale: When ehr-20.001-20.002.sql was created, the module version was bumped from 21.001 to 21.002
+-- rendering ehr-20.001-20.002.sql useless if the ehr module v. was already at 21.00x in the db.
+-- The script should have been numbered ehr-21.001-21.002.sql instead of ehr-20.001-20.002.sql.
+-- This script is an correction attempt to get in sync with the ehr module v. 21.00x so that this script runs
+-- and below col and constraint gets added as intended.
 
 CREATE FUNCTION ehr.addUrlColToFormFrameworkTypes() RETURNS VOID AS $$
 DECLARE

--- a/ehr/resources/schemas/dbscripts/postgresql/ehr-21.002-21.003.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr-21.002-21.003.sql
@@ -1,0 +1,38 @@
+-- contents of ehr-20.001-20.002.sql
+
+CREATE FUNCTION ehr.addUrlColToFormFrameworkTypes() RETURNS VOID AS $$
+DECLARE
+BEGIN
+    IF NOT EXISTS (
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_name='form_framework_types' and table_schema='ehr' and column_name='url'
+        )
+    THEN
+        ALTER TABLE ehr.form_framework_types ADD url varchar(255) DEFAULT NULL;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT ehr.addUrlColToFormFrameworkTypes();
+
+DROP FUNCTION ehr.addUrlColToFormFrameworkTypes();
+
+
+CREATE FUNCTION ehr.addConstraintToFormFrameworkTypes() RETURNS VOID AS $$
+DECLARE
+BEGIN
+    IF NOT EXISTS (
+            SELECT constraint_name
+            FROM information_schema.table_constraints
+            WHERE table_name='form_framework_types' and table_schema='ehr' and constraint_name='ehr_form_framework_types_unique'
+        )
+    THEN
+        ALTER TABLE ehr.form_framework_types ADD CONSTRAINT ehr_form_framework_types_unique UNIQUE (RowId);
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT ehr.addConstraintToFormFrameworkTypes();
+
+DROP FUNCTION ehr.addConstraintToFormFrameworkTypes();

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-21.002-21.003.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-21.002-21.003.sql
@@ -1,0 +1,8 @@
+-- contents of ehr-20.001-20.002.sql
+EXEC core.fn_dropifexists 'form_framework_types', 'ehr', 'column', 'url';
+GO
+ALTER TABLE ehr.form_framework_types add url varchar(255) DEFAULT NULL;
+
+EXEC core.fn_dropifexists 'form_framework_types', 'ehr', 'CONSTRAINT', 'ehr_form_framework_types_unique';
+GO
+ALTER TABLE ehr.form_framework_types ADD CONSTRAINT ehr_form_framework_types_unique UNIQUE (RowId);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-21.002-21.003.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-21.002-21.003.sql
@@ -1,4 +1,10 @@
--- contents of ehr-20.001-20.002.sql
+-- same contents as ehr-20.001-20.002.sql.
+-- Rationale: When ehr-20.001-20.002.sql was created, the module version was bumped from 21.001 to 21.002
+-- rendering ehr-20.001-20.002.sql useless if the ehr module v. was already at 21.00x in the db.
+-- The script should have been numbered ehr-21.001-21.002.sql instead of ehr-20.001-20.002.sql.
+-- This script is an correction attempt to get in sync with the ehr module v. 21.00x so that this script runs
+-- and below col and constraint gets added as intended.
+
 EXEC core.fn_dropifexists 'form_framework_types', 'ehr', 'column', 'url';
 GO
 ALTER TABLE ehr.form_framework_types add url varchar(255) DEFAULT NULL;

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -131,7 +131,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.002;
+        return 21.003;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Latest ehr script created was ehr-20.001-20.002.sql (it should have been named ehr-21.001-21.002.sql), but the module version got bumped from 21.001 to 21.002, rendering ehr-20.001-20.002.sql useless if the ehr module v. was already at 21.000.

#### Changes
*Add another script ehr-21.002-21.003.sql that's creating the same column and constraint as in ehr-20.001-20.002.sql, and bump the module v. to 21.003
