### PR TITLE
Avoid copying referenceStudy on dev machines where source root and pipeline root match

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -58,6 +58,7 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.resource.DirectoryResource;
 import org.labkey.api.resource.FileResource;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.SecurableResource;
@@ -870,7 +871,7 @@ public class EHRServiceImpl extends EHRService
 
         java.nio.file.Path studyXmlPath;
 
-        if (root instanceof FileResource && ((FileResource)root).getFile().equals(pipeRootPath.toFile()))
+        if (root instanceof DirectoryResource && ((DirectoryResource)root).getDir().equals(pipeRootPath.toFile()))
         {
             // The pipeline root is already pointed at the study definition's folder, like it might be on a dev machine.
             // No need to copy, especially since copying can cause infinite recursion when the paths are nested

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -58,6 +58,7 @@ import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
+import org.labkey.api.resource.FileResource;
 import org.labkey.api.resource.Resource;
 import org.labkey.api.security.SecurableResource;
 import org.labkey.api.security.SecurityPolicy;
@@ -866,16 +867,29 @@ public class EHRServiceImpl extends EHRService
         Resource root = m.getModuleResource(sourceStudyDirPath);
         PipeRoot pipeRoot = PipelineService.get().findPipelineRoot(container);
         java.nio.file.Path pipeRootPath = pipeRoot.getRootNioPath();
-        java.nio.file.Path studyPath = pipeRootPath.resolve("upgradeStudyImport");
-        if (Files.exists(studyPath))
+
+        java.nio.file.Path studyXmlPath;
+
+        if (root instanceof FileResource && ((FileResource)root).getFile().equals(pipeRootPath.toFile()))
         {
-            FileUtil.deleteDir(studyPath);
+            // The pipeline root is already pointed at the study definition's folder, like it might be on a dev machine.
+            // No need to copy, especially since copying can cause infinite recursion when the paths are nested
+            studyXmlPath = pipeRootPath.resolve("study.xml");
         }
-        copyResourceToPath(root, studyPath);
-        java.nio.file.Path studyXmlPath = studyPath.resolve("study.xml");
+        else
+        {
+            java.nio.file.Path studyPath = pipeRootPath.resolve("moduleStudyImport");
+            studyXmlPath = studyPath.resolve("study.xml");
+            if (Files.exists(studyPath))
+            {
+                FileUtil.deleteDir(studyPath);
+            }
+            copyResourceToPath(root, studyPath);
+        }
+
         if (!Files.exists(studyXmlPath))
         {
-            throw new FileNotFoundException("Couldn't find an extracted " + studyPath);
+            throw new FileNotFoundException("Couldn't find an extracted " + studyXmlPath);
         }
         ImportOptions options = new ImportOptions(container.getId(), user.getUserId());
         options.setSkipQueryValidation(true);


### PR DESCRIPTION
#### Rationale
On a dev machine, if you point an EHR folder's pipeline root at the referenceStudy directory, the server will infinitely recurse trying to copy the files from the source to the target. That's because it keeps making more files in the target, which is also the source of the copy.

#### Changes
* Short circuit when the directories match and just use the source folder directly