### PR TITLE
Task form assignedTo field options filtered to groups and active users

### DIFF
--- a/ehr/resources/queries/core/PrincipalsWithoutAdmin.sql
+++ b/ehr/resources/queries/core/PrincipalsWithoutAdmin.sql
@@ -19,7 +19,8 @@ SELECT
   u.DisplayName,
   'u' as Type,
   u.FirstName,
-  u.LastName
+  u.LastName,
+  u.Active
 
 FROM core.Users u
 WHERE u.userid > 0
@@ -31,6 +32,7 @@ SELECT
   g.Name as DisplayName,
   'g' as Type,
   null as FirstName,
-  null as LastName
+  null as LastName,
+  true as Active
 FROM core.groups g
 WHERE g.userid > 0

--- a/ehr/resources/web/ehr/form/field/UsersAndGroupsCombo.js
+++ b/ehr/resources/web/ehr/form/field/UsersAndGroupsCombo.js
@@ -20,7 +20,8 @@ Ext4.define('EHR.form.field.UsersAndGroupsCombo', {
                 queryName: 'PrincipalsWithoutAdmin',
                 columns: 'UserId,DisplayName,FirstName,LastName',
                 sort: 'Type,DisplayName',
-                autoLoad: true
+                autoLoad: true,
+                filterArray: [LABKEY.Filter.create('Active', 'true')]
             },
             anyMatch: true,
             caseSensitive: false,


### PR DESCRIPTION
#### Rationale
Task forms assignedTo field currently displays groups and all users in the select options. This PR filters those options to groups and ACTIVE users.  This will not affect how the assignedTo field resolves in the tasks table.

#### Changes
* Include Active field in PrincipalsWithoutAdmin
* Update UsersAndGroupsCombo to filter on Active users
