### PR TITLE
Issue 128 - Fix timeout issue in deaths trigger script

### DIFF
--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -884,7 +884,7 @@ public class TriggerScriptHelper
                 {
                     throw new RuntimeException(e);
                 }
-            }, DbScope.CommitTaskOption.POSTCOMMIT);
+            }, DbScope.CommitTaskOption.PRECOMMIT);
             transaction.commit();
         }
     }

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -32,7 +32,6 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbSchema;
-import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.RuntimeSQLException;
@@ -870,23 +869,9 @@ public class TriggerScriptHelper
             }
         }
 
-        DbScope scope = ti.getSchema().getScope();
-        try (DbScope.Transaction transaction = scope.ensureTransaction())
-        {
-            transaction.addCommitTask(() ->
-            {
-                try
-                {
-                    ti.getUpdateService().updateRows(getUser(), getContainer(), newRows, keyRows, null, getExtraContext());
-                    EHRDemographicsService.get().getAnimals(getContainer(), ids);
-                }
-                catch (InvalidKeyException | BatchValidationException | QueryUpdateServiceException | SQLException e)
-                {
-                    throw new RuntimeException(e);
-                }
-            }, DbScope.CommitTaskOption.PRECOMMIT);
-            transaction.commit();
-        }
+        ti.getUpdateService().updateRows(getUser(), getContainer(), newRows, keyRows, null, getExtraContext());
+
+        EHRDemographicsService.get().getAnimals(getContainer(), ids);
     }
 
     public Map<String, Object> getExtraContext()

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -91,7 +91,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -105,8 +104,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 
 /**


### PR DESCRIPTION
#### Rationale
Deaths trigger script times out during ETL due to the update of all the rows in demographics on deaths. This PR fixes the problem by making the update rows call outside the trigger script scope.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

