### PR TITLE
Attempt to improve reliability of ViralLoadAssatTest

### DIFF
--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -636,10 +636,11 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         clickAndWait(templates.link(0, 0)); // the 'enter results' link
 
         _ext4Helper.waitForMaskToDisappear();
+        waitForElement(Ext4Helper.Locators.getGridRow("A10"));
 
         //use the same data included with this assay
-        waitForElement(Locator.linkContainingText("Download Example Data"));
-        
+        waitForElement(Ext4Helper.Locators.ext4ButtonEnabled("Download Example Data"));
+
         Ext4FieldRef.waitForField(this, "Instrument");
 
         assertEquals("Incorrect value for field", "ABI 7500", Ext4FieldRef.getForLabel(this, "Instrument").getValue());


### PR DESCRIPTION
This test has been having intermittent failures finding the instrument field. This adds a wait to ensure the grid is fully loaded - it's possible that reload is triggering a rerender on some page elements that's making the instrument field stale.