### PR TITLE
Do not override xtype for custom date components

### DIFF
--- a/ehr/resources/web/ehr/form/Panel.js
+++ b/ehr/resources/web/ehr/form/Panel.js
@@ -54,7 +54,9 @@ Ext4.define('EHR.form.Panel', {
         var items = [];
         var fields = EHR.model.DefaultClientModel.getFieldConfigs(this.formConfig.fieldConfigs, this.formConfig.configSources, this.extraMetaData);
         Ext4.Array.forEach(fields, function(field){
-            if (field.jsonType == 'date' && field.extFormat){
+            // don't override xtype for date for custom components
+            if (field.jsonType === 'date' && field.extFormat &&
+                    (field.xtype === undefined || field.xtype === 'xdate')) {
                 if (Ext4.Date.formatContainsHourInfo(field.extFormat)){
                     field.xtype = 'xdatetime';
                 }

--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -213,7 +213,9 @@ Ext4.define('EHR.grid.Panel', {
 
             var colCfg = EHR.DataEntryUtils.getColumnConfigFromMetadata(cfg, this);
             if (colCfg){
-                if (cfg.jsonType == 'date' && cfg.extFormat){
+                // don't override xtype for date for custom components
+                if (cfg.jsonType === 'date' && cfg.extFormat &&
+                        (cfg.xtype === undefined || cfg.xtype === 'xdate')) {
                     if (Ext4.Date.formatContainsHourInfo(cfg.extFormat)){
                         if(colCfg.editor)
                             colCfg.editor.xtype = 'xdatetime';


### PR DESCRIPTION
#### Rationale
This PR restricts the over riding of date component in grids and panel sections of data entry forms when custom date component is provided.

#### Related Pull Requests
* https://github.com/LabKey/tnprc_ehr/pull/728

