### PR TITLE
Update LSID metadata to avoid making it unselectable

### DIFF
--- a/EHR_Purchasing/resources/schemas/ehr_purchasing.xml
+++ b/EHR_Purchasing/resources/schemas/ehr_purchasing.xml
@@ -24,7 +24,7 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
+                <isUnselectable>false</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>
@@ -59,7 +59,7 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
+                <isUnselectable>false</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>
@@ -86,7 +86,7 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
+                <isUnselectable>false</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>
@@ -113,7 +113,7 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
+                <isUnselectable>false</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>
@@ -139,7 +139,7 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
+                <isUnselectable>false</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>
@@ -171,7 +171,7 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
+                <isUnselectable>false</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>
@@ -204,7 +204,7 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
+                <isUnselectable>false</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>


### PR DESCRIPTION
#### Rationale
Submitting a wnprc purchasing request form with extensible columns throws "java.lang.IllegalStateException: LSID value not found in table - purchasingRequests".

Its a regression from changes made w.r.t extensible columns and TableSelector ignoring unselectable columns:
https://github.com/LabKey/platform/pull/3151
https://github.com/LabKey/platform/pull/3227

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/180

#### Changes
* Update LSID metadata to set 'isUnselectable' to false.
