### PR TITLE
Issue 43104: Veterinarian auto populate is broken

### DIFF
--- a/ehr/resources/web/ehr/data/DataEntryClientStore.js
+++ b/ehr/resources/web/ehr/data/DataEntryClientStore.js
@@ -31,6 +31,7 @@ Ext4.define('EHR.data.DataEntryClientStore', {
         }
 
         this.addEvents('validation');
+        this.addEvents('projectchange');
 
         if (this.hasFormSortField){
             this.on('datachanged', this.updateFormSortField, this);
@@ -121,6 +122,7 @@ Ext4.define('EHR.data.DataEntryClientStore', {
                                 rec.beginEdit();
                                 rec.set('project', assignments[0].project);
                                 rec.endEdit(true);
+                                this.fireEvent('projectchange', assignments[0].project, null);
                                 this.fireEvent('validation', this, rec);
                             }
                         }, this);


### PR DESCRIPTION
#### Rationale
For TNPRC, the vet field should auto-populated based on the project. Recent changes to improve how the project field populated caused the vet field to not auto-populate in response to entering an animal ID

#### Changes
* Fire an event when the store initiates the project change
