### PR TITLE
EHR Sample Manager Module

### DIFF
--- a/EHR_SM/build.gradle
+++ b/EHR_SM/build.gradle
@@ -1,0 +1,9 @@
+import org.labkey.gradle.util.BuildUtils;
+
+plugins {
+    id 'org.labkey.build.module'
+}
+
+dependencies {
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
+}

--- a/EHR_SM/module.properties
+++ b/EHR_SM/module.properties
@@ -1,0 +1,5 @@
+ModuleClass: org.labkey.ehr_sm.EHR_SMModule
+Label: EHR customization of Sample Manager
+Description: Adds additional EHR related data to Sample Manager. Provides ETL for Animal sources.
+License: Apache 2.0
+LicenseURL: http://www.apache.org/licenses/LICENSE-2.0

--- a/EHR_SM/resources/etls/animal.xml
+++ b/EHR_SM/resources/etls/animal.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<etl xmlns="http://labkey.org/etl/xml">
+    <name>Animal</name>
+    <description>Animal Source Data</description>
+    <transforms>
+        <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
+            <description>Copy Animal Data to Animal Source</description>
+            <!-- For source, update folderPath to the folder path of your EHR folder using dot notation. queryName can be
+            demographics or another query if you want to copy in a subset of animals -->
+            <source schemaName="Site.SNPRC.study" queryName="demographics">
+                <sourceColumns>
+                    <column>Id</column>
+                </sourceColumns>
+            </source>
+            <destination schemaName="exp.data" queryName="Animal" targetOption="merge" />
+        </transform>
+    </transforms>
+    <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
+        <!-- For deletedRowsSource, update folderPath to the folder path of your EHR folder using dot notation.
+         DemographicsDeleted is a query in the EHR to indicate when an animal record has been deleted using audit logs -->
+        <deletedRowsSource schemaName="Site.SNPRC.auditLog" queryName="DemographicsDeleted" timestampColumnName="Date" deletedSourceKeyColumnName="Id" targetKeyColumnName="Id"/>
+    </incrementalFilter>
+    <schedule>
+        <poll interval="1d"/>
+    </schedule>
+</etl>

--- a/EHR_SM/resources/etls/animal_template.xml
+++ b/EHR_SM/resources/etls/animal_template.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <etl xmlns="http://labkey.org/etl/xml">
-    <name>Animal</name>
-    <description>Animal Source Data</description>
+    <!-- Change my name -->
+    <name>Animal Template</name>
+    <description>Animal Id ETL Template (see documentation)</description>
     <transforms>
         <transform id="step1" type="org.labkey.di.pipeline.TransformTask">
             <description>Copy Animal Data to Animal Source</description>
             <!-- For source, update folderPath to the folder path of your EHR folder using dot notation. queryName can be
             demographics or another query if you want to copy in a subset of animals -->
-            <source schemaName="Site.SNPRC.study" queryName="demographics">
+            <source schemaName="Site.folderPath.study" queryName="demographics">
                 <sourceColumns>
                     <column>Id</column>
                 </sourceColumns>
@@ -18,7 +19,7 @@
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
         <!-- For deletedRowsSource, update folderPath to the folder path of your EHR folder using dot notation.
          DemographicsDeleted is a query in the EHR to indicate when an animal record has been deleted using audit logs -->
-        <deletedRowsSource schemaName="Site.SNPRC.auditLog" queryName="DemographicsDeleted" timestampColumnName="Date" deletedSourceKeyColumnName="Id" targetKeyColumnName="Id"/>
+        <deletedRowsSource schemaName="Site.folderPath.auditLog" queryName="DemographicsDeleted" timestampColumnName="Date" deletedSourceKeyColumnName="Id" targetKeyColumnName="Id"/>
     </incrementalFilter>
     <schedule>
         <poll interval="1d"/>

--- a/EHR_SM/resources/queries/exp/data/Animal.query.xml
+++ b/EHR_SM/resources/queries/exp/data/Animal.query.xml
@@ -1,0 +1,9 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="Animal" tableDbType="TABLE" useColumnOrder="true">
+                <javaCustomizer class="org.labkey.ehr_sm.EHR_SMCustomizer" />
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
+++ b/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
@@ -1,0 +1,14 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" canOverride="true">
+    <columns>
+        <column name="name"/>
+        <column name="Id"/>
+        <column name="Id/Demographics/gender"/>
+        <column name="Id/Demographics/species"/>
+        <column name="Id/Demographics/calculated_status"/>
+        <column name="Id/age/age_friendly"/>
+        <column name="Id/MostRecentWeight/MostRecentWeight"/>
+        <column name="Id/MostRecentWeight/MostRecentWeightDate"/>
+        <column name="Id/curLocation/room"/>
+        <column name="Id/curLocation/cage"/>
+    </columns>
+</customView>

--- a/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
+++ b/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
@@ -5,10 +5,11 @@
         <column name="Id/Demographics/gender"/>
         <column name="Id/Demographics/species"/>
         <column name="Id/Demographics/calculated_status"/>
-        <column name="Id/age/age_friendly"/>
+        <column name="Id/age/ageFriendly"/>
+        <column name="Id/Demographics/birth"/>
+        <column name="Id/Demographics/death"/>
+        <column name="Id/Flags/flags"/>
         <column name="Id/MostRecentWeight/MostRecentWeight"/>
         <column name="Id/MostRecentWeight/MostRecentWeightDate"/>
-        <column name="Id/curLocation/room"/>
-        <column name="Id/curLocation/cage"/>
     </columns>
 </customView>

--- a/EHR_SM/resources/queries/exp/data/Animal/~~DETAILS~~.qview.xml
+++ b/EHR_SM/resources/queries/exp/data/Animal/~~DETAILS~~.qview.xml
@@ -1,0 +1,16 @@
+<customView xmlns="http://labkey.org/data/xml/queryCustomView" canOverride="true">
+    <columns>
+        <column name="name"/>
+        <column name="Id"/>
+        <column name="Id/Demographics/gender"/>
+        <column name="Id/Demographics/species"/>
+        <column name="Id/Demographics/calculated_status"/>
+        <column name="Id/age/age_friendly"/>
+        <column name="Id/Demographics/birth"/>
+        <column name="Id/Demographics/death"/>
+        <column name="Id/MostRecentWeight/MostRecentWeight"/>
+        <column name="Id/MostRecentWeight/MostRecentWeightDate"/>
+        <column name="Id/curLocation/room"/>
+        <column name="Id/curLocation/cage"/>
+    </columns>
+</customView>

--- a/EHR_SM/resources/queries/exp/data/Animal/~~DETAILS~~.qview.xml
+++ b/EHR_SM/resources/queries/exp/data/Animal/~~DETAILS~~.qview.xml
@@ -5,12 +5,11 @@
         <column name="Id/Demographics/gender"/>
         <column name="Id/Demographics/species"/>
         <column name="Id/Demographics/calculated_status"/>
-        <column name="Id/age/age_friendly"/>
+        <column name="Id/age/ageFriendly"/>
         <column name="Id/Demographics/birth"/>
         <column name="Id/Demographics/death"/>
+        <column name="Id/Flags/flags"/>
         <column name="Id/MostRecentWeight/MostRecentWeight"/>
         <column name="Id/MostRecentWeight/MostRecentWeightDate"/>
-        <column name="Id/curLocation/room"/>
-        <column name="Id/curLocation/cage"/>
     </columns>
 </customView>

--- a/EHR_SM/resources/queries/samples/AllSampleTypes.query.xml
+++ b/EHR_SM/resources/queries/samples/AllSampleTypes.query.xml
@@ -1,0 +1,10 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="AllSampleTypes" tableDbType="TABLE" useColumnOrder="true">
+                <insertUrl></insertUrl>
+                <javaCustomizer class="org.labkey.ehr_sm.EHR_SMCustomizer  " />
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/EHR_SM/resources/queries/samples/AllSampleTypes.query.xml
+++ b/EHR_SM/resources/queries/samples/AllSampleTypes.query.xml
@@ -3,7 +3,7 @@
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="AllSampleTypes" tableDbType="TABLE" useColumnOrder="true">
                 <insertUrl></insertUrl>
-                <javaCustomizer class="org.labkey.ehr_sm.EHR_SMCustomizer  " />
+                <javaCustomizer class="org.labkey.ehr_sm.EHR_SMCustomizer" />
             </table>
         </tables>
     </metadata>

--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMContainerListener.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMContainerListener.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.ehr_sm;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager.ContainerListener;
+import org.labkey.api.data.PropertyManager;
+import org.labkey.api.security.User;
+import java.util.Collections;
+import java.util.Collection;
+
+import java.beans.PropertyChangeEvent;
+
+public class EHR_SMContainerListener implements ContainerListener
+{
+    @Override
+    public void containerCreated(Container c, User user)
+    {
+    }
+
+    @Override
+    public void containerDeleted(Container c, User user)
+    {
+        PropertyManager.purgeObjectProperties(c);
+    }
+
+    @Override
+    public void propertyChange(PropertyChangeEvent evt)
+    {
+    }
+
+    @Override
+    public void containerMoved(Container c, Container oldParent, User user)
+    {
+    }
+
+    @NotNull @Override
+    public Collection<String> canMove(Container c, Container newParent, User user)
+    {
+        return Collections.emptyList();
+    }
+}

--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMController.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMController.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.ehr_sm;
+
+import org.labkey.api.action.FormViewAction;
+import org.labkey.api.action.SimpleViewAction;
+import org.labkey.api.action.SpringActionController;
+import org.labkey.api.data.PropertyManager;
+import org.labkey.api.exp.api.ExpSampleType;
+import org.labkey.api.exp.api.SampleTypeService;
+import org.labkey.api.security.RequiresPermission;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.api.security.permissions.ReadPermission;
+import org.labkey.api.util.URLHelper;
+import org.labkey.api.view.ActionURL;
+import org.labkey.api.view.JspView;
+import org.labkey.api.view.NavTree;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+import org.springframework.web.servlet.ModelAndView;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class EHR_SMController extends SpringActionController
+{
+    private static final DefaultActionResolver _actionResolver = new DefaultActionResolver(EHR_SMController.class);
+    public static final String NAME = "ehr_sm";
+
+    public EHR_SMController()
+    {
+        setActionResolver(_actionResolver);
+    }
+
+    @RequiresPermission(ReadPermission.class)
+    public class BeginAction extends SimpleViewAction
+    {
+        public ModelAndView getView(Object o, BindException errors)
+        {
+            JspView<Void> view = new JspView<>("/org/labkey/ehr_sm/view/hello.jsp");
+            view.setTitle("EHR Sample Manager");
+            return view;
+        }
+
+        public void addNavTrail(NavTree root) { }
+    }
+
+    public static class AdminForm
+    {
+        private String sampleReceivedCol;
+        private List<? extends ExpSampleType> animalSampleTypes;
+        private String[] selectedAnimalSampleTypes;
+
+        public String getSampleReceivedCol()
+        {
+            return sampleReceivedCol;
+        }
+
+        public void setSampleReceivedCol(String sampleReceivedCol)
+        {
+            this.sampleReceivedCol = sampleReceivedCol;
+        }
+
+        public List<? extends ExpSampleType> getAnimalSampleTypes()
+        {
+            return animalSampleTypes;
+        }
+
+        public void setAnimalSampleTypes(List<? extends ExpSampleType> animalSampleTypes)
+        {
+            this.animalSampleTypes = animalSampleTypes;
+        }
+
+        public String[] getSelectedAnimalSampleTypes()
+        {
+            return selectedAnimalSampleTypes;
+        }
+
+        public void setSelectedAnimalSampleTypes(String[] selectedAnimalSampleTypes)
+        {
+            this.selectedAnimalSampleTypes = selectedAnimalSampleTypes;
+        }
+    }
+
+    @RequiresPermission(AdminPermission.class)
+    public class AdminAction extends FormViewAction<AdminForm>
+    {
+        public void addNavTrail(NavTree root) { }
+
+        @Override
+        public void validateCommand(AdminForm target, Errors errors)
+        {
+
+        }
+
+        @Override
+        public ModelAndView getView(AdminForm adminForm, boolean reshow, BindException errors) throws Exception
+        {
+            PropertyManager.PropertyMap props = PropertyManager.getProperties(getContainer(), EHR_SMManager.ANIMAL_SAMPLE_PROP_SET_NAME);
+            adminForm.setSelectedAnimalSampleTypes(props.keySet().toArray(new String[0]));
+            adminForm.setAnimalSampleTypes(SampleTypeService.get().getSampleTypes(getContainer(), getUser(), false));
+            adminForm.setSampleReceivedCol(props.get(EHR_SMManager.ANIMAL_SAMPLE_RECEIVED_PROP));
+
+            JspView<AdminForm> view = new JspView<>("/org/labkey/ehr_sm/view/admin.jsp", adminForm, errors);
+            view.setTitle("EHR Sample Manager Admin");
+
+            return view;
+        }
+
+        @Override
+        public boolean handlePost(AdminForm adminForm, BindException errors)
+        {
+            PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(getContainer(), EHR_SMManager.ANIMAL_SAMPLE_PROP_SET_NAME, true);
+            for (ExpSampleType animalSampleType : SampleTypeService.get().getSampleTypes(getContainer(), getUser(), false))
+            {
+                if (Arrays.stream(adminForm.getSelectedAnimalSampleTypes()).anyMatch(s -> s.equals(animalSampleType.getName())))
+                {
+                    props.put(animalSampleType.getName(), "true");
+                }
+                else
+                {
+                    props.remove(animalSampleType.getName());
+                }
+            }
+            props.put(EHR_SMManager.ANIMAL_SAMPLE_RECEIVED_PROP, adminForm.getSampleReceivedCol());
+            props.save();
+
+            return true;
+        }
+
+        @Override
+        public URLHelper getSuccessURL(AdminForm adminForm)
+        {
+            return new ActionURL(BeginAction.class, getContainer());
+        }
+    }
+}

--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMCustomizer.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMCustomizer.java
@@ -1,0 +1,195 @@
+package org.labkey.ehr_sm;
+
+import org.labkey.api.data.AbstractTableInfo;
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.ContainerService;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.JdbcType;
+import org.labkey.api.data.MutableColumnInfo;
+import org.labkey.api.data.PropertyManager;
+import org.labkey.api.data.SQLFragment;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.ldk.table.AbstractTableCustomizer;
+import org.labkey.api.module.Module;
+import org.labkey.api.module.ModuleLoader;
+import org.labkey.api.module.ModuleProperty;
+import org.labkey.api.query.AliasedColumn;
+import org.labkey.api.query.ExprColumn;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.QueryForeignKey;
+import org.labkey.api.query.QueryService;
+import org.labkey.api.query.UserSchema;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class EHR_SMCustomizer extends AbstractTableCustomizer
+{
+    @Override
+    public void customize(TableInfo tableInfo)
+    {
+        if (tableInfo instanceof AbstractTableInfo && "Animal".equalsIgnoreCase(tableInfo.getName()))
+        {
+            customizeAnimal((AbstractTableInfo) tableInfo);
+            return;
+        }
+
+        UserSchema us = tableInfo.getUserSchema();
+        if (null != us)
+        {
+            PropertyManager.PropertyMap props = PropertyManager.getProperties(us.getContainer(), EHR_SMManager.ANIMAL_SAMPLE_PROP_SET_NAME);
+
+            if (tableInfo instanceof AbstractTableInfo && props.containsKey(tableInfo.getName()))
+            {
+                customizeSamples((AbstractTableInfo) tableInfo);
+                return;
+            }
+        }
+    }
+
+    private SQLFragment getAgeSql(TableInfo demographics, String alias, ColumnInfo idCol, ColumnInfo receivedCol)
+    {
+        SQLFragment ageSql = null;
+        if (demographics.getSqlDialect().isSqlServer())
+        {
+            ageSql = new SQLFragment("(SELECT CONVERT(DECIMAL(10,2), DATEDIFF(month, dem.birth, ").append(receivedCol.getValueSql(alias));
+            ageSql.append(") / 12.0) as ageAtSample FROM ").append(demographics, "dem");
+            ageSql.append(" WHERE dem.ParticipantId = ").append(idCol.getValueSql(alias)).append(")");
+        }
+        else if (demographics.getSqlDialect().isPostgreSQL())
+        {
+            ageSql = new SQLFragment("(SELECT ROUND(CAST((EXTRACT(YEAR FROM age) + EXTRACT(MONTH FROM age) / 12) AS NUMERIC), 2) AS ageAtSample ");
+            ageSql.append("FROM age(").append(receivedCol.getValueSql(alias)).append(", ");
+            ageSql.append("(SELECT dem.birth FROM ").append(demographics, "dem");
+            ageSql.append(" WHERE dem.ParticipantId = ").append(idCol.getValueSql(alias)).append(")) AS t(age))");
+        }
+
+        return ageSql;
+    }
+
+    private void customizeSamples(AbstractTableInfo ti)
+    {
+        String ehrContainerName = getEHRContainer(Objects.requireNonNull(ti.getUserSchema()).getContainer());
+        if (null == ehrContainerName)
+            return;
+
+        FieldKey idFk = FieldKey.fromParts("Ancestors", "RegistryAndSources", "Animal", "Id");
+        ColumnInfo idCol = QueryService.get().getColumns(ti, Arrays.asList(idFk)).get(idFk);
+
+        if (null != idCol)
+        {
+            // Add to default columns
+            List<FieldKey> defaultCols = new ArrayList<>(ti.getDefaultVisibleColumns());
+
+            FieldKey animalRecordFk = FieldKey.fromParts("AnimalRecord");
+            var aliasCol = new AliasedColumn(idCol.getParentTable(), animalRecordFk, idCol, false);
+            aliasCol.setShownInInsertView(false);
+            aliasCol.setShownInUpdateView(false);
+
+            defaultCols.add(animalRecordFk);
+            defaultCols.add(FieldKey.fromParts("AnimalRecord", "Demographics", "Species"));
+            defaultCols.add(FieldKey.fromParts("AnimalRecord", "Demographics", "Gender"));
+            ti.setDefaultVisibleColumns(defaultCols);
+            ti.addColumn(aliasCol);
+
+            // Get received sample date column for age at sample time calculation. Default to created if not set
+            PropertyManager.PropertyMap props = PropertyManager.getProperties(ti.getUserSchema().getContainer(), EHR_SMManager.ANIMAL_SAMPLE_PROP_SET_NAME);
+            String receivedDateCol = props.get(EHR_SMManager.ANIMAL_SAMPLE_RECEIVED_PROP);
+            if (null == receivedDateCol)
+                receivedDateCol = "Created";
+
+            ColumnInfo receivedCol = ti.getColumn(receivedDateCol);
+            if (null == receivedCol)
+                _log.warn("Sample type " + ti.getName() + " does not have column " + receivedDateCol + " for age at sample calculation.");
+
+            TableInfo demographics = QueryService.get().getUserSchema(ti.getUserSchema().getUser(), ContainerService.get().getForPath(ehrContainerName), "study").getTable("demographics");
+
+            // Age at sample time column
+            if (null != receivedCol && null != demographics)
+            {
+                SQLFragment ageSql = getAgeSql(demographics, ti.getName(), idCol, receivedCol);
+                if (null != ageSql)
+                {
+                    FieldKey ageFk = FieldKey.fromParts("ageAtSample");
+                    defaultCols.add(ageFk);
+                    ExprColumn ageAtSampleCol = new ExprColumn(ti, ageFk, ageSql, JdbcType.DECIMAL, idCol, receivedCol);
+                    ageAtSampleCol.setLabel("Age At Sample (yrs)");
+
+                    // Need this display column factory just to ensure the "received column" is available in the underlying
+                    // samples query if it is not in the displayed view
+                    ageAtSampleCol.setDisplayColumnFactory(new DisplayColumnFactory()
+                    {
+                        @Override
+                        public DisplayColumn createRenderer(ColumnInfo colInfo)
+                        {
+                            return new DataColumn(colInfo)
+                            {
+                                @Override
+                                public void addQueryFieldKeys(Set<FieldKey> keys)
+                                {
+                                    super.addQueryFieldKeys(keys);
+                                    keys.add(receivedCol.getFieldKey());
+                                }
+                            };
+                        }
+                    });
+                    ti.addColumn(ageAtSampleCol);
+                }
+            }
+        }
+    }
+
+    private String getEHRContainer(Container c)
+    {
+        Module ehr = ModuleLoader.getInstance().getModule("ehr");
+        ModuleProperty mp = ehr.getModuleProperties().get("EHRStudyContainer");
+        if (mp == null || mp.getEffectiveValue(c) == null)
+        {
+            _log.warn("Attempted to access EHR containerPath Module Property, which has not been set for the root container", new Exception());
+            return null;
+        }
+
+        return mp.getEffectiveValue(c);
+    }
+
+    private void customizeAnimal(AbstractTableInfo ti)
+    {
+        MutableColumnInfo idCol = (MutableColumnInfo) ti.getColumn("Id");
+        if (null != idCol)
+        {
+            // Prevent manually entering values that will be ETLed in instead. There might be nothing wrong
+            // with manually entering values and having ETL merge on Id, but cross container fk is not resolving so just
+            // don't allow for now.
+            idCol.setRequired(true);
+            idCol.setShownInUpdateView(false);
+            idCol.setShownInInsertView(false);
+
+            UserSchema us = ti.getUserSchema();
+            if (null != us)
+            {
+                String ehrContainerName = getEHRContainer(us.getContainer());
+                if (null != ehrContainerName)
+                {
+                    Container ehrContainer = ContainerService.get().getForPath(ehrContainerName);
+                    if (null != ehrContainer)
+                    {
+                        ContainerFilter ehrCF = new ContainerFilter.SimpleContainerFilterWithUser(ti.getUserSchema().getUser(), ehrContainer);
+                        TableInfo animalTi = QueryService.get().getUserSchema(ti.getUserSchema().getUser(), ehrContainer, "study").getTable("Animal", ehrCF);
+                        idCol.setFk(new QueryForeignKey(animalTi, "Id", "Id"));
+                    }
+                }
+                else
+                {
+                    _log.warn("EHR container not found for sample animal Id lookup.");
+                }
+            }
+        }
+    }
+}

--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMManager.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMManager.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.ehr_sm;
+
+public class EHR_SMManager
+{
+    private static final EHR_SMManager _instance = new EHR_SMManager();
+
+    public static final String ANIMAL_SAMPLE_PROP_SET_NAME = "AnimalSamplePropSet";
+    public static final String ANIMAL_SAMPLE_RECEIVED_PROP = "sampleReceivedCol";
+
+    private EHR_SMManager()
+    {
+        // prevent external construction with a private default constructor
+    }
+
+    public static EHR_SMManager get()
+    {
+        return _instance;
+    }
+}

--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMModule.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMModule.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.ehr_sm;
+
+import org.jetbrains.annotations.NotNull;
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerManager;
+import org.labkey.api.module.CodeOnlyModule;
+import org.labkey.api.module.ModuleContext;
+import org.labkey.api.view.WebPartFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class EHR_SMModule extends CodeOnlyModule
+{
+    public static final String NAME = "EHR_SM";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    @NotNull
+    protected Collection<WebPartFactory> createWebPartFactories()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected void init()
+    {
+        addController(EHR_SMController.NAME, EHR_SMController.class);
+    }
+
+    @Override
+    public void doStartup(ModuleContext moduleContext)
+    {
+        // add a container listener so we'll know when our container is deleted:
+        ContainerManager.addContainerListener(new EHR_SMContainerListener());
+    }
+
+    @Override
+    @NotNull
+    public Collection<String> getSummary(Container c)
+    {
+        return Collections.emptyList();
+    }
+}

--- a/EHR_SM/src/org/labkey/ehr_sm/view/admin.jsp
+++ b/EHR_SM/src/org/labkey/ehr_sm/view/admin.jsp
@@ -1,0 +1,78 @@
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
+<%
+    /*
+     * Copyright (c) 2022 LabKey Corporation
+     *
+     * Licensed under the Apache License, Version 2.0 (the "License");
+     * you may not use this file except in compliance with the License.
+     * You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+%>
+<%@ page import="org.labkey.api.data.Container" %>
+<%@ page import="org.labkey.api.exp.api.ExpSampleType" %>
+<%@ page import="org.labkey.api.security.User" %>
+<%@ page import="org.labkey.api.util.HtmlString" %>
+<%@ page import="org.labkey.api.view.HttpView" %>
+<%@ page import="org.labkey.api.view.JspView" %>
+<%@ page import="org.labkey.ehr_sm.EHR_SMController" %>
+<%@ page import="static java.util.Arrays.stream" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%
+    JspView<EHR_SMController.AdminForm> me = (JspView<EHR_SMController.AdminForm>) HttpView.currentView();
+    EHR_SMController.AdminForm form = me.getModelBean();
+    Container c = getContainer();
+    User user = getUser();
+%>
+
+<labkey:errors/>
+<labkey:form method="POST">
+    <div style="font-weight: bold; margin-bottom: 1em; margin-top: 1em;">
+        Sample Received Column
+        <%=helpPopup("Sample Received Date Column", "Used for calculation of columns like age at sample time. Must be a date column.")%>
+    </div>
+    <input
+            style="width:300px; margin-bottom: 2em;"
+            type="text"
+            id="sampleReceivedCol"
+            name="sampleReceivedCol"
+            value=<%=form.getSampleReceivedCol() != null ? h(form.getSampleReceivedCol()) : h("Created")%>
+    />
+    <div style="font-weight: bold; margin-bottom: 1em;">
+        Animal Sample Types
+        <%=helpPopup("Sample Types", "Sample types to include animal data. Must use Animal source.")%>
+    </div>
+    <table class="lk-fields-table">
+        <%
+            for (ExpSampleType animalSampleType : form.getAnimalSampleTypes())
+            {
+                HtmlString typeName = h(animalSampleType.getName());
+                boolean isSelected = stream(form.getSelectedAnimalSampleTypes()).anyMatch(s -> s.equals(typeName.toString()));
+        %>
+                <tr>
+                    <td nowrap>
+                        <div style="margin-bottom: 1em;">
+                            <labkey:checkbox
+                                    id="<%=typeName.toString()%>"
+                                    name="selectedAnimalSampleTypes"
+                                    value="<%=typeName.toString()%>"
+                                    checked="<%=isSelected%>"
+                            />
+                            <label for=<%=typeName%>><%=typeName%></label>
+                        </div>
+                    </td>
+                </tr>
+        <%
+            }
+        %>
+    </table>
+    <input style="margin-top: 1em;" type="submit" value="Save">
+</labkey:form>

--- a/EHR_SM/src/org/labkey/ehr_sm/view/hello.jsp
+++ b/EHR_SM/src/org/labkey/ehr_sm/view/hello.jsp
@@ -1,0 +1,36 @@
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
+<%
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+%>
+<%@ page import="org.labkey.api.data.Container" %>
+<%@ page import="org.labkey.api.security.User" %>
+<%@ page import="org.labkey.api.view.ActionURL" %>
+<%@ page import="org.labkey.ehr_sm.EHR_SMController" %>
+<%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
+<%@ page extends="org.labkey.api.jsp.JspBase" %>
+<%
+    Container c = getContainer();
+    User user = getUser();
+%>
+<div name="helloMessage">Hello, and welcome to the EHR Sample Manager module. Please see <a>documentation</a> for setup and description of the module.</div>
+<br>
+<a href="<%=h(new ActionURL("sampleManager", "app", getContainer()))%>">Go To Sample Manager</a>
+<br>
+<% if(c.hasPermission(user, AdminPermission.class)) {%>
+    <br>
+    <a href="<%=h(new ActionURL(EHR_SMController.AdminAction.class, getContainer()))%>">Admin Page</a>
+<% } %>

--- a/EHR_SM/src/org/labkey/ehr_sm/view/hello.jsp
+++ b/EHR_SM/src/org/labkey/ehr_sm/view/hello.jsp
@@ -18,15 +18,18 @@
 %>
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.security.User" %>
+<%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
+<%@ page import="org.labkey.api.util.HelpTopic" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.ehr_sm.EHR_SMController" %>
-<%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     Container c = getContainer();
     User user = getUser();
+    String href = new HelpTopic("ehrSamples").getHelpTopicHref();
 %>
-<div name="helloMessage">Hello, and welcome to the EHR Sample Manager module. Please see <a>documentation</a> for setup and description of the module.</div>
+
+<div name="helloMessage">Hello, and welcome to the EHR Sample Manager module. Please see <a href="<%=h(href)%>" target="_blank">documentation</a> for setup and description of the module.</div>
 <br>
 <a href="<%=h(new ActionURL("sampleManager", "app", getContainer()))%>">Go To Sample Manager</a>
 <br>

--- a/EHR_SM/test/src/org/labkey/test/pages/ehr_sm/BeginPage.java
+++ b/EHR_SM/test/src/org/labkey/test/pages/ehr_sm/BeginPage.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.test.pages.ehr_sm;
+
+import org.labkey.test.Locator;
+import org.labkey.test.WebDriverWrapper;
+import org.labkey.test.WebTestHelper;
+import org.labkey.test.pages.LabKeyPage;
+import org.openqa.selenium.WebElement;
+
+public class BeginPage extends LabKeyPage<BeginPage.ElementCache>
+{
+    public BeginPage(WebDriverWrapper driver)
+    {
+        super(driver);
+    }
+
+    public static BeginPage beginAt(WebDriverWrapper driver)
+    {
+        return beginAt(driver, driver.getCurrentContainerPath());
+    }
+
+    public static BeginPage beginAt(WebDriverWrapper driver, String containerPath)
+    {
+        driver.beginAt(WebTestHelper.buildURL("ehr_sm", containerPath, "begin"));
+        return new BeginPage(driver);
+    }
+
+    public String getHelloMessage()
+    {
+        return elementCache().helloMessage.getText();
+    }
+
+    @Override
+    protected ElementCache newElementCache()
+    {
+        return new ElementCache();
+    }
+
+    protected class ElementCache extends LabKeyPage.ElementCache
+    {
+        protected final WebElement helloMessage = Locator.tagWithName("div", "helloMessage").findWhenNeeded(this);
+    }
+}

--- a/EHR_SM/test/src/org/labkey/test/tests/ehr_sm/EHR_SMTest.java
+++ b/EHR_SM/test/src/org/labkey/test/tests/ehr_sm/EHR_SMTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.labkey.test.tests.ehr_sm;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.BaseWebDriverTest;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.categories.InDevelopment;
+import org.labkey.test.pages.ehr_sm.BeginPage;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@Category({InDevelopment.class})
+public class EHR_SMTest extends BaseWebDriverTest
+{
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        _containerHelper.deleteProject(getProjectName(), afterTest);
+    }
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        EHR_SMTest init = (EHR_SMTest)getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(getProjectName(), null);
+    }
+
+    @Before
+    public void preTest()
+    {
+        goToProjectHome();
+    }
+
+    @Test
+    public void testEHR_SMModule()
+    {
+        _containerHelper.enableModule("EHR_SM");
+        BeginPage beginPage = BeginPage.beginAt(this, getProjectName());
+        assertEquals(200, getResponseCode());
+        final String expectedHello = "Hello, and welcome to the EHR Sample Manager module. Please see documentation for setup and description of the module.";
+        assertEquals("Wrong hello message", expectedHello, beginPage.getHelloMessage());
+    }
+
+    @Override
+    protected BrowserType bestBrowser()
+    {
+        return BrowserType.CHROME;
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "EHR_SMTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Collections.singletonList("EHR_SM");
+    }
+}

--- a/ehr/resources/queries/auditLog/DemographicsDeleted.sql
+++ b/ehr/resources/queries/auditLog/DemographicsDeleted.sql
@@ -1,6 +1,6 @@
 SELECT
     Date,
-    substring(DataChanges, IdStart, LOCATE('&', DataChanges, LOCATE('&Id=', DataChanges) + 1) - IdStart) as Id
+    substring(DataChanges, IdStart, CAST(LOCATE('&', DataChanges, LOCATE('&Id=', DataChanges) + 1) - IdStart AS INTEGER)) as Id
 FROM (
     SELECT Date,
     DataChanges,

--- a/ehr/resources/queries/auditLog/DemographicsDeleted.sql
+++ b/ehr/resources/queries/auditLog/DemographicsDeleted.sql
@@ -1,0 +1,10 @@
+SELECT
+    Date,
+    substring(DataChanges, IdStart, LOCATE('&', DataChanges, LOCATE('&Id=', DataChanges) + 1) - IdStart) as Id
+FROM (
+    SELECT Date,
+    DataChanges,
+    LOCATE('&Id=', DataChanges) + LENGTH('&Id=') as IdStart
+    FROM DatasetAuditEvent
+    WHERE DatasetId.Name = 'demographics' AND Comment = 'A dataset record was deleted'
+    )

--- a/ehr/resources/queries/study/sampleAgeInYears.sql
+++ b/ehr/resources/queries/study/sampleAgeInYears.sql
@@ -1,0 +1,7 @@
+
+PARAMETERS(sampleDate TIMESTAMP)
+
+SELECT
+    d.id,
+    ROUND(CONVERT(age_in_months(d.birth, COALESCE(d.lastDayAtCenter, now())), DOUBLE) / 12, 1) AS atSample
+FROM study.Demographics d


### PR DESCRIPTION
#### Rationale
This can be enabled within a Sample Manager project on a server with an EHR project to apply EHR metadata to an Animal Source within Sample Manager. The animal source will provide the user with the full animal record from the EHR project.  Allows aligning animal source data with sample data in Sample Manager.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3754

#### Changes
* Create EHR_SM module
* Animal ETL to populate and maintain the list of animal Ids in the animal source
* Java customizer to setup Animal Source metadata to link to and pull in data from EHR Animal Record
* Java customizer to add Animal Record as a top level field for animal samples
* Age at sample time column to calculate animal age when sample was taken
* Admin page to select which sample types are from animal sources and which sample "received" column to use for animal age calculation
