### PR TITLE
Finish truncating all tables before queueing new jobs

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
+++ b/ehr/api-src/org/labkey/api/ehr/SharedEHRUpgradeCode.java
@@ -236,6 +236,7 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
                 throw UnexpectedException.wrap(e);
             }
 
+            // Truncate and reset all tables before queueing the jobs to reduce contention and possible deadlocks
             for (Map.Entry<String, Boolean> etlInfo : _etls.entrySet())
             {
                 if (etlInfo.getValue().booleanValue())
@@ -251,7 +252,11 @@ public class SharedEHRUpgradeCode implements UpgradeCode, StartupListener
                         LOG.info("No saved state for " + etlInfo.getKey() + " found for reset, starting ETL.");
                     }
                 }
+            }
 
+            // Now queue all the ETL jobs
+            for (Map.Entry<String, Boolean> etlInfo : _etls.entrySet())
+            {
                 try
                 {
                     DataIntegrationService.get().runTransformNow(container, user, etlInfo.getKey());


### PR DESCRIPTION
#### Rationale
```
ERROR ExceptionUtil            2022-05-12T07:41:33,421       http-nio-80-exec-1 : Unhandled exception: ERROR: deadlock detected
  Detail: Process 1520 waits for ShareLock on transaction 7320473; blocked by process 1040.
Process 1040 waits for ShareLock on transaction 7320472; blocked by process 1520.
  Hint: See server log for query details.
  Where: while deleting tuple (10093,25) in relation "c6d75_housing"
org.labkey.api.data.RuntimeSQLException: ERROR: deadlock detected
  Detail: Process 1520 waits for ShareLock on transaction 7320473; blocked by process 1040.
Process 1040 waits for ShareLock on transaction 7320472; blocked by process 1520.
  Hint: See server log for query details.
  Where: while deleting tuple (10093,25) in relation "c6d75_housing"
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:329) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:315) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:291) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:286) ~[postgresql-42.3.3.jar:42.3.3]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193) ~[tomcat-dbcp.jar:9.0.46]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193) ~[tomcat-dbcp.jar:9.0.46]
	at org.labkey.api.data.dialect.StatementWrapper.execute(StatementWrapper.java:2051) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor$NormalStatementExecutor.execute(SqlExecutor.java:147) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor$NormalStatementExecutor.execute(SqlExecutor.java:135) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor.execute(SqlExecutor.java:113) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor.execute(SqlExecutor.java:74) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.study.model.DatasetDefinition.deleteRows(DatasetDefinition.java:827) ~[study-22.3-SNAPSHOT.jar:?]
	at org.labkey.study.query.DatasetUpdateService.truncateRows(DatasetUpdateService.java:557) ~[study-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.query.AbstractQueryUpdateService.truncateRows(AbstractQueryUpdateService.java:816) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.study.query.DatasetUpdateService.truncateRows(DatasetUpdateService.java:567) ~[study-22.3-SNAPSHOT.jar:?]
	at org.labkey.di.pipeline.TransformManager.truncateTargets(TransformManager.java:1149) ~[dataintegration-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.ehr.SharedEHRUpgradeCode.moduleStartupComplete(SharedEHRUpgradeCode.java:243) ~[ehr_api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.util.ContextListener.moduleStartupComplete(ContextListener.java:143) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.completeStartup(ModuleLoader.java:1584) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.initiateModuleStartup(ModuleLoader.java:1496) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.afterUpgrade(ModuleLoader.java:1687) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.lambda$startNonCoreUpgradeAndStartup$7(ModuleLoader.java:1664) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleUpgrader.lambda$upgrade$0(ModuleUpgrader.java:111) ~[api-22.3-SNAPSHOT.jar:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
ERROR ExceptionUtil            2022-05-12T07:41:33,547       http-nio-80-exec-3 : Unhandled exception: ERROR: deadlock detected
  Detail: Process 1520 waits for ShareLock on transaction 7320473; blocked by process 1040.
Process 1040 waits for ShareLock on transaction 7320472; blocked by process 1520.
  Hint: See server log for query details.
  Where: while deleting tuple (10093,25) in relation "c6d75_housing"
org.labkey.api.data.RuntimeSQLException: ERROR: deadlock detected
  Detail: Process 1520 waits for ShareLock on transaction 7320473; blocked by process 1040.
Process 1040 waits for ShareLock on transaction 7320472; blocked by process 1520.
  Hint: See server log for query details.
  Where: while deleting tuple (10093,25) in relation "c6d75_housing"
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:329) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeCachedSql(PgStatement.java:315) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.executeWithFlags(PgStatement.java:291) ~[postgresql-42.3.3.jar:42.3.3]
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:286) ~[postgresql-42.3.3.jar:42.3.3]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193) ~[tomcat-dbcp.jar:9.0.46]
	at org.apache.tomcat.dbcp.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193) ~[tomcat-dbcp.jar:9.0.46]
	at org.labkey.api.data.dialect.StatementWrapper.execute(StatementWrapper.java:2051) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor$NormalStatementExecutor.execute(SqlExecutor.java:147) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor$NormalStatementExecutor.execute(SqlExecutor.java:135) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor.execute(SqlExecutor.java:113) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.data.SqlExecutor.execute(SqlExecutor.java:74) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.study.model.DatasetDefinition.deleteRows(DatasetDefinition.java:827) ~[study-22.3-SNAPSHOT.jar:?]
	at org.labkey.study.query.DatasetUpdateService.truncateRows(DatasetUpdateService.java:557) ~[study-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.query.AbstractQueryUpdateService.truncateRows(AbstractQueryUpdateService.java:816) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.study.query.DatasetUpdateService.truncateRows(DatasetUpdateService.java:567) ~[study-22.3-SNAPSHOT.jar:?]
	at org.labkey.di.pipeline.TransformManager.truncateTargets(TransformManager.java:1149) ~[dataintegration-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.ehr.SharedEHRUpgradeCode.moduleStartupComplete(SharedEHRUpgradeCode.java:243) ~[ehr_api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.util.ContextListener.moduleStartupComplete(ContextListener.java:143) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.completeStartup(ModuleLoader.java:1584) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.initiateModuleStartup(ModuleLoader.java:1496) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.afterUpgrade(ModuleLoader.java:1687) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleLoader.lambda$startNonCoreUpgradeAndStartup$7(ModuleLoader.java:1664) ~[api-22.3-SNAPSHOT.jar:?]
	at org.labkey.api.module.ModuleUpgrader.lambda$upgrade$0(ModuleUpgrader.java:111) ~[api-22.3-SNAPSHOT.jar:?]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

#### Changes
* Truncate and reset all tables before starting the ETLs