### PR TITLE
Add viewName metadata to ehr manageRecord view

### DIFF
--- a/ehr/resources/views/manageRecord.html
+++ b/ehr/resources/views/manageRecord.html
@@ -18,7 +18,8 @@ Ext.onReady(function(){
             keyField: LABKEY.ActionURL.getParameter('keyField'),
             keyValue: Ext.util.Format.htmlDecode(LABKEY.ActionURL.getParameter('key')),
             title: (LABKEY.ActionURL.getParameter('title') || EHR.Utils.toTitleCase(LABKEY.ActionURL.getParameter('queryName'))),
-            metadata: EHR.Metadata.getTableMetadata(LABKEY.ActionURL.getParameter('queryName'), metaSources)
+            metadata: EHR.Metadata.getTableMetadata(LABKEY.ActionURL.getParameter('queryName'), metaSources),
+            viewName: LABKEY.ActionURL.getParameter('viewName') || LABKEY.ActionURL.getParameter('query.viewName') || '~~UPDATE~~'
         }]
     });
     var webpart = <%=webpartContext%>;


### PR DESCRIPTION
#### Rationale
* Adds ability to specify viewName in the url to pull in metadata in the ext update form, see WNPRC ticket 45199

#### Related Pull Requests
* 

#### Changes
* Add viewName metadata to manageRecord.html
