### PR TITLE
Adding room and cage as separate columns for Ext3 and Ext4

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/dataentry/SimpleFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/SimpleFormSection.java
@@ -41,6 +41,7 @@ public class SimpleFormSection extends AbstractFormSection
     private String _queryName;
 
     protected boolean _showLocation = false;
+    protected boolean _showRoomCage = false;
     /** Whether the grid has a button to edit the row in a popup dialog with a text label/form element layout for each field */
     protected boolean _allowRowEditing = true;
 
@@ -103,6 +104,10 @@ public class SimpleFormSection extends AbstractFormSection
         if (_showLocation)
         {
             keys.add(0, FieldKey.fromString("Id/curLocation/location"));
+        }
+        if (_showRoomCage){
+            keys.add(1, FieldKey.fromString("Id/curLocation/room"));
+            keys.add(2, FieldKey.fromString("Id/curLocation/cage"));
         }
 
         return keys;

--- a/ehr/resources/web/ehr/model/sources/Default.js
+++ b/ehr/resources/web/ehr/model/sources/Default.js
@@ -46,6 +46,49 @@ EHR.model.DataModelManager.registerMetadata('Default', {
                 hidden: true
             }
         },
+        'id/curLocation/room': {
+            hidden: false,
+            allowBlank: true,
+            nullable: true,
+            shownInGrid: true,
+            caption: 'Room',
+            header: 'Room',
+            lookups: false,
+            //to allow natural sorting
+            sortType: function(val){
+                return val ? LDK.Utils.naturalize(val) : val;
+            },
+            allowDuplicateValue: false,
+            columnConfig: {
+                width: 175,
+                showLink: false
+            },
+            formEditorConfig: {
+                hidden: true
+            }
+        },
+        'id/curLocation/cage': {
+            hidden: false,
+            allowBlank: true,
+            nullable: true,
+            shownInGrid: true,
+            caption: 'Cage',
+            header: 'Cage',
+            lookups: false,
+            //to allow natural sorting
+            sortType: function(val){
+                return val ? LDK.Utils.naturalize(val) : val;
+            },
+            allowDuplicateValue: false,
+            columnConfig: {
+                width: 175,
+                showLink: false
+            },
+            formEditorConfig: {
+                hidden: true
+            }
+        },
+
         'id/numroommates/cagemates': {
             hidden: true,
             updateValueFromServer: true,


### PR DESCRIPTION
#### Rationale
We had a request from our user of the possibility to separate the location column into two columns to help sorting animal enclosures. There was already methods to get the room and cage, I modify the ext configuration to have it populate when the animalId get populated

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
Copy logic from location to have room and cage automatically populate when animalId is added