### PR TITLE
Reintroduce "reloadStudy" to ease script merges from 21.11

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -86,6 +86,13 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
         _reloadFolder = true;
     }
 
+    @Deprecated // Remove this once no more EHR development is taking place on 21.11
+    public void reloadStudy(ModuleContext context)
+    {
+        LOG.error("Update this script to invoke \"reloadFolder\" instead of \"reloadStudy\"!");
+        reloadFolder(context);
+    }
+
     @Override
     public void fallthroughHandler(String methodName)
     {


### PR DESCRIPTION
#### Rationale
EHR scripts being merged from 21.11 are likely to reference "reloadStudy", which was removed in develop. Add it back temporarily to keep everything running smoothly.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/307
