### PR TITLE
21.11 fb purchasing line item numbers

### DIFF
--- a/EHR_Purchasing/resources/schemas/dbscripts/postgresql/ehr_purchasing-21.006-21.007.sql
+++ b/EHR_Purchasing/resources/schemas/dbscripts/postgresql/ehr_purchasing-21.006-21.007.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_purchasing.lineItems ADD COLUMN lineItemNumber INTEGER DEFAULT 0 NOT NULL;

--- a/EHR_Purchasing/resources/schemas/dbscripts/postgresql/ehr_purchasing-21.006-21.007.sql
+++ b/EHR_Purchasing/resources/schemas/dbscripts/postgresql/ehr_purchasing-21.006-21.007.sql
@@ -1,1 +1,0 @@
-ALTER TABLE ehr_purchasing.lineItems ADD COLUMN lineItemNumber INTEGER DEFAULT 0 NOT NULL;

--- a/EHR_Purchasing/resources/schemas/dbscripts/postgresql/ehr_purchasing-22.000-22.001.sql
+++ b/EHR_Purchasing/resources/schemas/dbscripts/postgresql/ehr_purchasing-22.000-22.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_purchasing.lineItems ADD COLUMN lineItemNumber INTEGER DEFAULT 0 NOT NULL;

--- a/EHR_Purchasing/resources/schemas/ehr_purchasing.xml
+++ b/EHR_Purchasing/resources/schemas/ehr_purchasing.xml
@@ -159,6 +159,7 @@
         <columns>
             <column columnName="rowId"/>
             <column columnName="requestRowId"/>
+            <column columnName="lineItemNumber"/>
             <column columnName="item"/>
             <column columnName="itemUnitId"/>
             <column columnName="controlledSubstance"/>

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingModule.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingModule.java
@@ -46,7 +46,7 @@ public class EHR_PurchasingModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.006;
+        return 21.007;
     }
 
     @Override

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingModule.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingModule.java
@@ -46,7 +46,7 @@ public class EHR_PurchasingModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.007;
+        return 22.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
A new column is needed for giving each item in a purchase order a line item number

#### Related Pull Requests
The code added in the wnprc-modules relies on this new column
https://github.com/WNPRC-EHR-Services/wnprc-modules/pull/285

#### Changes
Added a new column to ehr_purchasing.lineItems and also added it to the schema xml file