### PR TITLE
Item 9192: Initial modifications to support sample status

### DIFF
--- a/ehr/resources/schemas/ehr.xml
+++ b/ehr/resources/schemas/ehr.xml
@@ -1499,7 +1499,7 @@
         </columns>
     </table>
     <table tableName="qcStateMetadata" tableDbType="TABLE" useColumnOrder="true">
-        <description>Additional EHR-specific information associated with the core.qcstate table</description>
+        <description>Additional EHR-specific information associated with the core.datastates table</description>
         <tableTitle>QCState Metadata</tableTitle>
         <javaCustomizer class="org.labkey.ehr.table.DefaultEHRCustomizer" />
         <auditLogging>DETAILED</auditLogging>

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -267,7 +267,7 @@ public class EHRManager
 
         //NOTE: there is no public API to set a study, so hit the DB directly.
         final TableInfo studyTable = DbSchema.get("study").getTable("study");
-        TableInfo ti = CoreSchema.getInstance().getTableInfoQCState();
+        TableInfo ti = CoreSchema.getInstance().getTableInfoDataStates();
 
         Object[][] states = new Object[][]{
             {"Abnormal", "Value is abnormal", true},

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -28,6 +28,7 @@ import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.PropertyManager;
@@ -266,7 +267,7 @@ public class EHRManager
 
         //NOTE: there is no public API to set a study, so hit the DB directly.
         final TableInfo studyTable = DbSchema.get("study").getTable("study");
-        TableInfo ti = DbSchema.get("core").getTable("qcstate");
+        TableInfo ti = CoreSchema.getInstance().getTableInfoQCState();
 
         Object[][] states = new Object[][]{
             {"Abnormal", "Value is abnormal", true},

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -1392,7 +1392,7 @@ public class EHRManager
 
     public EHRQCState[] getQCStates(Container c)
     {
-        SQLFragment sql = new SQLFragment("SELECT * FROM core.qcstate qc LEFT JOIN ehr.qcstatemetadata md ON (qc.label = md.QCStateLabel) WHERE qc.container = ?", c.getEntityId());
+        SQLFragment sql = new SQLFragment("SELECT * FROM core.datastates qc LEFT JOIN ehr.qcstatemetadata md ON (qc.label = md.QCStateLabel) WHERE qc.container = ?", c.getEntityId());
         DbSchema db = DbSchema.get("study");
         return new SqlSelector(db, sql).getArray(EHRQCStateImpl.class);
     }

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -1181,7 +1181,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         if (ti.getColumn(countsAgainstVolume) == null)
         {
             SQLFragment sql = new SQLFragment("CASE " +
-                " WHEN EXISTS (SELECT md.draftdata FROM core.qcstate q LEFT JOIN ehr.qcStateMetadata md ON (q.label = md.qcstatelabel) WHERE q.container = ? AND q.rowid = " + ExprColumn.STR_TABLE_ALIAS + ".qcstate AND (md.draftdata = " + ti.getSqlDialect().getBooleanTRUE() + " OR q.publicdata = " + ti.getSqlDialect().getBooleanTRUE() + ")) THEN " + ti.getSqlDialect().getBooleanTRUE() +
+                " WHEN EXISTS (SELECT md.draftdata FROM core.datastates q LEFT JOIN ehr.qcStateMetadata md ON (q.label = md.qcstatelabel) WHERE q.container = ? AND q.rowid = " + ExprColumn.STR_TABLE_ALIAS + ".qcstate AND (md.draftdata = " + ti.getSqlDialect().getBooleanTRUE() + " OR q.publicdata = " + ti.getSqlDialect().getBooleanTRUE() + ")) THEN " + ti.getSqlDialect().getBooleanTRUE() +
                 " ELSE " + ti.getSqlDialect().getBooleanFALSE() +
                 " END", ti.getUserSchema().getContainer().getId());
             ExprColumn col = new ExprColumn(ti, countsAgainstVolume, sql, JdbcType.BOOLEAN, ti.getColumn("qcstate"));


### PR DESCRIPTION
#### Rationale
We have renamed the core.qcstate table to core.datastates for more general use, in particular for supporting sample status values.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2636

#### Changes
* Update table name
