### PR TITLE
Clean up intermittent test failures when requestid is null when form is submitted

### DIFF
--- a/ehr/resources/web/ehr/data/RequestStoreCollection.js
+++ b/ehr/resources/web/ehr/data/RequestStoreCollection.js
@@ -29,8 +29,10 @@ Ext4.define('EHR.data.RequestStoreCollection', {
             this.clientStores.each(function(cs){
                 if (cs.getFields().get('requestid') != null){
                     cs.each(function(r){
-                        if (requestid != r.get('requestid')){
-                            LDK.Assert.assertEquality('Incorrect requestid for client store:' + cs.storeId, requestid, r.get('requestid'));
+                        if (requestid !== r.get('requestid')) {
+                            if (requestid) { // Tolerate null values
+                                LDK.Assert.assertEquality('Incorrect requestid for client store:' + cs.storeId, requestid, r.get('requestid'));
+                            }
                             r.beginEdit();
                             r.set('requestid', this.getRequestId());
                             r.endEdit(true);
@@ -46,8 +48,10 @@ Ext4.define('EHR.data.RequestStoreCollection', {
                             return;  //do not check these records.  they have deliberately been separated.
                         }
 
-                        if (requestid != r.get('requestid')){
-                            LDK.Assert.assertEquality('Incorrect requestid for server store:' + cs.storeId, requestid, r.get('requestid'));
+                        if (requestid !== r.get('requestid')) {
+                            if (requestid) { // Tolerate null values
+                                LDK.Assert.assertEquality('Incorrect requestid for server store:' + cs.storeId, requestid, r.get('requestid'));
+                            }
                             r.beginEdit();
                             r.set('requestid', this.getRequestId());
                             r.endEdit(true);


### PR DESCRIPTION
#### Rationale
https://teamcity.labkey.org/buildConfiguration/LabKey_217Release_Premium_Ehr_OnprcEhrSqlserver/1649642?buildTab=artifacts#%2FONPRC_EHRTest2.tar.gz

Can't repro locally. Intent of code seems to be to log true mismatches instead of a race condition where it hasn't been set.

#### Changes
* Tolerate requestid being null without warning message on server