### PR TITLE
Make some labwork functions available in EHRService

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -78,6 +78,12 @@ abstract public class EHRService
 
     abstract public void registerLabworkType(LabworkType type);
 
+    abstract public boolean showLabworkPerformedBy(Container c, @Nullable String type);
+
+    abstract public Map<String, List<String>> getLabworkResults(Container c, User u, String id, Date minDate, Date maxDate, boolean redacted);
+
+    abstract public Collection<LabworkType> getLabworkTypes(Container c);
+
     /**
      * Registers an additional JavaScript trigger script that runs whenever the core EHR's trigger script is initialized,
      * in containers in which the owning module is enabled.

--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -78,6 +78,7 @@ abstract public class EHRService
 
     abstract public void registerLabworkType(LabworkType type);
 
+    /** Labwork functions exposed in API for custom data sources and providers */
     abstract public boolean showLabworkPerformedBy(Container c, @Nullable String type);
 
     abstract public Map<String, List<String>> getLabworkResults(Container c, User u, String id, Date minDate, Date maxDate, boolean redacted);

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -155,6 +155,24 @@ public class EHRServiceImpl extends EHRService
     }
 
     @Override
+    public boolean showLabworkPerformedBy(Container c, @Nullable String type)
+    {
+        return LabworkManager.get().showPerformedBy(c, type);
+    }
+
+    @Override
+    public Map<String, List<String>> getLabworkResults(Container c, User u, String id, Date minDate, Date maxDate, boolean redacted)
+    {
+        return LabworkManager.get().getResults(c, u, id, minDate, maxDate, redacted);
+    }
+
+    @Override
+    public Collection<LabworkType> getLabworkTypes(Container c)
+    {
+        return LabworkManager.get().getTypes(c);
+    }
+
+    @Override
     public List<Resource> getExtraTriggerScripts(Container c)
     {
         List<Resource> resources = new ArrayList<>();

--- a/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
@@ -24,6 +24,7 @@ import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.history.HistoryRow;
 import org.labkey.api.ehr.history.AbstractDataSource;
 import org.labkey.api.module.Module;
@@ -63,7 +64,7 @@ public class DefaultLabworkDataSource extends AbstractDataSource
     {
         StringBuilder sb = new StringBuilder();
 
-        if (!redacted && LabworkManager.get().showPerformedBy(c, rs.hasColumn(FieldKey.fromString("type")) ? rs.getString("type") : null))
+        if (!redacted && EHRService.get().showLabworkPerformedBy(c, rs.hasColumn(FieldKey.fromString("type")) ? rs.getString("type") : null))
         {
             sb.append(safeAppend(rs, "Performed By", "performedby"));
             //Modified 10-13-2017 Blasa
@@ -119,7 +120,7 @@ public class DefaultLabworkDataSource extends AbstractDataSource
     {
         Date start = new Date();
 
-        _results = LabworkManager.get().getResults(c, u, subjectId, minDate, maxDate, redacted);
+        _results = EHRService.get().getLabworkResults(c, u, subjectId, minDate, maxDate, redacted);
 
         long duration = ((new Date()).getTime() - start.getTime()) / 1000;
         if (duration > 6)
@@ -191,7 +192,7 @@ public class DefaultLabworkDataSource extends AbstractDataSource
     {
         Set<String> types = new HashSet<>();
         types.add("Labwork");
-        for (LabworkType type : LabworkManager.get().getTypes(c))
+        for (LabworkType type : EHRService.get().getLabworkTypes(c))
         {
             types.add(type.getName());
         }


### PR DESCRIPTION
#### Rationale
To allow creating custom LabworkDataSource in PRC modules, expose some common Labwork functions in EHRService.

#### Changes
* Make labwork results, types and showPerformedBy available in EHRService 
