### PR TITLE
Small change to the EHR controller to better work with Ext4 pages.

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1402,10 +1402,10 @@ public class EHRController extends SpringActionController
                 return null;
             }
 
-            DataEntryForm def = DataEntryManager.get().getFormByName(form.getFormType(), getContainer(), getUser());
+            DataEntryForm def = DataEntryManager.get().getFormByName(formType, getContainer(), getUser());
             if (def == null)
             {
-                errors.reject(ERROR_MSG, "Unknown form type: " + form.getFormType());
+                errors.reject(ERROR_MSG, "Unknown form type: " + formType);
                 return null;
             }
 


### PR DESCRIPTION
#### Rationale
Change to EHR controller to allow to not pass a formtype and inside the URL and have the task details page determine from the Java Ext4 form, Issue #44892
#### Related Pull Requests
N/A

#### Changes
Using fomType throughout the GetDataEntryFormDetailsAction method.
