### PR TITLE
Selenium 4.2 compatibility

### DIFF
--- a/ehr/test/src/org/labkey/test/pages/ehr/AnimalHistoryPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/AnimalHistoryPage.java
@@ -27,6 +27,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -69,7 +70,7 @@ public class AnimalHistoryPage<A extends AnimalHistoryPage> extends ParticipantV
     {
         doAndWaitForPageSignal(
             () -> elementCache().updateButton.click(),
-            REPORT_TAB_SIGNAL, new WebDriverWait(getDriver(), 60));
+            REPORT_TAB_SIGNAL, new WebDriverWait(getDriver(), Duration.ofSeconds(60)));
 
         ensureWaitForReports();
 

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -48,6 +48,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -147,7 +148,7 @@ public class EHRTestHelper
         final Locator l = Locator.name(name);
         long secTimeout = msTimeout / 1000;
         secTimeout = secTimeout > 0 ? secTimeout : 1;
-        WebDriverWait wait = new WebDriverWait(test.getDriver(), secTimeout);
+        WebDriverWait wait = new WebDriverWait(test.getDriver(), Duration.ofSeconds(secTimeout));
         try
         {
             return wait.until(new ExpectedCondition<Boolean>()


### PR DESCRIPTION
#### Rationale
Several deprecated `WebDriverWait` constructors were removed in Selenium 4.1.3. Need top stop using them to update Selenium.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1122

#### Changes
* Stop using deprecated `WebDriverWait` constructor
