### PR TITLE
Add method on EHRService to expose EHRManager.ensureStudyQCStates

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -311,5 +311,6 @@ abstract public class EHRService
     /** Used to register EHR modules that require the edit url on the grid (with rows having task id values) to navigate to the data entry form **/
     abstract public void addModulePreferringTaskFormEditUI(Module m);
 
+    /** The EHR expects certain QC states to exist. This will inspect the current study and create any missing QC states. **/
     abstract public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges);
 }

--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -310,4 +310,6 @@ abstract public class EHRService
 
     /** Used to register EHR modules that require the edit url on the grid (with rows having task id values) to navigate to the data entry form **/
     abstract public void addModulePreferringTaskFormEditUI(Module m);
+
+    abstract public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges);
 }

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -255,8 +255,7 @@ public class EHRManager
     }
     
     /**
-     * The EHR expects certain properties to be present on all dataset.  This will iterate each dataset, add any
-     * missing columns and make sure the columns point to the correct propertyURI
+     * The EHR expects certain QC states to exist. This will inspect the current study and create any missing QC states.
      */
     public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges)
     {

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -832,6 +832,12 @@ public class EHRServiceImpl extends EHRService
     }
 
     @Override
+    public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges)
+    {
+        return EHRManager.get().ensureStudyQCStates(c, u, commitChanges);
+    }
+
+    @Override
     @NotNull
     public Collection<String> ensureFlagActive(User u, Container c, String flag, Date date, Date enddate, String remark, Collection<String> animalIds, boolean livingAnimalsOnly) throws BatchValidationException
     {


### PR DESCRIPTION
This adds a method on EHRService to expose the pre-existing EHRManager.ensureStudyQCStates() method. It also updates an incorrect pre-existing java doc.