### PR TITLE
Ticket 46941: Data entry grid view height recalculate

### DIFF
--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -93,7 +93,7 @@ Ext4.define('EHR.grid.Panel', {
     heightResize: false, // avoid infinite loop
     updateLayout: function(options){
         const view = this.getView();
-        if (view.rendered && view.body && !this.heightResize) {
+        if (view.rendered && view.body && view.body.dom && !this.heightResize) {
             this.heightResize = true;
             view.setHeight(view.body.getHeight());
         }

--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -60,13 +60,6 @@ Ext4.define('EHR.grid.Panel', {
 
         this.getSelectionModel().on('selectionchange', this.handleSectionChangeEvent, this);
 
-        // Ensure gridview height updated on long text cell edits
-        if (this.plugins.length > 0) {
-            this.plugins[0].on('edit', this.resizeHeight, this);
-            this.plugins[0].on('beforeedit', this.resizeHeight, this);
-            this.plugins[0].on('canceledit', this.resizeHeight, this);
-        }
-
         // the intention of the following is to avoid redrawing the entire grid, which is expensive, when we have
         // single row changes, or more importantly single row changes that only involve validation/tooltip error message differences
         this.on('storevalidationcomplete', this.onStoreValidationComplete, this, {buffer: 100, delay: 20});
@@ -95,6 +88,20 @@ Ext4.define('EHR.grid.Panel', {
     },
 
     pendingChanges: {},
+
+    getEditingPlugin: function(){
+        const plugin = Ext4.create('LDK.grid.plugin.CellEditing', {
+            pluginId: this.editingPluginId,
+            clicksToEdit: this.clicksToEdit
+        });
+
+        // Ensure gridview height updated on long text cell edits
+        plugin.on('edit', this.resizeHeight, this);
+        plugin.on('beforeedit', this.resizeHeight, this);
+        plugin.on('canceledit', this.resizeHeight, this);
+
+        return plugin;
+    },
 
     resizeHeight: function(){
         // A bit of a hack but there are some cases where the gridview does not resize height to match its contents. Called

--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -89,18 +89,18 @@ Ext4.define('EHR.grid.Panel', {
 
     pendingChanges: {},
 
-    getEditingPlugin: function(){
-        const plugin = Ext4.create('LDK.grid.plugin.CellEditing', {
-            pluginId: this.editingPluginId,
-            clicksToEdit: this.clicksToEdit
-        });
-
-        // Ensure gridview height updated on long text cell edits
-        plugin.on('edit', this.resizeHeight, this);
-        plugin.on('beforeedit', this.resizeHeight, this);
-        plugin.on('canceledit', this.resizeHeight, this);
-
-        return plugin;
+    // Force height to match contents. Blanket coverage of any layout updates
+    heightResize: false, // avoid infinite loop
+    updateLayout: function(options){
+        const view = this.getView();
+        if (view.rendered && view.body && !this.heightResize) {
+            this.heightResize = true;
+            view.setHeight(view.body.getHeight());
+        }
+        else {
+            this.heightResize = false;
+            this.callParent();
+        }
     },
 
     resizeHeight: function(){

--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -99,7 +99,7 @@ Ext4.define('EHR.grid.Panel', {
         }
         else {
             this.heightResize = false;
-            this.callParent();
+            this.callParent(options);
         }
     },
 

--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -61,8 +61,11 @@ Ext4.define('EHR.grid.Panel', {
         this.getSelectionModel().on('selectionchange', this.handleSectionChangeEvent, this);
 
         // Ensure gridview height updated on long text cell edits
-        if (this.plugins.length > 0)
+        if (this.plugins.length > 0) {
             this.plugins[0].on('edit', this.resizeHeight, this);
+            this.plugins[0].on('beforeedit', this.resizeHeight, this);
+            this.plugins[0].on('canceledit', this.resizeHeight, this);
+        }
 
         // the intention of the following is to avoid redrawing the entire grid, which is expensive, when we have
         // single row changes, or more importantly single row changes that only involve validation/tooltip error message differences

--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -60,6 +60,10 @@ Ext4.define('EHR.grid.Panel', {
 
         this.getSelectionModel().on('selectionchange', this.handleSectionChangeEvent, this);
 
+        // Ensure gridview height updated on long text cell edits
+        if (this.plugins.length > 0)
+            this.plugins[0].on('edit', this.resizeHeight, this);
+
         // the intention of the following is to avoid redrawing the entire grid, which is expensive, when we have
         // single row changes, or more importantly single row changes that only involve validation/tooltip error message differences
         this.on('storevalidationcomplete', this.onStoreValidationComplete, this, {buffer: 100, delay: 20});
@@ -88,6 +92,14 @@ Ext4.define('EHR.grid.Panel', {
     },
 
     pendingChanges: {},
+
+    resizeHeight: function(){
+        // A bit of a hack but there are some cases where the gridview does not resize height to match its contents. Called
+        // on store validation complete as this covers initial load and adding new rows scenario. Also done on cell edit
+        // for long text cells.
+        var view = this.getView();
+        view.setHeight(view.body.getHeight());
+    },
 
     handleSectionChangeEvent: function(sm, models){
         if (models.length != 1)
@@ -135,6 +147,7 @@ Ext4.define('EHR.grid.Panel', {
         if (this.needsRefresh || keys.length > 5){
             //console.log('grid refresh: ' + this.store.storeId);
             this.getView().refresh();
+            this.resizeHeight();
         }
         else if (!keys.length){
             console.log('no changes, skipping refresh');


### PR DESCRIPTION
#### Rationale
Grid views in data entry do not always correctly re-set height as the contents change or are updated. This update just ensures the grid view height is set to the height of it's body to ensure all contents are displayed. Covers initial load, adding/removing rows and multi-line text cell edits

#### Changes
* Add resize height function
* Add updateLayout override to adjust height of grid view to contents
* Add resize after validation complete
