### PR TITLE
Backport query lint fixes

### DIFF
--- a/ehr/resources/queries/ehr/TasksById.sql
+++ b/ehr/resources/queries/ehr/TasksById.sql
@@ -5,18 +5,8 @@
  */
 SELECT
   sd.id,
---   sd.id.curlocation.location as location,
---   sd.id.curlocation.room,
---   sd.id.curlocation.cage,
---   t.title,
---   t.formtype,
   t.taskId,
-  t.formtype,
---   t.assignedTo,
---   t.duedate,
---   t.created,
---   t.createdby,
---   t.qcstate
+  t.formtype
 
 FROM ehr.tasks t
 

--- a/ehr/resources/queries/ehr/my_formtemplates.sql
+++ b/ehr/resources/queries/ehr/my_formtemplates.sql
@@ -9,7 +9,7 @@ SELECT
     category,
     formType,
     userId,
-    description,
+    description
 
 FROM ehr.formtemplates t
 

--- a/ehr/resources/queries/ehr/protocolActiveAnimals.sql
+++ b/ehr/resources/queries/ehr/protocolActiveAnimals.sql
@@ -6,7 +6,7 @@
 SELECT
   p.protocol,
   count(distinct a.Id) AS TotalActiveAnimals,
-  group_concat(distinct a.Id) AS ActiveAnimals,
+  group_concat(distinct a.Id) AS ActiveAnimals
 
 FROM ehr.protocol p
 

--- a/ehr/resources/queries/ehr/protocolHistoricAnimals.sql
+++ b/ehr/resources/queries/ehr/protocolHistoricAnimals.sql
@@ -11,7 +11,7 @@ SELECT
   a.LatestStart,
   a.LatestEnd,
 
-  COALESCE(a.Total, 0) AS TotalAssignments,
+  COALESCE(a.Total, 0) AS TotalAssignments
 
 FROM ehr.protocol p
 

--- a/ehr/resources/queries/ehr/protocolTotalHistoricAnimalsBySpecies.sql
+++ b/ehr/resources/queries/ehr/protocolTotalHistoricAnimalsBySpecies.sql
@@ -9,8 +9,7 @@ p.protocol,
 p.approve,
 p.species,
 pc.allowed,
-p.TotalAnimals,
---pc.allowed - p.TotalAnimals as TotalRemaining,
+p.TotalAnimals
 
 FROM
 (
@@ -18,7 +17,7 @@ SELECT
   coalesce(p.protocol, pa.protocol) as protocol,
   p.approve,
   pa.species,
-  CONVERT(Count(pa.id), INTEGER) AS TotalAnimals,
+  CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
 
 FROM ehr.protocol p
 LEFT OUTER JOIN ehr.protocolHistoricAnimals pa ON (p.protocol = pa.protocol)
@@ -39,7 +38,7 @@ SELECT
   p.approve,
   'All Species' as species,
   p.maxAnimals as allowed,
-  CONVERT(Count(pa.id), INTEGER) AS TotalAnimals,
+  CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
 
 FROM ehr.protocol p
 LEFT OUTER JOIN ehr.protocolHistoricAnimals pa ON (p.protocol = pa.protocol)

--- a/ehr/resources/queries/ehr_lookups/cagesMissingColumn.sql
+++ b/ehr/resources/queries/ehr_lookups/cagesMissingColumn.sql
@@ -7,4 +7,4 @@ SELECT
   c.cage
 FROM ehr_lookups.cage c
 LEFT JOIN ehr_lookups.cage_positions cp ON (c.cage = cp.cage)
-WHERE cp.cage IS NULL and cp.cage IS NOT NULL;
+WHERE cp.cage IS NULL and cp.cage IS NOT NULL

--- a/ehr/resources/queries/ehr_lookups/dateRange.sql
+++ b/ehr/resources/queries/ehr_lookups/dateRange.sql
@@ -18,7 +18,7 @@ cast(NumDays as integer) as numDays @hidden
 
 FROM (SELECT
 
-timestampadd('SQL_TSI_DAY', i.value, CAST(COALESCE(CAST(StartDate as date), curdate()) AS TIMESTAMP)) as date,
+timestampadd('SQL_TSI_DAY', i.value, CAST(COALESCE(CAST(StartDate as date), curdate()) AS TIMESTAMP)) as date
 
 FROM ldk.integers i
 

--- a/ehr/resources/queries/ehr_lookups/next30Days.sql
+++ b/ehr/resources/queries/ehr_lookups/next30Days.sql
@@ -10,11 +10,11 @@ cast(dayofyear(i.date) as integer) as DayOfYear,
 cast(dayofmonth(i.date) as integer) as DayOfMonth,
 cast(dayofweek(i.date) as integer) as DayOfWeek,
 ceiling(cast(dayofmonth(i.date) as float) / 7.0) as WeekOfMonth,
-cast(week(i.date) as integer) as WeekOfYear,
+cast(week(i.date) as integer) as WeekOfYear
 
 FROM (SELECT
 
-timestampadd('SQL_TSI_DAY', i.value-7, curdate()) as date,
+timestampadd('SQL_TSI_DAY', i.value-7, curdate()) as date
 
 FROM ldk.integers i
 

--- a/ehr/resources/queries/ehr_lookups/yearMonth.sql
+++ b/ehr/resources/queries/ehr_lookups/yearMonth.sql
@@ -6,7 +6,7 @@
 SELECT
   convert((year(curdate()) - i.value), integer) as year,
   m.month,
-  m.rowid as MonthNum,
+  m.rowid as MonthNum
   
 FROM ldk.integers i
 CROSS JOIN ehr_lookups.months m

--- a/ehr/resources/queries/study/AssignmentOverlaps.sql
+++ b/ehr/resources/queries/study/AssignmentOverlaps.sql
@@ -39,7 +39,7 @@ FROM (
   h.project.title as title,
   h.qcstate,
   cast(COALESCE(StartDate, '1900-01-01') as date) as StartDateParam,
-  cast(COALESCE(EndDate, curdate()) as date) as EndDateParam,
+  cast(COALESCE(EndDate, curdate()) as date) as EndDateParam
   FROM study.assignment h
 ) h
 

--- a/ehr/resources/queries/study/HousingCheck.sql
+++ b/ehr/resources/queries/study/HousingCheck.sql
@@ -35,8 +35,8 @@ case
 end as next,
 h.remark,
 h.qcstate,
-(select min(i.date) FROM study.housing i WHERE i.Id = h.Id and i.date > h.date) as nextHousingRecord,
-(select max(i.date) FROM study.housing i WHERE i.Id = h.Id and i.date < h.date) as previousHousingRecord
+(select min(i.date) AS d FROM study.housing i WHERE i.Id = h.Id and i.date > h.date) as nextHousingRecord,
+(select max(i.date) AS d FROM study.housing i WHERE i.Id = h.Id and i.date < h.date) as previousHousingRecord
 
 FROM study.housing h
 

--- a/ehr/resources/queries/study/HousingOverlapsByIdDateOnly.sql
+++ b/ehr/resources/queries/study/HousingOverlapsByIdDateOnly.sql
@@ -8,7 +8,7 @@ PARAMETERS(StartDate TIMESTAMP, EndDate TIMESTAMP, Room CHAR DEFAULT NULL, Cage 
 
 SELECT
 h.Id,
-cast(StartDate as timestamp) as date,
+cast(StartDate as timestamp) as date
 
 FROM study.housing h
 

--- a/ehr/resources/queries/study/assignmentTotalDaysAssigned.sql
+++ b/ehr/resources/queries/study/assignmentTotalDaysAssigned.sql
@@ -28,7 +28,7 @@ CASE
     9999
 END
 ), integer)
-AS TotalDaysAssigned,
+AS TotalDaysAssigned
 
 
 
@@ -43,9 +43,7 @@ a.date,
 coalesce(a.enddate, now()) AS enddate,
 
 convert(year(a.date), 'INTEGER') as StartYear,
-convert(year(coalesce(a.enddate, now())), 'INTEGER') as EndYear,
-
---TIMESTAMPDIFF('SQL_TSI_DAY', a.date, coalesce(a.enddate, curdate())) AS TotalDaysAssigned,
+convert(year(coalesce(a.enddate, now())), 'INTEGER') as EndYear
 
 FROM (SELECT convert(year(curdate()), 'INTEGER')-i.value as Year FROM ldk.integers i WHERE i.value <=5) i
 LEFT JOIN study.assignment a

--- a/ehr/resources/queries/study/colonyPopulationChange.sql
+++ b/ehr/resources/queries/study/colonyPopulationChange.sql
@@ -10,7 +10,7 @@ SELECT
 --   T1.id.dataset.demographics.species as species,
   'Births' AS Category,
   T1.date,
-  convert(year(T1.date), integer) AS Year,
+  convert(year(T1.date), integer) AS Year
 
 FROM study.Birth T1
 WHERE T1.date IS NOT NULL
@@ -23,7 +23,7 @@ SELECT
 --   T2.id.dataset.demographics.species,
   'Arrivals' AS Category,
   T2.date,
-  convert(year(T2.date), INTEGER) AS Year,
+  convert(year(T2.date), INTEGER) AS Year
 
 FROM study.Arrival T2
 WHERE T2.date IS NOT NULL
@@ -37,7 +37,7 @@ SELECT
 --   T3.id.dataset.demographics.species,
   'Departures' AS Category,
   T3.date,
-  convert(year(T3.date), INTEGER) AS Year,
+  convert(year(T3.date), INTEGER) AS Year
 
 FROM study.Departure T3
 WHERE T3.date IS NOT NULL
@@ -51,7 +51,7 @@ SELECT
 --   T4.id.dataset.demographics.species,
   'Deaths' AS Category,
   T4.date,
-  convert(year(T4.date), INTEGER) AS Year,
+  convert(year(T4.date), INTEGER) AS Year
 
 FROM study.Deaths T4
 WHERE T4.date IS NOT NULL

--- a/ehr/resources/queries/study/demographicsAgeClass.sql
+++ b/ehr/resources/queries/study/demographicsAgeClass.sql
@@ -8,7 +8,7 @@ SELECT
 d.id,
 ac.AgeClass,
 ac.label,
-ac.gender,
+ac.gender
 
 FROM study.demographics d
 LEFT JOIN ehr_lookups.ageclass ac

--- a/ehr/resources/queries/study/demographicsArrival.sql
+++ b/ehr/resources/queries/study/demographicsArrival.sql
@@ -10,7 +10,7 @@ SELECT
 
   T2.EarliestArrival,
 
-  coalesce(T2.EarliestArrival, d.birth) as Center_Arrival,
+  coalesce(T2.EarliestArrival, d.birth) as Center_Arrival
 
 FROM study.demographics d
 

--- a/ehr/resources/queries/study/demographicsCurLocation.sql
+++ b/ehr/resources/queries/study/demographicsCurLocation.sql
@@ -30,7 +30,7 @@ coalesce(d2.room, '') as room_order,
 d2.room_sortValue @hidden,
 
 coalesce(d2.cage, '') as cage_order,
-d2.cage_sortValue @hidden,
+d2.cage_sortValue @hidden
 
 FROM study.housing d2
 

--- a/ehr/resources/queries/study/demographicsMostRecentWeight.sql
+++ b/ehr/resources/queries/study/demographicsMostRecentWeight.sql
@@ -20,7 +20,7 @@ cast((
 FROM (
 SELECT
   w.Id AS Id,
-  max(w.date) AS MostRecentWeightDate,
+  max(w.date) AS MostRecentWeightDate
 
 FROM study.weight w
 WHERE w.qcstate.publicdata = true and w.weight is not null

--- a/ehr/resources/queries/study/encountersWithSnomedBySet.sql
+++ b/ehr/resources/queries/study/encountersWithSnomedBySet.sql
@@ -20,7 +20,7 @@ e.date,
 e.caseno,
 e.set_number,
 group_concat(e.codeWithSort, chr(10)) as codes,
-group_concat(e.codeMeaning, chr(10)) as codesMeaning,
+group_concat(e.codeMeaning, chr(10)) as codesMeaning
 
 FROM (
 

--- a/ehr/resources/queries/study/validateFinalWeights.sql
+++ b/ehr/resources/queries/study/validateFinalWeights.sql
@@ -7,7 +7,7 @@
 select w.id, w.date as WeightDate, w.death, timestampdiff('SQL_TSI_DAY', w.date, w.death) as daysBetween
 
 from (SELECT
-  w.Id AS Id, max(w.date) AS date, max(w.id.dataset.demographics.death) as death,
+  w.Id AS Id, max(w.date) AS date, max(w.id.dataset.demographics.death) as death
 	FROM study.weight w
 	WHERE w.qcstate.publicdata = true and w.weight is not null and w.id.dataset.demographics.death is not null
 	GROUP BY w.id) w

--- a/ehr/resources/queries/study/weightConsecutiveDrops.sql
+++ b/ehr/resources/queries/study/weightConsecutiveDrops.sql
@@ -21,7 +21,7 @@ SELECT
   pd2.PrevDate as PrevDate2,
   pw2.weight AS PrevWeight2,
   Round(((pw1.weight - pw2.weight) * 100 / pw1.weight), 1) AS PctChange2,
-  timestampdiff('SQL_TSI_DAY', pw2.date, pw1.date) AS Interval2,
+  timestampdiff('SQL_TSI_DAY', pw2.date, pw1.date) AS Interval2
 
 FROM study.weight w
   --Find the next most recent weight date before this one

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -382,7 +382,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
     }
 
     /** Hook for center-specific setup that needs to happen after the containers are created but before the study is imported */
-    protected void doExtraPreStudyImportSetup()
+    protected void doExtraPreStudyImportSetup() throws IOException, CommandException
     {
 
     }


### PR DESCRIPTION
#### Rationale
Better to have a clean set of results from query validation

#### Changes
* Remove trailing commas, add aliases for expressions
* Allow subclasses to throw Java API exceptions during setup
