### PR TITLE
Extensible location tables and upgrade code for importing domain

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -1,5 +1,6 @@
 package org.labkey.api.ehr;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.labkey.api.audit.TransactionAuditProvider;
 import org.labkey.api.data.Container;
@@ -7,9 +8,11 @@ import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.UpgradeCode;
 import org.labkey.api.di.DataIntegrationService;
+import org.labkey.api.exp.property.DomainTemplateGroup;
 import org.labkey.api.gwt.client.AuditBehaviorType;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleContext;
+import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.query.AbstractQueryImportAction;
 import org.labkey.api.query.BatchValidationException;
@@ -28,6 +31,7 @@ import org.labkey.api.util.Path;
 import org.labkey.api.util.StartupListener;
 import org.labkey.api.util.UnexpectedException;
 import org.labkey.api.util.logging.LogHelper;
+import org.labkey.api.view.NotFoundException;
 
 import javax.servlet.ServletContext;
 import java.io.IOException;
@@ -54,6 +58,7 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
 
     private static final String ETL_PREFIX = "etl;";
     private static final String IMPORT_FROM_TSV_PREFIX = "importFromTsv;";
+    private static final String IMPORT_DOMAIN_TEMPLATE = "importTemplate;";
 
     private boolean _reloadStudy;
     /** ETL name -> whether to truncate before running */
@@ -119,6 +124,42 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
             String tsvPath = tsvArguments[3];
 
             _tsvImports.add(new TsvImport(schemaName, queryName, tsvPath));
+        }
+        else if (methodName.startsWith(IMPORT_DOMAIN_TEMPLATE))
+        {
+            String[] tsvArguments = methodName.split(";");
+            if (tsvArguments.length != 3)
+            {
+                throw new UnsupportedOperationException("Expected three arguments for importTemplate but got " + (tsvArguments.length - 1));
+            }
+
+            String moduleName = tsvArguments[1];
+            String domainGroup = tsvArguments[2];
+
+            Module module = ModuleLoader.getInstance().getModule(moduleName);
+            if (module == null)
+                throw new NotFoundException("Module '" + moduleName + "' for domain template import not found");
+
+            DomainTemplateGroup templateGroup = DomainTemplateGroup.get(module, domainGroup);
+            if (templateGroup != null)
+            {
+                if (templateGroup.hasErrors())
+                {
+                    throw new UnsupportedOperationException("Domain template group '" + domainGroup + "' has errors: " + StringUtils.join(templateGroup.getErrors(), "\n"));
+                }
+                try
+                {
+                    templateGroup.createAndImport(EHRService.get().getEHRStudyContainer(ContainerManager.getRoot()), EHRService.get().getEHRUser(ContainerManager.getRoot()), true, false);
+                }
+                catch (BatchValidationException e)
+                {
+                    throw UnexpectedException.wrap(e);
+                }
+            }
+            else
+            {
+                LOG.error("Domain template '" + domainGroup + "' not found for module '" + moduleName + "'");
+            }
         }
         else
         {

--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -127,14 +127,27 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
         }
         else if (methodName.startsWith(IMPORT_DOMAIN_TEMPLATE))
         {
-            String[] tsvArguments = methodName.split(";");
-            if (tsvArguments.length != 3)
+            String[] templateArguments = methodName.split(";");
+            if (templateArguments.length != 3)
             {
-                throw new UnsupportedOperationException("Expected three arguments for importTemplate but got " + (tsvArguments.length - 1));
+                throw new UnsupportedOperationException("Expected three arguments for importTemplate but got " + (templateArguments.length - 1));
             }
 
-            String moduleName = tsvArguments[1];
-            String domainGroup = tsvArguments[2];
+            Container ehrStudyContainer = EHRService.get().getEHRStudyContainer(ContainerManager.getRoot());
+            User ehrUser = EHRService.get().getEHRUser(ContainerManager.getRoot());
+
+            if (ehrStudyContainer == null)
+            {
+                throw new UnsupportedOperationException("EHR Study Container module property not found for extensible column import");
+            }
+
+            if (ehrUser == null)
+            {
+                throw new UnsupportedOperationException("EHR Admin User module property not found for extensible column import");
+            }
+
+            String moduleName = templateArguments[1];
+            String domainGroup = templateArguments[2];
 
             Module module = ModuleLoader.getInstance().getModule(moduleName);
             if (module == null)
@@ -149,7 +162,7 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
                 }
                 try
                 {
-                    templateGroup.createAndImport(EHRService.get().getEHRStudyContainer(ContainerManager.getRoot()), EHRService.get().getEHRUser(ContainerManager.getRoot()), true, false);
+                    templateGroup.createAndImport(ehrStudyContainer, ehrUser, true, false);
                 }
                 catch (BatchValidationException e)
                 {

--- a/ehr/resources/queries/ehr_lookups/cage.js
+++ b/ehr/resources/queries/ehr_lookups/cage.js
@@ -10,7 +10,7 @@ triggers.initScript(this);
 var EHR = triggers.EHR;
 var LABKEY = require("labkey");
 
-function onUpsert(helper, scriptErrors, row, oldRow) {
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'ehr_lookups', 'cage', function(helper, scriptErrors, row, oldRow){
     row.location = row.room;
     if (row.cage)
         row.location += '-' + row.cage;
@@ -36,7 +36,7 @@ function onUpsert(helper, scriptErrors, row, oldRow) {
         };
         row.joinToCage = newArray.join(',');
     }
-}
+});
 
 function onUpdate(helper, scriptErrors, row, oldRow) {
     row.cage = row.cage || oldRow.cage;

--- a/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-22.000-22.001.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-22.000-22.001.sql
@@ -1,0 +1,20 @@
+ALTER TABLE ehr_lookups.cage ADD COLUMN Lsid LSIDtype;
+ALTER TABLE ehr_lookups.areas ADD COLUMN Lsid LSIDtype;
+
+CREATE TABLE ehr_lookups.floors (
+    rowId SERIAL,
+    floor varchar(100),
+    building varchar(100),
+    name varchar(100),
+    description varchar(100),
+    created timestamp,
+    createdby integer,
+    modified timestamp,
+    modifiedby integer,
+    container ENTITYID NOT NULL,
+    Lsid LSIDtype,
+
+    CONSTRAINT PK_Floors PRIMARY KEY (rowId),
+    CONSTRAINT FK_Floors_Container FOREIGN KEY (container) REFERENCES core.Containers (EntityId)
+);
+CREATE INDEX IX_Ehr_Lookups_Floors_Container ON ehr_lookups.floors (Container);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-22.000-22.001.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-22.000-22.001.sql
@@ -1,0 +1,20 @@
+ALTER TABLE ehr_lookups.cage ADD Lsid LSIDtype;
+ALTER TABLE ehr_lookups.areas ADD Lsid LSIDtype;
+
+CREATE TABLE ehr_lookups.floors (
+    rowId int identity(1,1),
+    floor varchar(100),
+    building varchar(100),
+    name varchar(100),
+    description varchar(100),
+    created datetime,
+    createdby integer,
+    modified datetime,
+    modifiedby integer,
+    container ENTITYID NOT NULL,
+    Lsid LSIDtype,
+
+    CONSTRAINT PK_Floors PRIMARY KEY (rowId),
+    CONSTRAINT FK_Floors_Container FOREIGN KEY (container) REFERENCES core.Containers (EntityId)
+);
+CREATE INDEX IX_Ehr_Lookups_Floors_Container ON ehr_lookups.floors (Container);

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-22.000-22.001.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-22.000-22.001.sql
@@ -3,10 +3,10 @@ ALTER TABLE ehr_lookups.areas ADD Lsid LSIDtype;
 
 CREATE TABLE ehr_lookups.floors (
     rowId int identity(1,1),
-    floor varchar(100),
-    building varchar(100),
-    name varchar(100),
-    description varchar(100),
+    floor NVARCHAR(100),
+    building NVARCHAR(100),
+    name NVARCHAR(100),
+    description NVARCHAR(100),
     created datetime,
     createdby integer,
     modified datetime,

--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -253,6 +253,18 @@
                     <fkColumnName>entityid</fkColumnName>
                 </fk>
             </column>
+            <column columnName="lsid">
+                <datatype>lsidtype</datatype>
+                <isReadOnly>true</isReadOnly>
+                <isHidden>true</isHidden>
+                <isUserEditable>false</isUserEditable>
+                <isUnselectable>true</isUnselectable>
+                <fk>
+                    <fkColumnName>ObjectUri</fkColumnName>
+                    <fkTable>Object</fkTable>
+                    <fkDbSchema>exp</fkDbSchema>
+                </fk>
+            </column>
         </columns>
     </table>
     <table tableName="yesno" tableDbType="TABLE" useColumnOrder="true">
@@ -333,7 +345,7 @@
         </columns>
     </table>
     <table tableName="areas" tableDbType="TABLE" useColumnOrder="true">
-        <description>The most general categorization for animal housing, one level up from rooms</description>
+        <description>The most general categorization for animal housing</description>
         <javaCustomizer class="org.labkey.ehr.table.DefaultEHRCustomizer" />
         <auditLogging>DETAILED</auditLogging>
         <tableTitle>Areas</tableTitle>
@@ -359,6 +371,71 @@
                     <fkDbSchema>core</fkDbSchema>
                     <fkTable>containers</fkTable>
                     <fkColumnName>entityid</fkColumnName>
+                </fk>
+            </column>
+            <column columnName="lsid">
+                <datatype>lsidtype</datatype>
+                <isReadOnly>true</isReadOnly>
+                <isHidden>true</isHidden>
+                <isUserEditable>false</isUserEditable>
+                <isUnselectable>true</isUnselectable>
+                <fk>
+                    <fkColumnName>ObjectUri</fkColumnName>
+                    <fkTable>Object</fkTable>
+                    <fkDbSchema>exp</fkDbSchema>
+                </fk>
+            </column>
+        </columns>
+    </table>
+    <table tableName="floors" tableDbType="TABLE" useColumnOrder="true">
+        <javaCustomizer class="org.labkey.ehr.table.DefaultEHRCustomizer" />
+        <auditLogging>DETAILED</auditLogging>
+        <tableTitle>Floors</tableTitle>
+        <importUrl></importUrl>
+        <insertUrl></insertUrl>
+        <updateUrl></updateUrl>
+        <deleteUrl></deleteUrl>
+        <pkColumnName>floor</pkColumnName>
+        <columns>
+            <column columnName="rowid">
+                <isAutoInc>true</isAutoInc>
+                <shownInDetailsView>false</shownInDetailsView>
+                <isHidden>true</isHidden>
+                <isKeyField>false</isKeyField> <!-- EHRContainerScopedTable will lookup the rowid for updateRows -->
+            </column>
+            <column columnName="floor">
+                <isKeyField>true</isKeyField>
+            </column>
+            <column columnName="building">
+                <columnTitle>Building</columnTitle>
+                <fk>
+                    <fkDbSchema>ehr_lookups</fkDbSchema>
+                    <fkTable>buildings</fkTable>
+                    <fkColumnName>name</fkColumnName>
+                    <fkDisplayColumnName useRawValue="true"/>
+                </fk>
+            </column>
+            <column columnName="description"/>
+            <column columnName="name"/>
+            <column columnName="container">
+                <isUserEditable>false</isUserEditable>
+                <isHidden>true</isHidden>
+                <fk>
+                    <fkDbSchema>core</fkDbSchema>
+                    <fkTable>containers</fkTable>
+                    <fkColumnName>entityid</fkColumnName>
+                </fk>
+            </column>
+            <column columnName="lsid">
+                <datatype>lsidtype</datatype>
+                <isReadOnly>true</isReadOnly>
+                <isHidden>true</isHidden>
+                <isUserEditable>false</isUserEditable>
+                <isUnselectable>true</isUnselectable>
+                <fk>
+                    <fkColumnName>ObjectUri</fkColumnName>
+                    <fkTable>Object</fkTable>
+                    <fkDbSchema>exp</fkDbSchema>
                 </fk>
             </column>
         </columns>

--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -438,6 +438,26 @@
                     <fkDbSchema>exp</fkDbSchema>
                 </fk>
             </column>
+            <column columnName="createdby">
+                <isUserEditable>false</isUserEditable>
+                <nullable>true</nullable>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="created">
+                <isUserEditable>false</isUserEditable>
+                <nullable>true</nullable>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="modifiedby">
+                <isUserEditable>false</isUserEditable>
+                <nullable>true</nullable>
+                <isHidden>true</isHidden>
+            </column>
+            <column columnName="modified">
+                <isUserEditable>false</isUserEditable>
+                <nullable>true</nullable>
+                <isHidden>true</isHidden>
+            </column>
         </columns>
     </table>
     <table tableName="clinpath_status" tableDbType="TABLE" useColumnOrder="true">

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -156,7 +156,7 @@ public class EHRManager
             if (emailAddress == null)
             {
                 if (logOnError)
-                    _log.error("Attempted to access EHR email module property from container: " + (c == null ? null : c.getPath()) + ", but it was null.  Some code may not work as expected.", new Exception());
+                    _log.warn("Attempted to access EHR email module property from container: " + (c == null ? null : c.getPath()) + ", but it was null.  Some code may not work as expected.", new Exception());
                 return null;
             }
 

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -52,6 +52,7 @@ import org.labkey.api.module.ModuleContext;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.SimpleTableDomainKind;
 import org.labkey.api.security.User;
 import org.labkey.api.security.roles.RoleManager;
 import org.labkey.api.util.ContextListener;
@@ -200,6 +201,7 @@ public class EHRModule extends ExtendedSimpleModule
 
         PropertyService.get().registerDomainKind(new EHRDomainKind());
         PropertyService.get().registerDomainKind(new EHR_LookupsDomainKind());
+        PropertyService.get().registerDomainKind(new SimpleTableDomainKind());
     }
 
     @Nullable

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -131,7 +131,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.006;
+        return 22.001;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/model/EHRDomainKind.java
+++ b/ehr/src/org/labkey/ehr/model/EHRDomainKind.java
@@ -63,9 +63,9 @@ public class EHRDomainKind extends ExtendedTableDomainKind
     }
 
     @Override
-    public Set<String> getReservedPropertyNames(Domain domain)
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
     {
-        return super.getReservedPropertyNames(domain);
+        return super.getReservedPropertyNames(domain, user);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Make cages and areas extensible, add floors table to ehr_lookups and add option to shared EHR upgrade code to import domain template

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3014
* https://github.com/LabKey/nircEHRModules/pull/99

#### Changes
* Upgrade scripts to add floor to ehr_lookups and lsid columns to cage and areas for extensibility
* Add import domain template option to SharedEHRUpgradeCode
* Make EHR cage trigger unregisterable
