### PR TITLE
Make ONPRC_EHRTest2.testArrivalForm a little more patient

### DIFF
--- a/ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
+++ b/ehr/test/src/org/labkey/test/tests/onprc_ehr/ONPRC_EHRTest2.java
@@ -613,7 +613,7 @@ public class ONPRC_EHRTest2 extends AbstractONPRC_EHRTest
         waitForElement(finalizeOKButton, WAIT_FOR_JAVASCRIPT);
         click(finalizeOKButton);
 
-        waitAndClick(WAIT_FOR_JAVASCRIPT * 2, Ext4Helper.Locators.window("Success").append(Ext4Helper.Locators.ext4Button("No")), WAIT_FOR_PAGE);
+        waitAndClick(WAIT_FOR_JAVASCRIPT * 5, Ext4Helper.Locators.window("Success").append(Ext4Helper.Locators.ext4Button("No")), WAIT_FOR_PAGE);
 
         waitForElement(Locator.tagWithText("a", "Enter New Data"));
 


### PR DESCRIPTION
#### Rationale
ONPRC_EHRTest2.testArrivalForm is failing intermittently. When it submits the arrivals, the server had a bunch of work to do. It currently times out at 20 seconds. Looking at the HTTP access log of the most recent failure, it took 27 seconds.

#### Changes
* Wait patiently for up to 60 seconds