### PR TITLE
Check allowRequestsInDistantFuture setting before rejecting requests

### DIFF
--- a/ehr/resources/scripts/ehr/ScriptHelper.js
+++ b/ehr/resources/scripts/ehr/ScriptHelper.js
@@ -89,6 +89,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
         removeTimeFromDate: false,
         removeTimeFromEndDate: false,
         allowRequestsInPast: false,
+        // deprecated - use defaultAllowedDaysForFutureRequest to set an explicit date cutoff
         allowRequestsInDistantFuture: false,
         allowDeadIds: false,
         allowAnyId: false,
@@ -105,6 +106,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
         announceAllModifiedParticipants: false,
         doStandardProtocolCountValidation: true,
         errorSeverityForBloodDrawsWithoutWeight: 'ERROR',
+        // Use null to indicate any date in the future is acceptable
         defaultAllowedDaysForFutureRequest: 30
     };
 
@@ -128,7 +130,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
             cachedValues[type][id].push(date);
         }
         else {
-            console.log('aready exists');
+            console.log('already exists');
         }
     }
 
@@ -138,7 +140,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
     //we allow the client to pass limited options using extraContext
     //this function is where all processing of client JSON -> server options should reside
     function setScriptOptionsFromExtraContext(){
-        LABKEY.ExtAdapter.each(['skipIdFormatCheck', 'allowAnyId', 'allowDatesInDistantPast', 'allowRequestsInDistantFuture'], function(name){
+        LABKEY.ExtAdapter.each(['skipIdFormatCheck', 'allowAnyId', 'allowDatesInDistantPast', 'allowRequestsInDistantFuture', 'defaultAllowedDaysForFutureRequest'], function(name){
             if (extraContext[name])
                 scriptOptions[name] = extraContext[name];
         }, this);
@@ -633,7 +635,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
         },
 
         getDefaultAllowedDaysForFutureRequest: function(){
-            return scriptOptions.defaultAllowedDaysForFutureRequest;
+            return scriptOptions.allowRequestsInDistantFuture ? null : scriptOptions.defaultAllowedDaysForFutureRequest;
         },
 
         // itemName is that item's name in the db row, itemLabel is the human-readable name, and itemValue is the actual value of the item

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -150,7 +150,7 @@ EHR.Server.Triggers.beforeInsert = function(row, errors){
 
         var daysAllowed = helper.getDefaultAllowedDaysForFutureRequest();
 
-        if(daysAllowed != null && !helper.shouldAllowRequestsInDistantFuture()) {
+        if(daysAllowed != null) {
             if ((-1 * timeDiffMills) > (1000 * 60 * 60 * 24 * daysAllowed)) //30 days by default
                 EHR.Server.Utils.addError(scriptErrors, 'date', 'Cannot place a request more than '+ daysAllowed + ' days in the future', 'ERROR');
         }

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -149,7 +149,8 @@ EHR.Server.Triggers.beforeInsert = function(row, errors){
         }
 
         var daysAllowed = helper.getDefaultAllowedDaysForFutureRequest();
-        if(daysAllowed != null) {
+
+        if(daysAllowed != null && !helper.shouldAllowRequestsInDistantFuture()) {
             if ((-1 * timeDiffMills) > (1000 * 60 * 60 * 24 * daysAllowed)) //30 days by default
                 EHR.Server.Utils.addError(scriptErrors, 'date', 'Cannot place a request more than '+ daysAllowed + ' days in the future', 'ERROR');
         }


### PR DESCRIPTION
#### Rationale
ScriptHelper.js has long had an allowRequestsInDistantFuture property but it's not being used in triggers.js when rejecting a request's date

#### Changes
* Skip the check completely when shouldAllowRequestsInDistantFuture() is true, otherwise check based on  defaultAllowedDaysForFutureRequest

