### PR TITLE
Animal Id Default Case Handling

### DIFF
--- a/ehr/resources/web/ehr/ehr_api.lib.xml
+++ b/ehr/resources/web/ehr/ehr_api.lib.xml
@@ -6,6 +6,7 @@
         <script path="ehr/DemographicsCache.js"/>
         <script path="ehr/Security.js"/>
         <script path="ehr/navMenu.js"/>
+        <script path="ehr/overrides.js"/>
 
 
         <!--Misc Ext4 components-->

--- a/ehr/resources/web/ehr/overrides.js
+++ b/ehr/resources/web/ehr/overrides.js
@@ -16,7 +16,7 @@ LDK.Utils.splitIds = function(subjectArray, unsorted, preserveDuplicates) {
         subjectArray = [];
     }
 
-    EHR.Utils.formatAnimalIds(subjectArray);
+    subjectArray = EHR.Utils.formatAnimalIds(subjectArray);
 
     if (subjectArray.length > 0) {
 

--- a/ehr/resources/web/ehr/overrides.js
+++ b/ehr/resources/web/ehr/overrides.js
@@ -1,0 +1,34 @@
+
+
+LDK.Utils.splitIds = function(subjectArray, unsorted, preserveDuplicates, preserveCase) {
+    if (!subjectArray){
+        return [];
+    }
+
+    subjectArray = Ext4.String.trim(subjectArray);
+    subjectArray = subjectArray.replace(/[\s,;]+/g, ';');
+    subjectArray = subjectArray.replace(/(^;|;$)/g, '');
+    if (!preserveCase)
+        subjectArray = subjectArray.toLowerCase();
+
+    if (subjectArray){
+        subjectArray = subjectArray.split(';');
+    }
+    else {
+        subjectArray = [];
+    }
+
+    EHR.Utils.formatAnimalIds(subjectArray);
+
+    if (subjectArray.length > 0) {
+
+        if (!preserveDuplicates) {
+            subjectArray = Ext4.unique(subjectArray);
+        }
+        if (!unsorted) {
+            subjectArray.sort();
+        }
+    }
+
+    return subjectArray;
+}

--- a/ehr/resources/web/ehr/overrides.js
+++ b/ehr/resources/web/ehr/overrides.js
@@ -18,7 +18,7 @@ LDK.Utils.splitIds = function(subjectArray, unsorted, preserveDuplicates) {
 
     subjectArray = EHR.Utils.formatAnimalIds(subjectArray);
 
-    if (subjectArray.length > 0) {
+    if (subjectArray.length > 1) {
 
         if (!preserveDuplicates) {
             subjectArray = Ext4.unique(subjectArray);

--- a/ehr/resources/web/ehr/overrides.js
+++ b/ehr/resources/web/ehr/overrides.js
@@ -1,6 +1,6 @@
 
 
-LDK.Utils.splitIds = function(subjectArray, unsorted, preserveDuplicates, preserveCase) {
+LDK.Utils.splitIds = function(subjectArray, unsorted, preserveDuplicates) {
     if (!subjectArray){
         return [];
     }
@@ -8,8 +8,6 @@ LDK.Utils.splitIds = function(subjectArray, unsorted, preserveDuplicates, preser
     subjectArray = Ext4.String.trim(subjectArray);
     subjectArray = subjectArray.replace(/[\s,;]+/g, ';');
     subjectArray = subjectArray.replace(/(^;|;$)/g, '');
-    if (!preserveCase)
-        subjectArray = subjectArray.toLowerCase();
 
     if (subjectArray){
         subjectArray = subjectArray.split(';');

--- a/ehr/resources/web/ehr/panel/AnimalHistoryPanel.js
+++ b/ehr/resources/web/ehr/panel/AnimalHistoryPanel.js
@@ -19,6 +19,7 @@ Ext4.define('EHR.panel.AnimalHistoryPanel', {
     showDiscvrLink: false,
     minTabHeight: 500,
     minTabWidth: 1000,
+    caseInsensitiveSubjects: true,
 
     initComponent: function(){
         Ext4.apply(this, {

--- a/ehr/resources/web/ehr/panel/ParticipantDetailsPanel.js
+++ b/ehr/resources/web/ehr/panel/ParticipantDetailsPanel.js
@@ -12,6 +12,7 @@
 
 Ext4.define('EHR.panel.ParticipantDetailsPanel', {
     extend: 'EHR.panel.AnimalHistoryPanel',
+    caseInsensitiveSubjects: true,
 
     initComponent: function(){
         this.callParent();

--- a/ehr/resources/web/ehr/utils.js
+++ b/ehr/resources/web/ehr/utils.js
@@ -628,7 +628,7 @@ EHR.Utils = new function(){
             };
         },
 
-        /** Override this function to apply custom formatting to ids entered into UI components like animal history, animal search,
+        /** Override this function to apply custom patterns (casing, hyphens, etc) to ids entered into UI components like animal history, animal search,
          *  and data entry windows. Default is no formatting.
          */
         formatAnimalIds: function(subjects){

--- a/ehr/resources/web/ehr/utils.js
+++ b/ehr/resources/web/ehr/utils.js
@@ -626,6 +626,13 @@ EHR.Utils = new function(){
                 minWidth: 60,
                 border: includeBorder
             };
+        },
+
+        /** Override this function to apply custom formatting to ids entered into UI components like animal history, animal search,
+         *  and data entry windows. Default is no formatting.
+         */
+        formatAnimalIds: function(subjects){
+            return subjects;
         }
     }
 };


### PR DESCRIPTION
#### Rationale
By default, animal Ids are being forced to lower case in several UI components like Animal History, Animal Search and bulk entry in data entry forms. All but one center have overridden this behavior. This PR changes the default to not force any formatting changes, but provides a formatting function which can be overridden in PRC modules.

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/233

#### Changes
* Add overrides file with updated splitids function that does not force lower case and has tie in for custom formatting
* Make case insensitive animal history search the default case
