### PR TITLE
Issue 45043: EHR upgrade code logs excessive warnings during bootstrap

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -120,6 +120,8 @@ abstract public class EHRService
      */
     abstract public User getEHRUser(Container c);
 
+    abstract public User getEHRUser(Container c, boolean logOnError);
+
     abstract public void registerReportLink(REPORT_LINK_TYPE type, String label, Module owner, DetailsURL url, @Nullable String category);
 
     abstract public void registerReportLink(REPORT_LINK_TYPE type, String label, Module owner, URLHelper url, @Nullable String category);

--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -141,16 +141,16 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
             }
 
             Container ehrStudyContainer = EHRService.get().getEHRStudyContainer(ContainerManager.getRoot());
-            User ehrUser = EHRService.get().getEHRUser(ContainerManager.getRoot());
+            User ehrUser = EHRService.get().getEHRUser(ContainerManager.getRoot(), false);
 
             if (ehrStudyContainer == null)
             {
-                LOG.warn("EHR Study Container module property not found for extensible column import. Skipping import.");
+                LOG.info("EHR Study Container module property not found for extensible column import. Skipping import.");
             }
 
             if (ehrUser == null)
             {
-                LOG.warn("EHR Admin User module property not found for extensible column import. Skipping import.");
+                LOG.info("EHR Admin User module property not found for extensible column import. Skipping import.");
             }
 
             if (ehrStudyContainer != null && ehrUser != null)

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -324,6 +324,12 @@ public class EHRServiceImpl extends EHRService
     }
 
     @Override
+    public User getEHRUser(Container c, boolean logOnError)
+    {
+        return EHRManager.get().getEHRUser(c, logOnError);
+    }
+
+    @Override
     public void registerReportLink(REPORT_LINK_TYPE type, String label, Module owner, DetailsURL url, @Nullable String category)
     {
         List<ReportLink> links = _reportLinks.get(type);


### PR DESCRIPTION
#### Rationale
When bootstrapping a server it won't have any EHR folders configured. So there's no need to cry that we can't find an EHR folder or admin user configured.

#### Changes
* Demote warning with stack trace to single info log message