### PR TITLE
Fix project entry field

### DIFF
--- a/ehr/resources/web/ehr/form/field/ProjectEntryField.js
+++ b/ehr/resources/web/ehr/form/field/ProjectEntryField.js
@@ -128,7 +128,7 @@ Ext4.define('EHR.form.field.ProjectEntryField', {
                     var storeProjects = Ext4.Array.filter(store.collect('project'), function(proj) {
                         return LABKEY.Utils.isNumber(proj);
                     });
-                    if (storeProjects.length > 0) {
+                    if (storeProjects.length === 1) {
                         this.setValue(storeProjects[0]);
                     }
                 }
@@ -318,19 +318,19 @@ Ext4.define('EHR.form.field.ProjectEntryField', {
     this.callParent([val]);
   },
 
-  resolveProjectFromStore: function(){
+  resolveProjectFromStore: function () {
     var val = this.getValue();
     if (!val || this.isDestroyed)
       return;
 
     LDK.Assert.assertNotEmpty('Unable to find store in ProjectEntryField', this.store);
     var rec = this.store ? this.store.findRecord('project', val) : null;
-    if (rec){
+    if (rec) {
       return;
     }
 
     rec = this.allProjectStore.findRecord('project', val);
-    if (rec){
+    if (rec) {
       var newRec = this.store.createModel({});
       newRec.set({
         project: rec.data.project,
@@ -344,11 +344,9 @@ Ext4.define('EHR.form.field.ProjectEntryField', {
         fromClient: true
       });
 
-      this.store.insert(0, newRec);
-
-            return newRec;
-        }
-    },
+      return newRec;
+    }
+  },
 
   resolveProject: function(val){
     if (this.allProjectStore.isLoading()){


### PR DESCRIPTION
#### Rationale
When an animal Id is entered into a data entry form grid row, the store gets populated with animal's project and setValue sets the value of project field with first value in the list which is correct, the subsequent addition of rows adds the projects in the store list and the value of next animal with different project is not first in the list and hence incorrect. This PR fixes the aforementioned problem and also fixes the problem of projects not getting populated from second row onwards with tabbing. 

#### Related Pull Requests
* https://github.com/LabKey/LabDevKitModules/pull/75

#### Changes
* do not insert more than one project in grid store
* populate the project field only when project is there
