### PR TITLE
Ticket 44392: Improve demographics caching for cagemate info

### DIFF
--- a/ehr/src/org/labkey/ehr/demographics/BasicDemographicsProvider.java
+++ b/ehr/src/org/labkey/ehr/demographics/BasicDemographicsProvider.java
@@ -54,7 +54,6 @@ public class BasicDemographicsProvider extends AbstractDemographicsProvider
 
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
-        keys.add(FieldKey.fromString("Id/numRoommates/NumRoommates"));
         keys.add(FieldKey.fromString("gender"));
         keys.add(FieldKey.fromString("gender/meaning"));
         keys.add(FieldKey.fromString("gender/origGender"));


### PR DESCRIPTION
#### Rationale
No EHR code is relying on this demographics provider value and it's not being refreshed correctly when housing updates are made

#### Changes
* Get rid of the problematic and unused property