### PR TITLE
Support using linked schema in place of DB schema for testing purposes

### DIFF
--- a/ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -104,7 +104,8 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
                 new ModulePropertyValue("ONPRC_Billing", "/" + getProjectName(), "BillingContainer", "/" + getContainerPath()),
                 new ModulePropertyValue("ONPRC_Billing", "/" + getProjectName(), "BillingContainer_Public", "/" + getContainerPath()),
                 new ModulePropertyValue("SLA", "/" + getProjectName(), "SLAContainer", "/" + getContainerPath()),
-                new ModulePropertyValue("ONPRC_EHR", "/" + getProjectName(), "DCM_NHP_Resources_Container", "/" + getContainerPath())
+                new ModulePropertyValue("ONPRC_EHR", "/" + getProjectName(), "DCM_NHP_Resources_Container", "/" + getContainerPath()),
+                new ModulePropertyValue("ONPRC_EHR", "/" + getProjectName(), "MHC_Container", "/" + getContainerPath())
         );
     }
 
@@ -184,6 +185,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
                 new ListHelper.ListColumn("totalTests", ListHelper.ListColumnType.Integer));
 
         schemaHelper.createLinkedSchema(this.getProjectName(), "dbo", "/" + this.getContainerPath(), null, "lists", null, null);
+        schemaHelper.createLinkedSchema(this.getProjectName(), "geneticscore", "/" + this.getContainerPath(), null, "lists", null, null);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
ONPRC has added a query that depends on geneticscore. It's easier to fake it up via a linked schema than to fully configure that module for testing purposes

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/283

#### Changes
* Set module property, configure linked schema
