### PR TITLE
admin.jsp cleanup

### DIFF
--- a/EHR_SM/src/org/labkey/ehr_sm/view/admin.jsp
+++ b/EHR_SM/src/org/labkey/ehr_sm/view/admin.jsp
@@ -1,38 +1,31 @@
-<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
-<%@ taglib prefix="form" uri="http://www.springframework.org/tags/form" %>
 <%
-    /*
-     * Copyright (c) 2022 LabKey Corporation
-     *
-     * Licensed under the Apache License, Version 2.0 (the "License");
-     * you may not use this file except in compliance with the License.
-     * You may obtain a copy of the License at
-     *
-     *     http://www.apache.org/licenses/LICENSE-2.0
-     *
-     * Unless required by applicable law or agreed to in writing, software
-     * distributed under the License is distributed on an "AS IS" BASIS,
-     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-     * See the License for the specific language governing permissions and
-     * limitations under the License.
-     */
+/*
+ * Copyright (c) 2022 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 %>
-<%@ page import="org.labkey.api.data.Container" %>
+<%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%@ page import="org.labkey.api.exp.api.ExpSampleType" %>
-<%@ page import="org.labkey.api.security.User" %>
-<%@ page import="org.labkey.api.util.HtmlString" %>
 <%@ page import="org.labkey.api.view.HttpView" %>
 <%@ page import="org.labkey.api.view.JspView" %>
 <%@ page import="org.labkey.ehr_sm.EHR_SMController" %>
-<%@ page import="static java.util.Arrays.stream" %>
+<%@ page import="java.util.Set" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     JspView<EHR_SMController.AdminForm> me = (JspView<EHR_SMController.AdminForm>) HttpView.currentView();
     EHR_SMController.AdminForm form = me.getModelBean();
-    Container c = getContainer();
-    User user = getUser();
 %>
-
 <labkey:errors/>
 <labkey:form method="POST">
     <div style="font-weight: bold; margin-bottom: 1em; margin-top: 1em;">
@@ -52,21 +45,22 @@
     </div>
     <table class="lk-fields-table">
         <%
+            Set<String> selectedTypes = Set.of(form.getSelectedAnimalSampleTypes());
             for (ExpSampleType animalSampleType : form.getAnimalSampleTypes())
             {
-                HtmlString typeName = h(animalSampleType.getName());
-                boolean isSelected = stream(form.getSelectedAnimalSampleTypes()).anyMatch(s -> s.equals(typeName.toString()));
+                String typeName = animalSampleType.getName();
+                boolean isSelected = selectedTypes.contains(typeName);
         %>
                 <tr>
                     <td nowrap>
                         <div style="margin-bottom: 1em;">
                             <labkey:checkbox
-                                    id="<%=typeName.toString()%>"
-                                    name="selectedAnimalSampleTypes"
-                                    value="<%=typeName.toString()%>"
-                                    checked="<%=isSelected%>"
+                                id="<%=typeName%>"
+                                name="selectedAnimalSampleTypes"
+                                value="<%=typeName%>"
+                                checked="<%=isSelected%>"
                             />
-                            <label for=<%=typeName%>><%=typeName%></label>
+                            <label for=<%=h(typeName)%>><%=h(typeName)%></label>
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
#### Rationale
Several minor problems with this JSP

#### Changes
* Shouldn't compare unencoded vs. encoded values
* Shouldn't pass encoded content to tags (checkbox, in this case); that causes double encoding
* Unnecessary reference to `http://www.springframework.org/tags/form` prevented runtime recompilation
* Optimize selected lookups
