### PR TITLE
Issue 44283: Age is not calculated for new animals on snapshot

### DIFF
--- a/ehr/resources/queries/study/Demographics.js
+++ b/ehr/resources/queries/study/Demographics.js
@@ -14,17 +14,17 @@ function onInit(event, helper){
     });
 }
 
-function onUpsert(helper, scriptErrors, row, oldRow){
+function onInsert(helper, scriptErrors, row) {
+    // If we're doing inserts in demographics (where we don't have an old row), don't fire the normal notifications
+    // of changes to refresh the demographics cache, as we have to do a special clearing after study has done its
+    // bookkeeping. See ticket 44283 and the clearing in TriggerScriptHelper.createDemographicsRecord()
+    helper.getExtraContext().skipAnnounceChangedParticipants = true;
+}
+
+function onUpsert(helper, scriptErrors, row, oldRow) {
     //NOTE: this should be getting set by the birth, death, arrival & departure tables
     //ALSO: it should be rare to insert directly into this table.  usually this record will be created by inserting into either birth or arrival
     if (!row.calculated_status && !helper.isETL()){
         row.calculated_status = helper.getJavaHelper().getCalculatedStatusValue(row.Id);
     }
-    if (!oldRow) {
-        // If we're doing inserts in demographics (where we don't have an old row), don't fire the normal notifications
-        // of changes to refresh the demographics cache, as we have to do a special clearing after study has done its
-        // bookkeeping. See ticket 44283 and the clearing in TriggerScriptHelper.createDemographicsRecord()
-        helper.getExtraContext().skipAnnounceChangedParticipants = true;
-    }
-
 }

--- a/ehr/resources/queries/study/Demographics.js
+++ b/ehr/resources/queries/study/Demographics.js
@@ -14,13 +14,6 @@ function onInit(event, helper){
     });
 }
 
-function onInsert(helper, scriptErrors, row) {
-    // If we're doing inserts in demographics (where we don't have an old row), don't fire the normal notifications
-    // of changes to refresh the demographics cache, as we have to do a special clearing after study has done its
-    // bookkeeping. See ticket 44283 and the clearing in TriggerScriptHelper.createDemographicsRecord()
-    helper.getExtraContext().skipAnnounceChangedParticipants = true;
-}
-
 function onUpsert(helper, scriptErrors, row, oldRow) {
     //NOTE: this should be getting set by the birth, death, arrival & departure tables
     //ALSO: it should be rare to insert directly into this table.  usually this record will be created by inserting into either birth or arrival

--- a/ehr/resources/queries/study/Demographics.js
+++ b/ehr/resources/queries/study/Demographics.js
@@ -20,5 +20,11 @@ function onUpsert(helper, scriptErrors, row, oldRow){
     if (!row.calculated_status && !helper.isETL()){
         row.calculated_status = helper.getJavaHelper().getCalculatedStatusValue(row.Id);
     }
+    if (!oldRow) {
+        // If we're doing inserts in demographics (where we don't have an old row), don't fire the normal notifications
+        // of changes to refresh the demographics cache, as we have to do a special clearing after study has done its
+        // bookkeeping. See ticket 44283 and the clearing in TriggerScriptHelper.createDemographicsRecord()
+        helper.getExtraContext().skipAnnounceChangedParticipants = true;
+    }
 
 }

--- a/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
@@ -233,7 +233,7 @@ public class EHRDemographicsServiceImpl extends EHRDemographicsService
         _cache.put(key, record);
     }
 
-    private void recacheRecords(Container c, List<String> ids)
+    public void recacheRecords(Container c, List<String> ids)
     {
         for (String id : ids)
         {

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -826,7 +826,11 @@ public class TriggerScriptHelper
         if (errors.hasErrors())
             throw errors;
 
-        EHRDemographicsServiceImpl.get().getAnimal(getContainer(), id);
+        // The normal (re)caching of demographics providers runs before the study module has done its bookkeeping and
+        // inserted a row into study.participant, which means that calculated lookup values like the animal's current
+        // age won't resolve until AFTER the call to insertRows() has completed. Thus, refresh the cache for this new
+        // animal an extra time. See ticket 44283.
+        EHRDemographicsServiceImpl.get().recacheRecords(getContainer(), Collections.singletonList(id));
     }
 
     public void updateDemographicsRecord(List<Map<String, Object>> updatedRows) throws QueryUpdateServiceException, SQLException, BatchValidationException, InvalidKeyException


### PR DESCRIPTION
#### Rationale
The EHR makes heavy use of queries to calculate values like current animal age and weight via SQL queries wired up as lookups through the Id field. Those lookups only resolve correctly when the study module has already inserted a row into study.participant for the new animal/participant, so we shouldn't trust calculated demographic info until the study module has done its bookkeeping.

#### Changes
* When we know we're inserting a new demographics record, likely the first time we've seen an animal, refresh the demographics call an extra time.