### PR TITLE
Remove extra verbose logging added recently for troubleshooting

### DIFF
--- a/ehr/resources/queries/ehr_lookups/cage.js
+++ b/ehr/resources/queries/ehr_lookups/cage.js
@@ -14,9 +14,6 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
     row.location = row.room;
     if (row.cage)
         row.location += '-' + row.cage;
-    if (row.location.length > 24) {
-        console.log("Location is longer than allowed length: ", row.location);
-    }
 
     //remove whitespace, normalize punctuation and pad digits
     if (row.joinToCage){

--- a/ehr/resources/scripts/ehr/utils.js
+++ b/ehr/resources/scripts/ehr/utils.js
@@ -181,7 +181,6 @@ EHR.Server.Utils = new function(){
                 }
             }
             else {
-                console.log('EHR trigger script is being passed a date with value: ' + val);
                 if (!isNaN(val)) {
                     // NOTE: i'm not sure if we should really attempt this.  this should really never happen,
                     // and it's probably an error if it does


### PR DESCRIPTION
#### Rationale
The date logging is overwhelming server log. We've already found the problematic data and also added more centralized logging of the full problematic row.

#### Changes
* Back out the temporary logging