### PR TITLE
Option to do query validation at end of tests

### DIFF
--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -189,7 +189,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
     {
         if (shouldValidateQueries())
         {
-            super.validateQueries(true);
+            validateQueries(true, 300000);
         }
         else
         {

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -189,7 +189,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
     {
         if (shouldValidateQueries())
         {
-            super.validateQueries(validateSubfolders);
+            super.validateQueries(true);
         }
         else
         {

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -179,12 +179,24 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
             log("EHR test has too many hard coded links and special actions to crawl effectively. Skipping crawl.");
     }
 
+    protected boolean shouldValidateQueries()
+    {
+        return false;
+    }
+
     @Override
     public void validateQueries(boolean validateSubfolders)
     {
-        //NOTE: the queries are also validated as part of study import
-        //also, validation takes place on the project root, while the EHR and required datasets are loaded into a subfolder
-        log("Skipping query validation.");
+        if (shouldValidateQueries())
+        {
+            super.validateQueries(validateSubfolders);
+        }
+        else
+        {
+            //NOTE: the queries are also validated as part of study import
+            //also, validation takes place on the project root, while the EHR and required datasets are loaded into a subfolder
+            log("Skipping query validation.");
+        }
     }
 
     protected Pattern[] getIgnoredElements()


### PR DESCRIPTION
#### Rationale
Currently EHR tests don't do query validation in test postamble. This provides option to do that validation there.

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/426

#### Changes
* Add shouldValidateQueries()
