### PR TITLE
Introduce EHR 'reloadFolder' option, mimicking 'reloadStudy' but loading a folder archive

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -304,7 +304,12 @@ abstract public class EHRService
     abstract public void addModuleRequiringLegacyExt3EditUI(Module m);
 
     /** Extracts the study definition from a module resource to the pipeline root and queues a study import job */
+    @Deprecated
     abstract public void importStudyDefinition(Container container, User user, Module m, Path studyFolderPath) throws IOException;
+
+    /** Extracts the folder archive containing the study from a module resource to the pipeline root and queues a folder import job */
+    @Deprecated
+    abstract public void importFolderDefinition(Container container, User user, Module m, Path studyFolderPath) throws IOException;
 
     /** Used to register EHR modules that require the edit url on the grid (with rows having task id values) to navigate to the data entry form **/
     abstract public void addModulePreferringTaskFormEditUI(Module m);

--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -308,7 +308,6 @@ abstract public class EHRService
     abstract public void importStudyDefinition(Container container, User user, Module m, Path studyFolderPath) throws IOException;
 
     /** Extracts the folder archive containing the study from a module resource to the pipeline root and queues a folder import job */
-    @Deprecated
     abstract public void importFolderDefinition(Container container, User user, Module m, Path studyFolderPath) throws IOException;
 
     /** Used to register EHR modules that require the edit url on the grid (with rows having task id values) to navigate to the data entry form **/

--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -55,7 +55,9 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
     private static final String ETL_PREFIX = "etl;";
     private static final String IMPORT_FROM_TSV_PREFIX = "importFromTsv;";
 
+    @Deprecated // migrate all modules to use reloadFolder and delete this
     private boolean _reloadStudy;
+    private boolean _reloadFolder;
     /** ETL name -> whether to truncate before running */
     private final Map<String, Boolean> _etls = new LinkedHashMap<>();
     private final Set<TsvImport> _tsvImports = new LinkedHashSet<>();
@@ -79,6 +81,12 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
     public void reloadStudy(ModuleContext context)
     {
         _reloadStudy = true;
+    }
+
+    @SuppressWarnings("unused")
+    public void reloadFolder(ModuleContext context)
+    {
+        _reloadFolder = true;
     }
 
     @Override
@@ -135,7 +143,7 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
     @Override
     public void moduleStartupComplete(ServletContext servletContext)
     {
-        if (_reloadStudy || !_etls.isEmpty() || !_tsvImports.isEmpty())
+        if (_reloadStudy || _reloadFolder || !_etls.isEmpty() || !_tsvImports.isEmpty())
         {
             Container container = EHRService.get().getEHRStudyContainer(ContainerManager.getRoot());
             if (container == null)
@@ -165,6 +173,11 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
                 if (_reloadStudy)
                 {
                     EHRService.get().importStudyDefinition(container, user, _module, new Path("referenceStudy"));
+                }
+
+                if (_reloadFolder)
+                {
+                    EHRService.get().importFolderDefinition(container, user, _module, new Path("referenceStudy"));
                 }
             }
             catch (IOException | SQLException | BatchValidationException | QueryUpdateServiceException e)

--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -42,10 +42,10 @@ import java.util.Set;
 import static org.labkey.api.query.AbstractQueryUpdateService.createTransactionAuditEvent;
 
 /**
- * Allows upgrade scripts to prescribe study reloads and ETL executions (including truncates). Will look at the
+ * Allows upgrade scripts to prescribe folder reloads and ETL executions (including truncates). Will look at the
  * site-wide ehrStudyContainer and ehrAdminUser module properties to decide where and as whom to run the jobs.
  *
- * Supports 'reloadStudy' or 'etl;%TRANSFORM_ID%' with an optional ';truncate' suffix
+ * Supports 'reloadFolder' or 'etl;%TRANSFORM_ID%' with an optional ';truncate' suffix
  */
 public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
 {

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -36,12 +36,10 @@ import org.labkey.test.WebTestHelper;
 import org.labkey.test.pages.ehr.AnimalHistoryPage;
 import org.labkey.test.util.AdvancedSqlTest;
 import org.labkey.test.util.ApiPermissionsHelper;
-import org.labkey.test.util.ListHelper;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PasswordUtil;
 import org.labkey.test.util.PermissionsHelper;
-import org.labkey.test.util.SchemaHelper;
 import org.labkey.test.util.ehr.EHRClientAPIHelper;
 import org.labkey.test.util.ehr.EHRTestHelper;
 import org.labkey.test.util.ext4cmp.Ext4CmpRef;
@@ -337,6 +335,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
     @LogMethod
     protected abstract void importStudy();
 
+    @Deprecated // study archives are going away... use importFolderFromPath() instead
     protected void importStudyFromPath(int jobCount)
     {
         File path = new File(TestFileUtils.getLabKeyRoot(), getModulePath() + "/resources/referenceStudy");
@@ -362,6 +361,29 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
 
         clickButton("Start Import"); // Validate queries page
         waitForPipelineJobsToComplete(jobCount, "Study import", false, MAX_WAIT_SECONDS * 2500);
+    }
+
+    protected void importFolderFromPath(int jobCount)
+    {
+        File path = new File(TestFileUtils.getLabKeyRoot(), getModulePath() + "/resources/referenceStudy");
+        setPipelineRoot(path.getPath());
+
+        beginAt(WebTestHelper.getBaseURL() + "/pipeline-status/" + getContainerPath() + "/begin.view");
+        clickButton("Process and Import Data", defaultWaitForPage);
+
+        _fileBrowserHelper.expandFileBrowserRootNode();
+        _fileBrowserHelper.checkFileBrowserFileCheckbox("folder.xml");
+        _fileBrowserHelper.selectImportDataAction("Import Folder");
+
+        if (skipStudyImportQueryValidation())
+        {
+            Locator cb = Locator.checkboxByName("validateQueries");
+            waitForElement(cb);
+            uncheckCheckbox(cb);
+        }
+
+        clickButton("Start Import"); // Validate queries page
+        waitForPipelineJobsToComplete(jobCount, "Folder import", false, MAX_WAIT_SECONDS * 2500);
     }
 
     protected boolean skipStudyImportQueryValidation()


### PR DESCRIPTION
#### Rationale
Support for importing study archives is going away. Add the ability to reload an EHR folder archive at upgrade time.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2925
* https://github.com/LabKey/tnprc_ehr/pull/704