### PR TITLE
Ticket 45398: Errors cleared incorrectly after Save Draft

### DIFF
--- a/ehr/resources/web/ehr/DataEntryUtils.js
+++ b/ehr/resources/web/ehr/DataEntryUtils.js
@@ -166,7 +166,7 @@ EHR.DataEntryUtils = new function(){
             itemId: 'saveDraftBtn',
             handler: function(btn){
                 var panel = btn.up('ehr-dataentrypanel');
-                panel.onSubmit(btn)
+                panel.onSubmit(btn, false, true);
             },
             disableOn: 'ERROR'
         },

--- a/ehr/resources/web/ehr/panel/DataEntryPanel.js
+++ b/ehr/resources/web/ehr/panel/DataEntryPanel.js
@@ -598,7 +598,7 @@ Ext4.define('EHR.panel.DataEntryPanel', {
         return EHR.DataEntryUtils.hasPermission(qcStateLabel, permissionName, this.formConfig.permissions, null);
     },
 
-    onSubmit: function(btn, ignoreBeforeSubmit){
+    onSubmit: function(btn, ignoreBeforeSubmit, retainErrors){
         if (ignoreBeforeSubmit !== true){
             if (this.onBeforeSubmit(btn) === false)
                 return;
@@ -615,7 +615,7 @@ Ext4.define('EHR.panel.DataEntryPanel', {
         };
 
         //we delay this event so that any modified fields can fire their blur events and/or commit changes
-        Ext4.defer(this.storeCollection.commitChanges, 300, this.storeCollection, [true, extraContext]);
+        Ext4.defer(this.storeCollection.commitChanges, 300, this.storeCollection, [true, extraContext, retainErrors]);
     },
 
     //allows subclasses to provide custom warnings prior to saving


### PR DESCRIPTION
#### Rationale
EHR data entry forms combine browser-side validation (primarily for required fields) and server-side validation (from trigger scripts). The forms have a long-standing behavior of clearing server-side errors immediately after doing a Save Draft. They are restored the next time a user makes a modification which triggers a round trip to the trigger script.

#### Changes
* Conditionalize when the form clears the errors after a save
* Don't clear the errors for the Save Draft scenario