### PR TITLE
Fix EHR test failures in trigger scripts after refactor to use loadRows()

### DIFF
--- a/ehr/resources/scripts/ehr/security.js
+++ b/ehr/resources/scripts/ehr/security.js
@@ -138,7 +138,7 @@ EHR.Server.Security = new function(){
             if (!hasLoaded)
                 throw 'EHR.Security.init() has not been called or returned prior to this call';
 
-           var qc = _qcByRowId[rowid];
+           var qc = _qcByRowId[parseInt(rowid)];
            if (!qc){
                 console.error('ERROR: QC State associated with the rowId ' + rowid + ' not found');
                 return null;

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -831,9 +831,10 @@ public class TriggerScriptHelper
 
     public void updateDemographicsRecord(List<Map<String, Object>> updatedRows) throws QueryUpdateServiceException, SQLException, BatchValidationException, InvalidKeyException
     {
-        updatedRows = new ArrayList<>(updatedRows);
         if (updatedRows == null || updatedRows.isEmpty())
             return;
+
+        updatedRows = new ArrayList<>(updatedRows);
 
         Set<String> ids = new HashSet<>(updatedRows.size());
         List<Map<String, Object>> newRows = new ArrayList<>(updatedRows.size());
@@ -869,9 +870,12 @@ public class TriggerScriptHelper
             }
         }
 
-        ti.getUpdateService().updateRows(getUser(), getContainer(), newRows, keyRows, null, getExtraContext());
-
-        EHRDemographicsService.get().getAnimals(getContainer(), ids);
+        if (!newRows.isEmpty())
+        {
+            ti.getUpdateService().updateRows(getUser(), getContainer(), newRows, keyRows, null, getExtraContext());
+            // Prime the cache for the updated IDs
+            EHRDemographicsService.get().getAnimals(getContainer(), ids);
+        }
     }
 
     public Map<String, Object> getExtraContext()


### PR DESCRIPTION
#### Rationale
Numeric values being added to the row map in the JS trigger code were coming through as Doubles and not converting to Longs even though they were whole numbers. Not strictly necessary due to related PR in platform, but a bit more defensive in terms of the values we can accept from the client.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2582

#### Changes
* Do explicit type conversion to ensure we get an Integer instead of a floating point for the QCState RowId
