### PR TITLE
SecurityPolicy.getPermissions()

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/dataentry/AbstractDataEntryForm.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/AbstractDataEntryForm.java
@@ -314,19 +314,15 @@ public class AbstractDataEntryForm implements DataEntryForm
             if (queryPerms == null)
                 queryPerms = new HashMap<>();
 
-            SecurityPolicy policy;
+            Set<Class<? extends Permission>> setOfPermissions;
 
             //test if this is a dataset
             if ("study".equalsIgnoreCase(schemaName) && datasetMap.get(queryName) != null)
-            {
-                policy = SecurityPolicyManager.getPolicy(datasetMap.get(queryName));
-            }
+                setOfPermissions = datasetMap.get(queryName).getPermissions(_ctx.getUser());
             else
-            {
-                policy = SecurityPolicyManager.getPolicy(_ctx.getContainer());
-            }
+                setOfPermissions = SecurityManager.getPermissions(_ctx.getContainer().getPolicy(), _ctx.getUser(), Set.of());
 
-            for (Class<? extends Permission> p : policy.getPermissions(_ctx.getUser()))
+            for (Class<? extends Permission> p : setOfPermissions)
             {
                 queryPerms.put(p.getName(), p.getCanonicalName());
             }

--- a/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
+++ b/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
@@ -89,7 +89,15 @@ public class EHRSecurityManager
 
     public boolean testPermission (User u, SecurableResource resource, Class<? extends Permission> perm, EHRQCState qcState)
     {
-        return resource.hasPermission(u, perm);
+        try
+        {
+            Class qcPerm = Class.forName(getPermissionClassName(perm, qcState));
+            return resource.hasPermission(u, qcPerm);
+        }
+        catch (ClassNotFoundException x)
+        {
+            return false;
+        }
     }
 
     public String getPermissionClassName(Class<? extends Permission> perm, EHRQCState qc)

--- a/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
+++ b/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.ehr.EHRQCState;
 import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.security.EHRSecurityEscalator;
+import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.SecurityPolicyManager;
@@ -88,28 +89,7 @@ public class EHRSecurityManager
 
     public boolean testPermission (User u, SecurableResource resource, Class<? extends Permission> perm, EHRQCState qcState)
     {
-        Collection<Class<? extends Permission>> permissions;
-        String className = getPermissionClassName(perm, qcState);
-
-        //NOTE: See getResourceProps() in SecurityApiActions for notes on this hack
-        if (resource instanceof Dataset)
-        {
-            Dataset ds = (Dataset)resource;
-            permissions = ds.getPermissions(u);
-        }
-        else
-        {
-            SecurityPolicy policy = SecurityPolicyManager.getPolicy(resource);
-            permissions = policy.getPermissions(u);
-        }
-
-        for (Class<? extends Permission> p : permissions)
-        {
-            if (p.getName().equals(className))
-                return true;
-        }
-
-        return false;
+        return resource.hasPermission(u, perm);
     }
 
     public String getPermissionClassName(Class<? extends Permission> perm, EHRQCState qc)


### PR DESCRIPTION
#### Rationale
Create new permission check choke-point.  Replace/unify Container.hasPermission() and SecurityPolicy.hasPermission()
* SecurityManager.hasAllPermissions()
* SecurityManager.hasAnyPermissions()
* SecurityManager.getPermissions()
* SecurityManager.getPermissionNames()

#### Related Pull Requests
* https://github.com/LabKey/compliance/pull/118
* https://github.com/LabKey/ehrModules/pull/195
* https://github.com/LabKey/snd/pull/97
* https://github.com/LabKey/platform/pull/2359
* https://github.com/LabKey/MacCossLabModules/pull/122
* https://github.com/LabKey/wnprc-modules/pull/86

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->