### PR TITLE
Clinical remarks data source

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultClinicalRemarksDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultClinicalRemarksDataSource.java
@@ -44,7 +44,12 @@ public class DefaultClinicalRemarksDataSource extends AbstractDataSource
     protected String getCategoryText(Results rs) throws SQLException
     {
         String category = rs.getString("category");
-        return (category == null || REPLACED_SOAP.equals(category) || REPLACEMENT_SOAP.equals(category) ?  "Clinical" : category) + " Remark";
+
+        FieldKey titleFk = FieldKey.fromString("category/title");
+        if (rs.hasColumn(titleFk))
+            category = rs.getString(titleFk);
+
+        return (category == null || REPLACED_SOAP.equals(category) || REPLACEMENT_SOAP.equals(category) ?  "Clinical" : category) + " - Remark";
     }
 
 //    @Override

--- a/ehr/src/org/labkey/ehr/query/EHRLookupsUserSchema.java
+++ b/ehr/src/org/labkey/ehr/query/EHRLookupsUserSchema.java
@@ -29,9 +29,9 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.security.EHRDataAdminPermission;
 import org.labkey.api.ehr.security.EHRHousingTransferPermission;
-import org.labkey.api.ehr.security.EHRSnomedEditPermission;
 import org.labkey.api.ehr.security.EHRLocationEditPermission;
 import org.labkey.api.ehr.security.EHRProcedureManagementPermission;
+import org.labkey.api.ehr.security.EHRSnomedEditPermission;
 import org.labkey.api.ldk.table.ContainerScopedTable;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
@@ -204,7 +204,7 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
             return createVeterinariansTable(name, cf);
         else if (EHRSchema.TABLE_LOOKUP_SETS.equalsIgnoreCase(name))
         {
-            ContainerScopedTable ret = new ContainerScopedTable<>(this, createSourceTable(name), cf, "setname");
+            ContainerScopedTable<SimpleUserSchema> ret = new LookupSetsTable<>(this, createSourceTable(name), cf, "setname");
             ret.addPermissionMapping(InsertPermission.class, EHRDataAdminPermission.class);
             ret.addPermissionMapping(UpdatePermission.class, EHRDataAdminPermission.class);
             ret.addPermissionMapping(DeletePermission.class, EHRDataAdminPermission.class);

--- a/ehr/src/org/labkey/ehr/query/LookupSetsTable.java
+++ b/ehr/src/org/labkey/ehr/query/LookupSetsTable.java
@@ -5,6 +5,7 @@ import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.ldk.table.ContainerScopedTable;
 import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SimpleUserSchema;
@@ -13,6 +14,7 @@ import org.labkey.api.security.User;
 import org.labkey.ehr.dataentry.DataEntryManager;
 
 import java.sql.SQLException;
+import java.util.Map;
 
 /**
  * This TableInfo is for the actual ehr.lookupsets table. It is not a duplicate of LookupSetTable which
@@ -42,6 +44,14 @@ public class LookupSetsTable<SchemaType extends UserSchema> extends ContainerSco
         protected void afterInsertUpdate(int count, BatchValidationException errors)
         {
             DataEntryManager.get().getCache().clear();
+        }
+
+        @Override
+        protected Map<String, Object> deleteRow(User user, Container container, Map<String, Object> oldRowMap) throws QueryUpdateServiceException, SQLException, InvalidKeyException
+        {
+            Map<String, Object> row = super.deleteRow(user, container, oldRowMap);
+            DataEntryManager.get().getCache().clear();
+            return row;
         }
 
         @Override

--- a/ehr/src/org/labkey/ehr/query/LookupSetsTable.java
+++ b/ehr/src/org/labkey/ehr/query/LookupSetsTable.java
@@ -1,0 +1,55 @@
+package org.labkey.ehr.query;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.ldk.table.ContainerScopedTable;
+import org.labkey.api.query.BatchValidationException;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.security.User;
+import org.labkey.ehr.dataentry.DataEntryManager;
+
+import java.sql.SQLException;
+
+/**
+ * This TableInfo is for the actual ehr.lookupsets table. It is not a duplicate of LookupSetTable which
+ * is for the virtual tables created from the data in ehr.lookupsets.
+ */
+public class LookupSetsTable<SchemaType extends UserSchema> extends ContainerScopedTable<SchemaType>
+{
+    public LookupSetsTable(SchemaType schema, TableInfo st, ContainerFilter cf, String newPk)
+    {
+        super(schema, st, cf, newPk);
+    }
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        return new UpdateService(this);
+    }
+
+    private class UpdateService extends ContainerScopedTable<SchemaType>.UpdateService
+    {
+        public UpdateService(SimpleUserSchema.SimpleTable<SchemaType> ti)
+        {
+            super(ti);
+        }
+
+        @Override
+        protected void afterInsertUpdate(int count, BatchValidationException errors)
+        {
+            DataEntryManager.get().getCache().clear();
+        }
+
+        @Override
+        protected int truncateRows(User user, Container container) throws QueryUpdateServiceException, SQLException
+        {
+            int i = super.truncateRows(user, container);
+            DataEntryManager.get().getCache().clear();
+            return i;
+        }
+    }
+}


### PR DESCRIPTION
#### Rationale
Clinical remarks categories value can be an integer so try to use title if it's available, then fall back to value.  Also refresh EHR data entry cache when EHR lookup sets are updated.

#### Related Pull Requests
* https://github.com/LabKey/nircEHRModules/pull/47

#### Changes
* Add change to DefaultClinicalRemarksDataSource.getCategoryText
* Add lookupsets table info and QUS with cache refresh
