### PR TITLE
Correct casing on table and schema names so that Postgres detects when they exist

### DIFF
--- a/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-20.000-20.001.sql
+++ b/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-20.000-20.001.sql
@@ -9,7 +9,7 @@ BEGIN
     IF NOT EXISTS (
             SELECT column_name
             FROM information_schema.columns
-            WHERE table_name='miscCharges' and table_schema='ehr_billing' and column_name='chargeGroup'
+            WHERE table_name='misccharges' and table_schema='ehr_billing' and column_name='chargegroup'
         )
     THEN
         ALTER TABLE ehr_billing.miscCharges ADD chargeGroup VARCHAR(200);


### PR DESCRIPTION
#### Rationale
The upgrade script is intending to only add the ehr_billing.misccharges.chargegroup column when it's not already present. However, it's not matching correctly so it tries to double-add them and fails.

#### Changes
* Use lower case to match against PG metadata storage