### PR TITLE
Reduce memory use and improve perf when populating EHR demographics cache during ETL

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
@@ -143,13 +143,13 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
         UserSchema us = defaultSchema.getUserSchema(_schemaName);
         if (us == null)
         {
-            throw new IllegalArgumentException("Schema " + _schemaName + " not found in the container: " + c.getPath());
+            throw new IllegalArgumentException("Schema " + _schemaName + " not found in the container: " + defaultSchema.getContainer().getPath());
         }
 
         final TableInfo ti = us.getTable(_queryName, null);
         if (ti == null)
         {
-            throw new IllegalArgumentException("Table: " + _schemaName + "." + _queryName + " not found in the container: " + c.getPath());
+            throw new IllegalArgumentException("Table: " + _schemaName + "." + _queryName + " not found in the container: " + defaultSchema.getContainer().getPath());
         }
 
         return ti;

--- a/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
@@ -31,11 +31,13 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.ehr.EHROwnable;
 import org.labkey.api.module.Module;
+import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 
+import javax.validation.groups.Default;
 import java.sql.Clob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -71,7 +73,7 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
     }
 
     @Override
-    public Map<String, Map<String, Object>> getProperties(Container c, User u, Collection<String> ids)
+    public Map<String, Map<String, Object>> getProperties(DefaultSchema defaultSchema, Collection<String> ids)
     {
         // if in debug, consider enabling debug logging on EHRDemographicsServiceImpl as well
         _log.debug("Running DemographicsProvider named: " + this.getName());
@@ -90,7 +92,7 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
         if (debugEnabled)
             startTableInfo = LocalDateTime.now();
 
-        final TableInfo ti = getTableInfo(c, u);
+        final TableInfo ti = getTableInfo(defaultSchema);
         String tiName = null;
 
         if (debugEnabled)
@@ -136,9 +138,9 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
         return ret;
     }
 
-    protected TableInfo getTableInfo(Container c, User u)
+    protected TableInfo getTableInfo(DefaultSchema defaultSchema)
     {
-        UserSchema us = QueryService.get().getUserSchema(u, c, _schemaName);
+        UserSchema us = defaultSchema.getUserSchema(_schemaName);
         if (us == null)
         {
             throw new IllegalArgumentException("Schema " + _schemaName + " not found in the container: " + c.getPath());

--- a/ehr/api-src/org/labkey/api/ehr/demographics/DemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/DemographicsProvider.java
@@ -16,6 +16,7 @@
 package org.labkey.api.ehr.demographics;
 
 import org.labkey.api.data.Container;
+import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.security.User;
 
 import java.util.Collection;
@@ -38,7 +39,7 @@ public interface DemographicsProvider
 
     boolean isAvailable(Container c, User u);
 
-    Map<String, Map<String, Object>> getProperties(Container c, User u, Collection<String> ids);
+    Map<String, Map<String, Object>> getProperties(DefaultSchema defaultSchema, Collection<String> ids);
 
     /**
      * report whether this provider requires calculation of cached data when a row in this passed table has changed

--- a/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
@@ -17,7 +17,6 @@ package org.labkey.api.ehr.demographics;
 
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
-import org.labkey.api.data.Container;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.Selector;
@@ -25,10 +24,9 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.ehr.demographics.AbstractListDemographicsProvider;
 import org.labkey.api.module.Module;
+import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.FieldKey;
-import org.labkey.api.security.User;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -65,10 +63,10 @@ public class WeightsDemographicsProvider extends AbstractListDemographicsProvide
     }
 
     @Override
-    public Map<String, Map<String, Object>> getProperties(Container c, User u, Collection<String> ids)
+    public Map<String, Map<String, Object>> getProperties(DefaultSchema defaultSchema, Collection<String> ids)
     {
         final Map<String, Map<String, Object>> ret = new HashMap<>();
-        final TableInfo ti = getTableInfo(c, u);
+        final TableInfo ti = getTableInfo(defaultSchema);
         final Map<FieldKey, ColumnInfo> cols = getColumns(ti);
         Sort sort = getSort();
 

--- a/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
@@ -265,7 +265,7 @@ public class EHRDemographicsServiceImpl extends EHRDemographicsService
 
         if (async)
         {
-            for (String id : ids)
+            for (String id : copiedIds)
             {
                 _cache.remove(getCacheKey(c, id));
             }


### PR DESCRIPTION
#### Rationale
We had a production server run out of memory on a 4GB heap during a large ETL

#### Changes
* Copy list of animal IDs to avoid holding JS "native" array in memory, which can drag the whole JS trigger script scope through
* Use a DefaultSchema during demographics cache refresh so that schemas and tables can be cached