### PR TITLE
Match casing on test data species list

### DIFF
--- a/ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/onprc_ehr/AbstractGenericONPRC_EHRTest.java
@@ -60,7 +60,7 @@ public abstract class AbstractGenericONPRC_EHRTest extends AbstractGenericEHRTes
     protected static final SimpleDateFormat _tf = new SimpleDateFormat("yyyy-MM-dd HH:mm");
     protected static final SimpleDateFormat _df = new SimpleDateFormat("yyyy-MM-dd");
 
-    protected final String RHESUS = "RHESUS MACAQUE";
+    protected final String RHESUS = "Rhesus";
     protected final String INDIAN = "INDIA";
 
     protected static String[] SUBJECTS = {"12345", "23456", "34567", "45678", "56789"};


### PR DESCRIPTION
#### Rationale
The crawler is hitting an intermittent error when rendering the population overview page because the test data species names aren't matching up. It's hitting most regularly in ONPRC_EHRTest.testCustomActions

https://teamcity.labkey.org/buildConfiguration/LabKey_217Release_Premium_Ehr_OnprcEhrSqlserver/1631361?focusLine=0

#### Changes
* Use species name that matches the age class TSV data
