### PR TITLE
Ticket 45145: CreatedBy fk overrides

### DIFF
--- a/ehr/resources/queries/ehr/Tasks_DataEntry.query.xml
+++ b/ehr/resources/queries/ehr/Tasks_DataEntry.query.xml
@@ -45,11 +45,6 @@
                     </column>
                     <column columnName="createdby">
                         <columnTitle>Created By</columnTitle>
-                        <fk>
-                            <fkDbSchema>core</fkDbSchema>
-                            <fkTable>users</fkTable>
-                            <fkColumnName>userid</fkColumnName>
-                        </fk>
                     </column>
                     <column columnName="created">
                         <columnTitle>Created</columnTitle>

--- a/ehr/resources/queries/ehr/my_requests.query.xml
+++ b/ehr/resources/queries/ehr/my_requests.query.xml
@@ -25,11 +25,6 @@
                     </column>
                     <column columnName="createdby">
                         <columnTitle>Created By</columnTitle>
-                        <fk>
-                            <fkDbSchema>core</fkDbSchema>
-                            <fkTable>users</fkTable>
-                            <fkColumnName>userid</fkColumnName>
-                        </fk>
                     </column>
                     <column columnName="notify1">
                         <columnTitle>First Contact</columnTitle>

--- a/ehr/resources/queries/ehr/my_tasks.query.xml
+++ b/ehr/resources/queries/ehr/my_tasks.query.xml
@@ -31,11 +31,6 @@
                     </column>
                     <column columnName="createdby">
                         <columnTitle>Created By</columnTitle>
-                        <fk>
-                            <fkDbSchema>core</fkDbSchema>
-                            <fkTable>users</fkTable>
-                            <fkColumnName>userid</fkColumnName>
-                        </fk>
                     </column>
                     <column columnName="created">
                         <columnTitle>Created</columnTitle>

--- a/ehr/resources/queries/ehr/requests.query.xml
+++ b/ehr/resources/queries/ehr/requests.query.xml
@@ -35,11 +35,6 @@
                     </column>
                     <column columnName="createdby">
                         <columnTitle>Created By</columnTitle>
-                        <fk>
-                            <fkDbSchema>core</fkDbSchema>
-                            <fkTable>users</fkTable>
-                            <fkColumnName>userid</fkColumnName>
-                        </fk>
                     </column>
                     <column columnName="notify1">
                         <columnTitle>First Contact</columnTitle>

--- a/ehr/resources/queries/ehr/tasks.query.xml
+++ b/ehr/resources/queries/ehr/tasks.query.xml
@@ -48,11 +48,6 @@
                     </column>
                     <column columnName="createdby">
                         <columnTitle>Created By</columnTitle>
-                        <fk>
-                            <fkDbSchema>core</fkDbSchema>
-                            <fkTable>users</fkTable>
-                            <fkColumnName>userid</fkColumnName>
-                        </fk>
                     </column>
                     <column columnName="created">
                         <columnTitle>Created</columnTitle>


### PR DESCRIPTION
#### Rationale
Built in CreatedBy column fks overridden.  Causes users removed from the project not to resolve in the lookup.  Not sure why this was done initially.  I don't see anything related to data entry or reporting where this is necessary.

#### Changes
* Remove fk overrides