### PR TITLE
Omit pedigree plot generations where both dam and sire are unknown

### DIFF
--- a/ehr/resources/reports/schemas/study/Pedigree/Pedigree.r
+++ b/ehr/resources/reports/schemas/study/Pedigree/Pedigree.r
@@ -15,8 +15,7 @@ library(Rlabkey)
 
 labkey.setCurlOptions(ssl_verifypeer = FALSE, ssl_verifyhost = FALSE)
 
-
-if ((length(labkey.data$id) == 0) || all(is.na(labkey.data$dam) & is.na(labkey.data$sire))) {
+if ((length(labkey.data$id) == 0) | (is.na(labkey.data$dam) & is.na(labkey.data$sire))){
     png(filename="${imgout:myscatterplot}", width = 650, height = 150);
     plot(0, 0, type='n', xaxt='n', yaxt='n', bty='n', ann=FALSE  )
     title(main = "No pedigree data found for selected animal(s).", sub = NULL, xlab = NULL, ylab = NULL,
@@ -185,6 +184,8 @@ if ((length(labkey.data$id) == 0) || all(is.na(labkey.data$dam) & is.na(labkey.d
         return (substr(lineNL, 1, nchar(lineNL) - 1));
      };
 
+    unknownIdIndex = 1
+
     #[Quoc: remove ]
     #The pedigree program expects all individuals to have either 2 parents or 1.
     #Sometimes the father is not known. For missing parents we give them a unique id and
@@ -200,8 +201,9 @@ if ((length(labkey.data$id) == 0) || all(is.na(labkey.data$dam) & is.na(labkey.d
         if (length(damIndex) == 0) damIndex <- which(allPed$Id == ped$Dam[i]);
         if (length(sireIndex) == 0) sireIndex <- which(allPed$Id == ped$Sire[i]);
 
-        if(is.na(ped$Sire[i])){
-            xt <- sample (1:99,1)
+        if((is.na(ped$Sire[i]))& (!is.na(ped$Dam[i]))){
+            xt <- unknownIdIndex
+            unknownIdIndex <- unknownIdIndex + 1
             #typeof(ped$Sire);
             #typeof(xt);
             ped$Sire[i] <- paste('xxs',xt)
@@ -209,8 +211,9 @@ if ((length(labkey.data$id) == 0) || all(is.na(labkey.data$dam) & is.na(labkey.d
             #print(ped$Dam[i])
             #print(ped$Sire[i])
         }
-        if(is.na(ped$Dam[i])){
-                xt <- sample (1:99,1)
+        if((is.na(ped$Dam[i]))& (!is.na(ped$Sire[i]))){
+                xt <- unknownIdIndex
+                unknownIdIndex <- unknownIdIndex + 1
                 #typeof(ped$Sire);
                 #typeof(xt);
                 ped$Dam[i] <- paste ('xxd',xt);


### PR DESCRIPTION
#### Rationale
The pedigree plot fills in "unknown" animals when a dam or sire is unknown. The plot used to omit generations where neither dam nor sire are known because it's essentially clutter. That got reverted accidentally.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/74

#### Changes
* Filter out generations where neither dam nor sire are known
* Use deterministic numbering for unknown animals so that the plots are consistent across renderings, and unknown animal IDs aren't accidentally reused