### PR TITLE
TNPRC Issue 290: Method to edit legacy data via query module update row

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1473,8 +1473,8 @@ public class EHRController extends SpringActionController
         {
             if (form.getFormType() == null)
             {
-                errors.reject(ERROR_MSG, "Must provide either the form type");
-                return null;
+                errors.reject(ERROR_MSG, "Must provide a form type");
+                return new SimpleErrorView(errors);
             }
 
             _def = DataEntryManager.get().getFormByName(form.getFormType(), getContainer(), getUser());

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -431,7 +431,19 @@ public class EHRController extends SpringActionController
                 if (form.isQueryUpdateURL())
                 {
                     // Send to the query controller's basic row-level update form
-                    updateUrl = DetailsURL.fromString("query-updateQueryRow.view?schemaName=" + ti.getUserSchema().getName() + "&queryName=" + ti.getName() + "&lsid=${lsid}");
+                    StringBuilder sb = new StringBuilder("query-updateQueryRow.view?schemaName=");
+                    sb.append(ti.getUserSchema().getName());
+                    sb.append("&queryName=");
+                    sb.append(ti.getName());
+                    for (String pk : pks)
+                    {
+                        sb.append("&");
+                        sb.append(pk);
+                        sb.append("=${");
+                        sb.append(pk);
+                        sb.append("}");
+                    }
+                    updateUrl = DetailsURL.fromString(sb.toString());
                 }
                 else if (EHRServiceImpl.get().isUseFormEditUI(getContainer()) && null != ti.getColumn("taskid"))
                 {

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -312,6 +312,7 @@ public class EHRController extends SpringActionController
     public static class EHRQueryForm extends QueryForm
     {
         private boolean _showImport = false;
+        private boolean _queryUpdateURL = false;
 
         public boolean isShowImport()
         {
@@ -321,6 +322,16 @@ public class EHRController extends SpringActionController
         public void setShowImport(boolean showImport)
         {
             _showImport = showImport;
+        }
+
+        public boolean isQueryUpdateURL()
+        {
+            return _queryUpdateURL;
+        }
+
+        public void setQueryUpdateURL(boolean queryUpdateURL)
+        {
+            _queryUpdateURL = queryUpdateURL;
         }
     }
 
@@ -417,7 +428,12 @@ public class EHRController extends SpringActionController
                 }
 
                 DetailsURL updateUrl;
-                if (EHRServiceImpl.get().isUseFormEditUI(getContainer()) && null != ti.getColumn("taskid"))
+                if (form.isQueryUpdateURL())
+                {
+                    // Send to the query controller's basic row-level update form
+                    updateUrl = DetailsURL.fromString("query-updateQueryRow.view?schemaName=" + ti.getUserSchema().getName() + "&queryName=" + ti.getName() + "&lsid=${lsid}");
+                }
+                else if (EHRServiceImpl.get().isUseFormEditUI(getContainer()) && null != ti.getColumn("taskid"))
                 {
                     updateUrl = DetailsURL.fromString("/ehr/dataEntryForm.view?taskid=${taskid}&formType=${taskid/formType}");
                 }

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -221,7 +221,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
         recallLocation();
         List<String> submenuItems = dr.getHeaderMenuOptions("More Actions");
         List<String> expectedSubmenu = Arrays.asList("Jump To History", "Return Distinct Values","Show Record History","Compare Weights","Edit Records");
-        Assert.assertEquals("More actions menu did not contain expected options",expectedSubmenu, submenuItems);
+        Assert.assertTrue("More actions menu did not contain expected options. Expected: " + expectedSubmenu + ", but found: " + submenuItems, submenuItems.containsAll(expectedSubmenu));
     }
 
     private void testUserAgainstAllStates(@LoggedParam EHRUser user)


### PR DESCRIPTION
#### Rationale
In rare cases, users need to navigate to the "raw" data entry page to edit records that were ETL'd instead of being entered into a LabKey EHR data entry form

#### Changes
* Option to use query-updateQueryRow.view for the edit link