### PR TITLE
Update WNPRC pedigree plots for new visPedigree library

### DIFF
--- a/ehr/resources/reports/schemas/study/Pedigree/PedigreeDown.r
+++ b/ehr/resources/reports/schemas/study/Pedigree/PedigreeDown.r
@@ -8,7 +8,7 @@ options(echo=FALSE)
 library(visPedigree)
 library(Rlabkey)
 
-labkey.setCurlOptions(ssl.verifypeer=FALSE, ssl.verifyhost=FALSE)
+labkey.setCurlOptions(ssl_verifypeer=FALSE, ssl_verifyhost=FALSE)
 
 id <- as.character(labkey.data$id)
 method <- "down"

--- a/ehr/resources/reports/schemas/study/Pedigree/PedigreeUp.r
+++ b/ehr/resources/reports/schemas/study/Pedigree/PedigreeUp.r
@@ -8,7 +8,7 @@ options(echo=FALSE)
 library(visPedigree)
 library(Rlabkey)
 
-labkey.setCurlOptions(ssl.verifypeer=FALSE, ssl.verifyhost=FALSE)
+labkey.setCurlOptions(ssl_verifypeer=FALSE, ssl_verifyhost=FALSE)
 
 id <- as.character(labkey.data$id)
 method <- "up"


### PR DESCRIPTION
#### Rationale
Modifying use of RLabKey inside Pedigree plots for WNPRC

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- Changing ssl.verifyhost to ssl_verifyhost to work with RLabKey 2.8.2
