### PR TITLE
Fix documentation link on EHR_SM portal

### DIFF
--- a/EHR_SM/src/org/labkey/ehr_sm/view/hello.jsp
+++ b/EHR_SM/src/org/labkey/ehr_sm/view/hello.jsp
@@ -19,17 +19,15 @@
 <%@ page import="org.labkey.api.data.Container" %>
 <%@ page import="org.labkey.api.security.User" %>
 <%@ page import="org.labkey.api.security.permissions.AdminPermission" %>
-<%@ page import="org.labkey.api.util.HelpTopic" %>
 <%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.ehr_sm.EHR_SMController" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     Container c = getContainer();
     User user = getUser();
-    String href = new HelpTopic("ehrSamples").getHelpTopicHref();
 %>
 
-<div name="helloMessage">Hello, and welcome to the EHR Sample Manager module. Please see <a href="<%=h(href)%>" target="_blank">documentation</a> for setup and description of the module.</div>
+<div data-name="helloMessage">Hello, and welcome to the EHR Sample Manager module. Please see <%=helpLink("ehrSamples", "documentation")%> for setup and description of the module.</div>
 <br>
 <a href="<%=h(new ActionURL("sampleManager", "app", getContainer()))%>">Go To Sample Manager</a>
 <br>

--- a/EHR_SM/test/src/org/labkey/test/pages/ehr_sm/BeginPage.java
+++ b/EHR_SM/test/src/org/labkey/test/pages/ehr_sm/BeginPage.java
@@ -51,8 +51,8 @@ public class BeginPage extends LabKeyPage<BeginPage.ElementCache>
         return new ElementCache();
     }
 
-    protected class ElementCache extends LabKeyPage.ElementCache
+    protected class ElementCache extends LabKeyPage<?>.ElementCache
     {
-        protected final WebElement helloMessage = Locator.tagWithName("div", "helloMessage").findWhenNeeded(this);
+        protected final WebElement helloMessage = Locator.tagWithAttribute("div", "data-name", "helloMessage").findWhenNeeded(this);
     }
 }

--- a/EHR_SM/test/src/org/labkey/test/tests/ehr_sm/EHR_SMTest.java
+++ b/EHR_SM/test/src/org/labkey/test/tests/ehr_sm/EHR_SMTest.java
@@ -22,15 +22,15 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.TestTimeoutException;
-import org.labkey.test.categories.InDevelopment;
+import org.labkey.test.categories.EHR;
 import org.labkey.test.pages.ehr_sm.BeginPage;
 
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
-@Category({InDevelopment.class})
+@Category({EHR.class})
 public class EHR_SMTest extends BaseWebDriverTest
 {
     @Override


### PR DESCRIPTION
#### Rationale
Links to external sites (such as labkey.org) should have the correct 'rel' attribute (see related [issue](https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=40708)). `JSPBase.helpLink` produces a correctly formatted link.
Also fixing a spec nit. `div`s shouldn't be [named](https://www.w3schools.com/tags/att_name.asp). Non-standard HTML attributes should be [prepended with `data-`](https://www.w3schools.com/tags/att_data-.asp).

#### Related Pull Requests
* #422 

#### Changes
* Fix bad 'rel' attribute in documentation link
* Put `EHR_SMTest` in a suite that will run on TeamCity
