### PR TITLE
reduce batchsize to fix deaths etl timeout

### DIFF
--- a/ehr/resources/queries/study/deaths.js
+++ b/ehr/resources/queries/study/deaths.js
@@ -10,7 +10,7 @@ EHR.Server.Utils = require("ehr/utils").EHR.Server.Utils;
 var demographicsUpdates = [];
 var validIds = [];
 var totalDemographicsAnimalsUpdated = 0;
-var batchSize = 1000;
+var batchSize = 250;
 
 function onInit(event, helper){
     helper.setScriptOptions({


### PR DESCRIPTION
#### Rationale
The deaths ETL is tripping up because of timeout of running trigger scripts. Reducing the batchsize of animal ids in trigger script to make it within the timeframe.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/169


