### PR TITLE
Shared EHR upgrade code ETL fix

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -184,7 +184,7 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
                     }
                     if (!DataIntegrationService.get().resetTransformState(container, user, etlInfo.getKey()))
                     {
-                        LOG.info("No saved state for " + etlInfo.getKey() + " found, starting ETL.");
+                        LOG.info("No saved state for " + etlInfo.getKey() + " found for reset, starting ETL.");
                     }
                 }
 

--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -184,8 +184,7 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
                     }
                     if (!DataIntegrationService.get().resetTransformState(container, user, etlInfo.getKey()))
                     {
-                        LOG.error("Failed to reset state of ETL " + etlInfo.getKey() + ", continuing without queuing a run.");
-                        continue;
+                        LOG.info("No saved state for " + etlInfo.getKey() + " found, starting ETL.");
                     }
                 }
 


### PR DESCRIPTION
#### Rationale
If state isn't found for an ETL, it just means it has not been run yet, so log a message and execute ETL, instead of throwing error

#### Changes
* Update handling of state not found