### PR TITLE
Add sire and dam to animal record

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/demographics/AnimalRecord.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/AnimalRecord.java
@@ -46,6 +46,10 @@ public interface AnimalRecord
     // Below are convenience methods for specific cached properties
     String getGender();
 
+    String getSire();
+
+    String getDam();
+
     String getGenderMeaning();
 
     String getOrigGender();

--- a/ehr/src/org/labkey/ehr/demographics/AnimalRecordImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/AnimalRecordImpl.java
@@ -113,6 +113,18 @@ public class AnimalRecordImpl implements AnimalRecord
     }
 
     @Override
+    public String getSire()
+    {
+        return (String)_props.get("sire");
+    }
+
+    @Override
+    public String getDam()
+    {
+        return (String)_props.get("dam");
+    }
+
+    @Override
     public String getGenderMeaning()
     {
         return (String)_props.get(FieldKey.fromString("gender/meaning").toString());

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -809,6 +809,12 @@ public class TriggerScriptHelper
 
     public void createDemographicsRecord(String id, Map<String, Object> props) throws QueryUpdateServiceException, DuplicateKeyException, SQLException, BatchValidationException
     {
+        createDemographicsRecord(id, props, null);
+    }
+
+    public void createDemographicsRecord(String id, Map<String, Object> props,
+                                         @Nullable Map<String, Object> extraDemographicsFieldMappings) throws QueryUpdateServiceException, DuplicateKeyException, SQLException, BatchValidationException
+    {
         if (id == null)
             return;
 
@@ -839,6 +845,11 @@ public class TriggerScriptHelper
         EHRQCState qc = getQCStateForLabel("Completed");
         if (qc != null)
             row.put("qcstate", qc.getRowId());
+
+        if (extraDemographicsFieldMappings != null)
+        {
+            row.putAll(extraDemographicsFieldMappings);
+        }
 
         List<Map<String, Object>> rows = new ArrayList<>();
         rows.add(row);
@@ -1544,11 +1555,7 @@ public class TriggerScriptHelper
         //allow the potential for entry without birth date
         demographicsProps.put("date", row.get("birth") != null ? row.get("birth") : row.get("date"));
         demographicsProps.put("calculated_status", "Alive");
-        if (extraDemographicsFieldMappings != null)
-        {
-            extraDemographicsFieldMappings.forEach(demographicsProps::put);
-        }
-        createDemographicsRecord(id, demographicsProps);
+        createDemographicsRecord(id, demographicsProps, extraDemographicsFieldMappings);
 
         if (row.get("birth") != null)
         {


### PR DESCRIPTION
#### Rationale
Add sire and dam to animal record object returned from TriggerScriptHelper.getDemographicRecord. Make default qcstate behavior in demographic create record easier to override.

#### Related Pull Requests
* https://github.com/LabKey/johnsHopkinsEHRModules/pull/28

#### Changes
* Add sire and dam getters to AnimalRecord
* Move extraDemographicsFieldMappings after default qcstate setting
