### PR TITLE
Issue 43508: Improve visibility of which user ID enabled which ETLs

### DIFF
--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingModule.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingModule.java
@@ -114,22 +114,10 @@ public class EHR_BillingModule extends SpringModule
         UserManager.addUserListener(new UserManager.UserListener()
         {
             @Override
-            public void userAddedToSite(User user) {}
-
-            @Override
             public void userDeletedFromSite(User user)
             {
                 Table.delete(EHR_BillingSchema.getInstance().getDataAccessTable(), new SimpleFilter(FieldKey.fromParts("UserId"), user.getUserId()));
             }
-
-            @Override
-            public void userAccountDisabled(User user) {}
-
-            @Override
-            public void userAccountEnabled(User user) {}
-
-            @Override
-            public void propertyChange(PropertyChangeEvent evt) {}
         });
     }
 


### PR DESCRIPTION
#### Rationale
Eliminate need to implement no-op methods in UserListener via a default implementation

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2490

#### Changes
* Delete no-op methods