### PR TITLE
Migrate use of boxed primitive constructors

### DIFF
--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/AbstractWNPRCImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/AbstractWNPRCImportMethod.java
@@ -393,8 +393,8 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
         Double copiesPerRxn = map.get("Concentration") == null ? null : ((Number)map.get("Concentration")).doubleValue();
         map.put("copiesPerRxn", copiesPerRxn);
 
-        Double eluateVol = new Double((Integer)map.get("eluateVol"));
-        Double volPerRxn = new Double((Integer)map.get("volPerRxn"));
+        Double eluateVol = Double.valueOf((Integer)map.get("eluateVol"));
+        Double volPerRxn = Double.valueOf((Integer)map.get("volPerRxn"));
         if (!map.containsKey("sampleVol"))
             map.put("sampleVol", 1.0);
 


### PR DESCRIPTION
#### Rationale
"Boxed primitive constructors" (e.g., `new Double(0.23457)`) have been deprecated since JDK 9 and marked for removal as of JDK 16. Migrate away from them to reduce warnings.