### PR TITLE
Viral assay load decimal precision

### DIFF
--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
@@ -16,6 +16,14 @@
 package org.labkey.viral_load_assay;
 
 import org.json.JSONObject;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.SchemaKey;
+import org.labkey.api.view.ViewContext;
+
+import java.text.DecimalFormat;
 
 /**
  * Created with IntelliJ IDEA.
@@ -41,7 +49,7 @@ public class Viral_Load_Manager
         return _instance;
     }
 
-    public JSONObject getDefaultAssayMetadata(JSONObject meta){
+    public JSONObject getDefaultAssayMetadata(JSONObject meta, ViewContext ctx){
         JSONObject runMeta = getJsonObject(meta, "Run");
         JSONObject technique = getJsonObject(runMeta, "technique");
         technique.put("defaultValue", "Lifson 1-Step VL");
@@ -74,6 +82,32 @@ public class Viral_Load_Manager
         JSONObject plate = getJsonObject(resultsMeta, "plate");
         plate.put("hidden", true);
         resultsMeta.put("plate", plate);
+
+        // This overrides extjs default decimalPrecision of 2, only where specified by metadata from the server. Makes input
+        // forms respect formatString on column metadata. Decimals will still round to two places if formatString not set.
+        // Consider: Move somewhere more central?
+        TableInfo resultTable = QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), SchemaKey.fromString("assay.Viral_Loads.Viral_Load")).getTable("Data");
+        if (null != resultTable)
+        {
+            for (ColumnInfo column : resultTable.getColumns())
+            {
+                if (column.getJdbcType().equals(JdbcType.DECIMAL) || column.getJdbcType().equals(JdbcType.DOUBLE))
+                {
+                    String format = column.getFormat();
+                    if (null != format)
+                    {
+                        int decimals = new DecimalFormat(format).getMaximumFractionDigits();
+                        JSONObject editor = new JSONObject().put("decimalPrecision", decimals);
+                        var col = (JSONObject)resultsMeta.get(column.getName());
+                        if (null == col)
+                            col = new JSONObject();
+
+                        col.put("editorConfig", editor);
+                        resultsMeta.put(column.getName(), col);
+                    }
+                }
+            }
+        }
 
         meta.put("Results", resultsMeta);
 

--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SchemaKey;
+import org.labkey.api.query.UserSchema;
 import org.labkey.api.view.ViewContext;
 
 import java.text.DecimalFormat;
@@ -86,24 +87,28 @@ public class Viral_Load_Manager
         // This overrides extjs default decimalPrecision of 2, only where specified by metadata from the server. Makes input
         // forms respect formatString on column metadata. Decimals will still round to two places if formatString not set.
         // Consider: Move somewhere more central?
-        TableInfo resultTable = QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), SchemaKey.fromString("assay.Viral_Loads.Viral_Load")).getTable("Data");
-        if (null != resultTable)
+        UserSchema viralAssaySchema = QueryService.get().getUserSchema(ctx.getUser(), ctx.getContainer(), SchemaKey.fromString("assay.Viral_Loads.Viral_Load"));
+        if (null != viralAssaySchema)
         {
-            for (ColumnInfo column : resultTable.getColumns())
+            TableInfo resultTable = viralAssaySchema.getTable("Data");
+            if (null != resultTable)
             {
-                if (column.getJdbcType().equals(JdbcType.DECIMAL) || column.getJdbcType().equals(JdbcType.DOUBLE))
+                for (ColumnInfo column : resultTable.getColumns())
                 {
-                    String format = column.getFormat();
-                    if (null != format)
+                    if (column.getJdbcType().equals(JdbcType.DECIMAL) || column.getJdbcType().equals(JdbcType.DOUBLE))
                     {
-                        int decimals = new DecimalFormat(format).getMaximumFractionDigits();
-                        JSONObject editor = new JSONObject().put("decimalPrecision", decimals);
-                        var col = (JSONObject)resultsMeta.get(column.getName());
-                        if (null == col)
-                            col = new JSONObject();
+                        String format = column.getFormat();
+                        if (null != format)
+                        {
+                            int decimals = new DecimalFormat(format).getMaximumFractionDigits();
+                            JSONObject editor = new JSONObject().put("decimalPrecision", decimals);
+                            var col = (JSONObject) resultsMeta.get(column.getName());
+                            if (null == col)
+                                col = new JSONObject();
 
-                        col.put("editorConfig", editor);
-                        resultsMeta.put(column.getName(), col);
+                            col.put("editorConfig", editor);
+                            resultsMeta.put(column.getName(), col);
+                        }
                     }
                 }
             }

--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/DefaultVLImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/DefaultVLImportMethod.java
@@ -45,7 +45,7 @@ class DefaultVLImportMethod extends DefaultAssayImportMethod
     public JSONObject getMetadata(ViewContext ctx, ExpProtocol protocol)
     {
         JSONObject meta = super.getMetadata(ctx, protocol);
-        Viral_Load_Manager.get().getDefaultAssayMetadata(meta);
+        Viral_Load_Manager.get().getDefaultAssayMetadata(meta, ctx);
         return meta;
     }
 

--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ViralLoadAssayDataProvider.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ViralLoadAssayDataProvider.java
@@ -58,7 +58,7 @@ public class ViralLoadAssayDataProvider extends AbstractAssayDataProvider
     {
         JSONObject meta = super.getTemplateMetadata(ctx);
         JSONObject domainMeta = meta.getJSONObject("domains");
-        Viral_Load_Manager.get().getDefaultAssayMetadata(domainMeta);
+        Viral_Load_Manager.get().getDefaultAssayMetadata(domainMeta, ctx);
 
         JSONObject runMeta = getJsonObject(domainMeta, "Run");
         String[] hiddenRunFields = new String[]{"instrument", "slope", "intercept", "rSquared"};


### PR DESCRIPTION
#### Rationale
ExtJS defaults number inputs to two decimal places. Currently this is not configurable for the viral load assays. This PR sets the decimal precision to match the formatString (if defined) for extjs decimal columns in viral load assay results. Default is still two. Setting formatString on column metadata will set the number of decimal places.

#### Related Pull Requests
https://github.com/LabKey/ehrModules/pull/383

#### Changes
* Default metadata for the assay results adds the decimalPrecision to any decimal or double values with a formatString defined
