### PR TITLE
Issue 236: Slow query when filtering SNOMED

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr-21.004-21.005.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr-21.004-21.005.sql
@@ -1,0 +1,1 @@
+CREATE INDEX snomed_tags_recordid ON ehr.snomed_tags (recordid);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-21.004-21.005.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-21.004-21.005.sql
@@ -1,0 +1,1 @@
+CREATE INDEX snomed_tags_recordid ON ehr.snomed_tags (recordid);

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -131,7 +131,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.004;
+        return 21.005;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
SNOMED reporting can be very slow when applying filters over the codes/meanings

#### Changes
* Add index to recordid to help make join more efficient