### PR TITLE
Attempt to fix ViralLoadAssayTest

### DIFF
--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -640,6 +640,8 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         //use the same data included with this assay
         Locator btn = Locator.linkContainingText("Download Example Data");
         waitForElement(btn);
+        
+        Ext4FieldRef.waitForField(this, "Instrument");
 
         assertEquals("Incorrect value for field", "ABI 7500", Ext4FieldRef.getForLabel(this, "Instrument").getValue());
         assertEquals("Incorrect value for field", Long.valueOf(60), Ext4FieldRef.getForLabel(this, "Eluate Volume").getValue());


### PR DESCRIPTION
The ViralLoadAssayTest can be flaky. This is an attempt to fix this type of failure:

https://teamcity.labkey.org/buildConfiguration/LabKey_213Release_External_Discvr_ExternalModulesTestPostgres/1375777?buildTab=overview