### PR TITLE
Fix usage of extraBirthFieldMappings

### DIFF
--- a/ehr/resources/scripts/ehr/ScriptHelper.js
+++ b/ehr/resources/scripts/ehr/ScriptHelper.js
@@ -48,8 +48,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
         quickValidation: false,
         errorThreshold: null,
         newIdsAdded: {},
-        extraBirthFieldMappings: {},
-        extraDemographicsFieldMappings: {}
+        extraBirthFieldMappings: {}
     };
 
     //test to see if GUID persisted across tables
@@ -81,6 +80,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
      *                  to update cached records.
      * @param {Boolean} doStandardProtocolCountValidation Validate animals in protocol using ehr.protocolTotalAnimalsBySpecies
      * @param {Boolean} errorSeverityForBloodDrawsWithoutWeight Error level for blood draw requests for animals without weight
+     * @param {Map} key extraDemographicsFieldMappings Object of extra demographics fields used in TriggerScriptHelper.onAnimalArrival
      */
 
     var scriptOptions = {
@@ -105,7 +105,8 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
         announceAllModifiedParticipants: false,
         doStandardProtocolCountValidation: true,
         errorSeverityForBloodDrawsWithoutWeight: 'ERROR',
-        defaultAllowedDaysForFutureRequest: 30
+        defaultAllowedDaysForFutureRequest: 30,
+        extraDemographicsFieldMappings: {}
     };
 
     var cachedValues = {

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1513,10 +1513,7 @@ public class TriggerScriptHelper
         demographicsProps.put("calculated_status", "Alive");
         if (extraDemographicsFieldMappings != null)
         {
-            for (String fieldName : extraDemographicsFieldMappings.keySet())
-            {
-                demographicsProps.put(fieldName, row.get(extraDemographicsFieldMappings.get(fieldName)));
-            }
+            extraDemographicsFieldMappings.forEach(demographicsProps::put);
         }
         createDemographicsRecord(id, demographicsProps);
 


### PR DESCRIPTION
#### Rationale
ScriptHelper had a props field 'extraBirthFieldMappings' for inserting extra properties in demographics upon arrival. This PR fixes the usage of that prop and bug where it was utilized in TriggerScriptHelper

#### Related Pull Requests
* https://github.com/LabKey/tnprc_ehr/pull/487

