### PR TITLE
Fix syntax error in EHR_ComplianceDB-12.42-12.43.sql

### DIFF
--- a/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-12.42-12.43.sql
+++ b/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-12.42-12.43.sql
@@ -2,11 +2,11 @@ CREATE TABLE ehr_compliancedb.Compliance_Reference_Data
 (
         rowId serial,
         label varchar(250) NULL,
-        value varchar(255) ,
-        columnName varchar(255)  NOT NULL,
-        sort_order integer  null,
-        endDate  TIMESTAMP  NULL,
+        value varchar(255),
+        columnName varchar(255) NOT NULL,
+        sort_order integer NULL,
+        endDate  TIMESTAMP NULL,
         objectid entityid
 
-            CONSTRAINT pk_compliance_reference PRIMARY KEY (value)
+        CONSTRAINT pk_compliance_reference PRIMARY KEY (value)
 );

--- a/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-12.42-12.43.sql
+++ b/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-12.42-12.43.sql
@@ -6,7 +6,7 @@ CREATE TABLE ehr_compliancedb.Compliance_Reference_Data
         columnName varchar(255) NOT NULL,
         sort_order integer NULL,
         endDate  TIMESTAMP NULL,
-        objectid entityid
+        objectid entityid,
 
         CONSTRAINT pk_compliance_reference PRIMARY KEY (value)
 );

--- a/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-12.42-12.43.sql
+++ b/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-12.42-12.43.sql
@@ -1,6 +1,6 @@
 CREATE TABLE ehr_compliancedb.Compliance_Reference_Data
 (
-        rowId int identity(1,1),
+        rowId serial,
         label varchar(250) NULL,
         value varchar(255) ,
         columnName varchar(255)  NOT NULL,


### PR DESCRIPTION
#### Rationale
`int identity(1,1)` isn't a valid column type on postgres. This is causing bootstrap failures.

#### Related Pull Requests
* #485 

#### Changes
* Use `serial` column on postgres
