### PR TITLE
Fix problems applying EHR template with animal IDs on tables with project field

### DIFF
--- a/ehr/resources/web/ehr/data/DataEntryClientStore.js
+++ b/ehr/resources/web/ehr/data/DataEntryClientStore.js
@@ -298,7 +298,7 @@ Ext4.define('EHR.data.DataEntryClientStore', {
             }
 
             if (idsNeeded.length){
-                this.ensureProjects(idsNeeded);
+                this.retrieveProjects(idsNeeded);
             }
         }
 


### PR DESCRIPTION
#### Rationale
Recent work broke applying an EHR data entry form template with animal IDs if the target table has a project field

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/161

#### Changes
* Call the right function to fetch the assignments via the demographics cache