### PR TITLE
Speed up EHR query analysis by ~75% by improving schema reuse

### DIFF
--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -1467,7 +1467,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
             public TableInfo getLookupTableInfo()
             {
                 String name = queryName + "_housingAtTime";
-                UserSchema targetSchema = QueryService.get().getUserSchema(u, targetSchemaContainer, targetSchemaName);
+                UserSchema targetSchema = ds.getUserSchema().getDefaultSchema().getUserSchema(targetSchemaName);
                 QueryDefinition qd = QueryService.get().createQueryDef(u, targetSchemaContainer, targetSchema, name);
                 qd.setSql("SELECT\n" +
                     "sd." + pkCol.getFieldKey().toSQLString() + ",\n" +
@@ -1695,7 +1695,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
             public TableInfo getLookupTableInfo()
             {
                 String name = queryName + "_ageAtTime";
-                UserSchema targetSchema = QueryService.get().getUserSchema(u, targetSchemaContainer, targetSchemaName);
+                UserSchema targetSchema = ds.getUserSchema().getDefaultSchema().getUserSchema(targetSchemaName);
                 QueryDefinition qd = QueryService.get().createQueryDef(u, targetSchemaContainer, targetSchema, name);
                 //NOTE: do not need to account for QCstate b/c study.demographics only allows 1 row per subject
                 qd.setSql("SELECT\n" +


### PR DESCRIPTION
#### Rationale
ONPRC_EHRTest2.manageCases is failing regularly across branches due to SQL deadlocks. The competing thread appears to be doing query analysis, which is very slow on TeamCity (~120 seconds). We can speed it up by reusing schema objects.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2858

#### Changes
* Make DefaultEHRCustomizer acquire schemas in a way that allows them to come from the cache
