### PR TITLE
Issue 44149 - increase cage.location column length

### DIFF
--- a/ehr/resources/queries/ehr_lookups/cage.js
+++ b/ehr/resources/queries/ehr_lookups/cage.js
@@ -14,7 +14,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
     row.location = row.room;
     if (row.cage)
         row.location += '-' + row.cage;
-    if (row.location.length > 24) {
+    if (row.location.length > 100) {
         console.log("Location is longer than allowed length: ", row.location);
     }
 

--- a/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-21.005-21.006.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-21.005-21.006.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_lookups.cage ALTER COLUMN location TYPE varchar(100);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-21.005-21.006.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-21.005-21.006.sql
@@ -1,1 +1,3 @@
+DROP INDEX cage_location ON ehr_lookups.cage (location);
 alter table ehr_lookups.cage alter column location nvarchar(100);
+CREATE INDEX cage_location ON ehr_lookups.cage (location ASC);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-21.005-21.006.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-21.005-21.006.sql
@@ -1,3 +1,5 @@
-DROP INDEX cage_location ON ehr_lookups.cage (location);
+ALTER TABLE ehr_lookups.cage DROP CONSTRAINT UQ_cage;
+DROP INDEX cage_location ON ehr_lookups.cage;
 alter table ehr_lookups.cage alter column location nvarchar(100);
 CREATE INDEX cage_location ON ehr_lookups.cage (location ASC);
+ALTER TABLE ehr_lookups.cage ADD CONSTRAINT UQ_cage UNIQUE (Container,Location);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-21.005-21.006.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-21.005-21.006.sql
@@ -1,0 +1,1 @@
+alter table ehr_lookups.cage alter column location nvarchar(100);

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -131,7 +131,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.005;
+        return 21.006;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Cage trigger script concatenates room and cage in location column of size 24 and some centers have longer names for rooms and cages. This PR increases the length of location column to 100.
