### PR TITLE
Add DataEntry cache access to EHRService

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -320,4 +320,18 @@ abstract public class EHRService
 
     /** The EHR expects certain QC states to exist. This will inspect the current study and create any missing QC states. **/
     abstract public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges);
+
+    /**
+     * Allow custom module trigger script helpers to access the data entry cache values
+     * @param cacheKey
+     * @return cached value
+     */
+    abstract public Map<String, Map<String, Object>> getDataEntryCacheValue(String cacheKey);
+
+    /**
+     * Allow custom module trigger script helpers to add data to data entry cache
+     * @param key
+     * @param value
+     */
+    abstract public void putDataEntryCacheValue(String key, Map<String, Map<String, Object>> value);
 }

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -1035,4 +1035,15 @@ public class EHRServiceImpl extends EHRService
             ti.addColumn(simpleRawCol);
         }
     }
+    @Override
+    public Map<String, Map<String, Object>> getDataEntryCacheValue(String cacheKey)
+    {
+        return (Map)DataEntryManager.get().getCache().get(cacheKey);
+    }
+
+    @Override
+    public void putDataEntryCacheValue(String key, Map<String, Map<String, Object>> value)
+    {
+        DataEntryManager.get().getCache().put(key, value);
+    }
 }


### PR DESCRIPTION
#### Rationale
In the related PR, the DataEntryManager cache needs to be accessed outside the EHR module in a trigger script helper.  This PR adds methods to EHRService to get and put from the data entry cache.

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/550

#### Changes
* Add DataEntryManager cache get and put methods to EHRService
