### PR TITLE
Issue 47002: EHR Kinship Calculations are not consistent and incorrect across servers

### DIFF
--- a/ehr/resources/pipeline/kinship/populateInbreeding.r
+++ b/ehr/resources/pipeline/kinship/populateInbreeding.r
@@ -31,8 +31,7 @@ is.na(allPed$Gender)<-which(allPed$Gender=="")
 df <- data.frame(id=as.character(allPed$Id), 'id parent1'=allPed$Dam, 'id parent2'=allPed$Sire, stringsAsFactors=FALSE);
 colnames(df)<-c("id", "id parent1", "id parent2")
 
-originalIds <-as.data.frame(df[,1])
-colnames(originalIds) <- c("id")
+originalIds <-as.data.frame(df[,1,drop=FALSE])
 
 #this is a function in the pedigree package designed to add missing parents to the dataframe
 #see pedigree package documentation for more detail

--- a/ehr/resources/pipeline/kinship/populateInbreeding.r
+++ b/ehr/resources/pipeline/kinship/populateInbreeding.r
@@ -13,6 +13,7 @@ options(error = dump.frames);
 library(pedigree);
 library(getopt);
 library(Matrix);
+library(dplyr)
 
 spec <- matrix(c(
 'inputFile', '-f', 1, "character"
@@ -30,6 +31,9 @@ is.na(allPed$Gender)<-which(allPed$Gender=="")
 df <- data.frame(id=as.character(allPed$Id), 'id parent1'=allPed$Dam, 'id parent2'=allPed$Sire, stringsAsFactors=FALSE);
 colnames(df)<-c("id", "id parent1", "id parent2")
 
+originalIds <-as.data.frame(df[,1])
+colnames(originalIds) <- c("id")
+
 #this is a function in the pedigree package designed to add missing parents to the dataframe
 #see pedigree package documentation for more detail
 df <- add.Inds(df);
@@ -40,6 +44,9 @@ df <- df[order(ord),]
 ib = calcInbreeding(df);
 
 newRecords <- data.frame(Id=as.character(df$id), coefficient=ib, stringsAsFactors=FALSE);
+
+#only calculate inbreeding for Ids at the center
+newRecords <- dplyr::filter(newRecords, Id %in% originalIds$id)
 
 # write TSV to disk
 print("Output table:");

--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -15,6 +15,7 @@ library(methods);
 library(kinship2);
 library(getopt);
 library(Matrix);
+library(dplyr);
 
 spec <- matrix(c(
 #'containerPath', '-c', 1, "character",
@@ -35,69 +36,37 @@ allPed$Species <- as.character(allPed$Species)
 allPed$Species[is.na(allPed$Species)] <- c('Unknown')
 allPed$Species <- as.factor(allPed$Species)
 
-##### commented out after checking data
-# duplicatedId=allPed$Id[duplicated(allPed$Id)]
-# allPed[allPed$Id%in%duplicatedId,]# Check for duplication: passed
-# Id.Dam=unique(allPed$Dam)
-# allPed[(allPed$Id%in%Id.Dam)&(allPed$Gender!=2),]#Check for Dam that is not female
-# Id.Sire=unique(allPed$Sire)
-# allPed[(allPed$Id%in%Id.Sire)&(allPed$Gender!=1),]#Check for Sire that is not male:1 not passed
-
-# this function adds missing parents to the pedigree
-# it is similar to add.Inds from kinship; however, we retain gender
-addMissing <- function(ped, species){
-    if(ncol(ped)<4)stop("pedigree should have at least 4 columns")
-    head <- names(ped)
-
-    nsires <- match(ped[,3],ped[,1])# [Quoc] change ped,2 to ped,3
-    nsires <- as.character(unique(ped[is.na(nsires),3]))
-    nsires <- nsires[!is.na(nsires)]
-    if(length(nsires)){
-        ped <- rbind(ped, data.frame(Id=nsires, Dam=rep(NA, length(nsires)), Sire=rep(NA, length(nsires)), Gender=rep(1, length(nsires)), Species=rep(species, length(nsires))));
-    }
-
-    ndams <- match(ped[,2],ped[,1])# [Quoc] change ped,3 to ped,2
-    ndams <- as.character(unique(ped[is.na(ndams),2]))
-    ndams <- ndams[!is.na(ndams)];
-
-    if(length(ndams)){
-        ped <- rbind(ped,data.frame(Id=ndams, Dam=rep(NA, length(ndams)), Sire=rep(NA, length(ndams)), Gender=rep(2, length(ndams)), Species=rep(species, length(ndams))));
-    }
-
-    names(ped) <- head
-    return(ped)
-}
-
 # In order to reduce the max matrix size, calculate famids using makefamid, then analyze each group separately
 # It resizes the biggest matrix from 12000^2 to 8200^2 thus reduces the memory used by half
 newRecords=NULL
+write.table('start', file = "pedigreeSpecies.txt", append = FALSE,row.names=F,quote=F,sep="\t");
+write.table('start', file = "kinshipMatrix.txt", append = FALSE,row.names=F,quote=F,sep="\t");
 for (species in unique(allPed$Species)){
     print(paste0('processing species: ', species))
-    recordsForSpecies <- allPed[allPed$Species == species,]
-    print(paste0('total subjects: ', nrow(recordsForSpecies)))
+    allRecordsForSpecies <- allPed[allPed$Species == species,]
 
-    recordsForSpecies <- addMissing(recordsForSpecies, species)
-    gc()
-    print(paste0('total subjects after adding missing: ', nrow(recordsForSpecies)))
+    # Add missing parents for accurate kinship calculations
+    fixedRecords <- with(allRecordsForSpecies, fixParents(id = Id, dadid = Sire, momid = Dam, sex = Gender))
 
-    fami=makefamid(id=recordsForSpecies$Id,father.id=recordsForSpecies$Sire,mother.id=recordsForSpecies$Dam)
-    famid=unique(fami)
-    famid=famid[famid!=0]
-    gc()
+    # Kinship is expecting records to be sorted IAW it's own pedigree function
+    recordsForSpecies <- with(fixedRecords, pedigree(id=id,dadid=dadid,momid=momid,sex=sex,missid=0))
 
-    print(paste0('total families: ', length(famid)))
-    for (fam.no in famid){
-        familytemp=recordsForSpecies[fami==fam.no,]
-        print(paste0('family size: ', nrow(familytemp)))
+    temp.kin=kinship(recordsForSpecies)
 
-        temp.kin=kinship(familytemp$Id,familytemp$Sire,familytemp$Dam)
-        rownames(temp.kin) <- colnames(temp.kin) #add rownames to make matrix symmetric, which is required downstream
-        sparse.kin=as(temp.kin,"dsTMatrix") #change kinship matrix to symmetric triplet sparse matrix
+    # Add rownames to make matrix symmetric, which is required downstream
+    rownames(temp.kin) <- colnames(temp.kin)
 
-        # convert to a sparse matrix usng S4 object from Matrix library
-        temp.tri=data.frame(Id=colnames(temp.kin)[sparse.kin@i+1],Id2=colnames(temp.kin)[sparse.kin@j+1],coefficient=sparse.kin@x,stringsAsFactors=FALSE)
-        newRecords=rbind(newRecords,temp.tri)
-    }
+    # Convert kinship matrix to a triplet list of two ids and their coefficient
+    summaryDf = as.data.frame(summary(as(temp.kin, "dgCMatrix")))
+    idList <- rownames(temp.kin)
+    temp.tri = data.frame(Id=idList[summaryDf$i], Id2=idList[summaryDf$j], coefficient=summaryDf$x)
+
+    # Now filter out parents added for kinship calculation
+    temp.tri <- dplyr::filter(temp.tri, grepl("^(?!addin).*$", Id, perl = TRUE))
+    temp.tri <- dplyr::filter(temp.tri, grepl("^(?!addin).*$", Id2, perl = TRUE))
+
+    newRecords=rbind(newRecords,temp.tri)
+    print(paste0('total subjects: ', nrow(allRecordsForSpecies)))
 }
 
 # write TSV to disk

--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -39,8 +39,6 @@ allPed$Species <- as.factor(allPed$Species)
 # In order to reduce the max matrix size, calculate famids using makefamid, then analyze each group separately
 # It resizes the biggest matrix from 12000^2 to 8200^2 thus reduces the memory used by half
 newRecords=NULL
-write.table('start', file = "pedigreeSpecies.txt", append = FALSE,row.names=F,quote=F,sep="\t");
-write.table('start', file = "kinshipMatrix.txt", append = FALSE,row.names=F,quote=F,sep="\t");
 for (species in unique(allPed$Species)){
     print(paste0('processing species: ', species))
     allRecordsForSpecies <- allPed[allPed$Species == species,]

--- a/ehr/resources/queries/ehr/kinshipSummary.sql
+++ b/ehr/resources/queries/ehr/kinshipSummary.sql
@@ -3,19 +3,6 @@
  *
  * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
  */
-SELECT
-  k.Id,
-  k.Id2,
-  k.coefficient
 
-FROM ehr.kinship k
-
-UNION ALL
-
-SELECT
-  k.Id2 as Id,
-  k.Id as Id2,
-  k.coefficient
-
-FROM ehr.kinship k
-WHERE k.Id != k.Id2
+SELECT * FROM ehr.kinship
+WHERE Id != Id2

--- a/ehr/resources/queries/study/demographicsOffspring.query.xml
+++ b/ehr/resources/queries/study/demographicsOffspring.query.xml
@@ -1,0 +1,20 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="demographicsOffspring" tableDbType="NOT_IN_DB">
+                <columns>
+                    <column columnName="Id">
+                        <isKeyField>true</isKeyField>
+                    </column>
+                    <column columnName="Offspring">
+                        <fk>
+                            <fkDbSchema>study</fkDbSchema>
+                            <fkTable>animal</fkTable>
+                            <fkColumnName>Id</fkColumnName>
+                        </fk>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/ehr/resources/queries/study/demographicsOffspring.sql
+++ b/ehr/resources/queries/study/demographicsOffspring.sql
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015-2016 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+SELECT
+    d.id as Id,
+    d2.id  AS Offspring,
+    d2.birth AS date,
+    d2.sire,
+    d2.dam,
+    d2.gender AS sex,
+    d.qcstate
+FROM study.Demographics d
+
+INNER JOIN study.Demographics d2 ON ((d2.sire = d.id OR d2.dam = d.id) AND d.id != d2.id)
+
+GROUP BY d.id, d2.id, d2.birth, d2.sire, d2.dam, d2.gender, d.qcstate

--- a/ehr/resources/queries/study/demographicsSiblings.query.xml
+++ b/ehr/resources/queries/study/demographicsSiblings.query.xml
@@ -1,0 +1,44 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <description>Siblings of Any Animal</description>
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="demographicsSiblings" tableDbType="NOT_IN_DB">
+                <description>Siblings of Any Animal</description>
+                <columns>
+                    <column columnName="Id">
+                        <isKeyField>true</isKeyField>
+                        <!--<isHidden>true</isHidden>-->
+                    </column>
+                    <column columnName="Relationship">
+                        <url>/query/executeQuery.view?schemaName=study&amp;
+                            query.queryName=demographicsSiblings&amp;
+                            query.Id~eq=${Id}
+                        </url>
+                    </column>
+                    <column columnName="Sibling">
+                        <fk>
+                            <fkDbSchema>study</fkDbSchema>
+                            <fkTable>animal</fkTable>
+                            <fkColumnName>Id</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="SiblingDam">
+                        <fk>
+                            <fkDbSchema>study</fkDbSchema>
+                            <fkTable>animal</fkTable>
+                            <fkColumnName>Id</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="SiblingSire">
+                        <fk>
+                            <fkDbSchema>study</fkDbSchema>
+                            <fkTable>animal</fkTable>
+                            <fkColumnName>Id</fkColumnName>
+                        </fk>
+                    </column>
+                </columns>
+                <titleColumn>Relationship</titleColumn>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/ehr/resources/queries/study/demographicsSiblings.query.xml
+++ b/ehr/resources/queries/study/demographicsSiblings.query.xml
@@ -7,7 +7,6 @@
                 <columns>
                     <column columnName="Id">
                         <isKeyField>true</isKeyField>
-                        <!--<isHidden>true</isHidden>-->
                     </column>
                     <column columnName="Relationship">
                         <url>/query/executeQuery.view?schemaName=study&amp;

--- a/ehr/resources/queries/study/demographicsSiblings.sql
+++ b/ehr/resources/queries/study/demographicsSiblings.sql
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015-2018 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+SELECT
+
+    d1.id,
+
+    CASE
+        WHEN (COALESCE(d1.id.parents.sire, '') = COALESCE(d2.id.parents.sire, '') and COALESCE(d1.id.parents.dam, '') = COALESCE(d2.id.parents.dam, '') AND COALESCE(d1.id.parents.sire, '')!='' AND COALESCE(d1.id.parents.dam, '')!='')
+            THEN 'Full Sib'
+        WHEN (COALESCE(d1.id.parents.sire, '') = COALESCE(d2.id.parents.sire, '') AND COALESCE(d1.id.parents.sire, '') != '' AND (COALESCE(d1.id.parents.dam, '') != COALESCE(d2.id.parents.dam, '') OR COALESCE(d1.id.parents.dam, '') = ''))
+            THEN 'Half-Sib Paternal'
+        WHEN (COALESCE(d1.id.parents.dam, '') = COALESCE(d2.id.parents.dam, '') AND COALESCE(d1.id.parents.dam, '') != '' AND (COALESCE(d1.id.parents.sire, '') != COALESCE(d2.id.parents.sire, '') OR COALESCE(d1.id.parents.sire, '') = ''))
+            THEN 'Half-Sib Maternal'
+        WHEN (COALESCE(d1.id.parents.sire, '') != COALESCE(d2.id.parents.sire, '') and COALESCE(d1.id.parents.dam, '') != COALESCE(d2.id.parents.dam, ''))
+            THEN 'ERROR'
+        END AS Relationship,
+
+    d2.id  AS Sibling,
+
+    d2.id.parents.dam AS SiblingDam,
+    d2.id.parents.sire AS SiblingSire,
+    d1.qcstate
+
+FROM study.Demographics d1
+JOIN study.Demographics d2 ON ((d2.id.parents.sire = d1.id.parents.sire OR d2.id.parents.dam = d1.id.parents.dam) AND d1.id != d2.id)
+WHERE d2.id is not null

--- a/ehr/resources/queries/study/demographicsSiblings.sql
+++ b/ehr/resources/queries/study/demographicsSiblings.sql
@@ -25,5 +25,5 @@ SELECT
     d1.qcstate
 
 FROM study.Demographics d1
-JOIN study.Demographics d2 ON ((d2.id.parents.sire = d1.id.parents.sire OR d2.id.parents.dam = d1.id.parents.dam) AND d1.id != d2.id)
+JOIN study.Demographics d2 ON ((d2.sire = d1.sire OR d2.dam = d1.dam) AND d1.id != d2.id)
 WHERE d2.id is not null

--- a/ehr/resources/queries/study/demographicsSiblings.sql
+++ b/ehr/resources/queries/study/demographicsSiblings.sql
@@ -8,13 +8,13 @@ SELECT
     d1.id,
 
     CASE
-        WHEN (COALESCE(d1.id.parents.sire, '') = COALESCE(d2.id.parents.sire, '') and COALESCE(d1.id.parents.dam, '') = COALESCE(d2.id.parents.dam, '') AND COALESCE(d1.id.parents.sire, '')!='' AND COALESCE(d1.id.parents.dam, '')!='')
+        WHEN (ISEQUAL(d1.sire, d2.sire) AND ISEQUAL(d1.dam, d2.dam))
             THEN 'Full Sib'
-        WHEN (COALESCE(d1.id.parents.sire, '') = COALESCE(d2.id.parents.sire, '') AND COALESCE(d1.id.parents.sire, '') != '' AND (COALESCE(d1.id.parents.dam, '') != COALESCE(d2.id.parents.dam, '') OR COALESCE(d1.id.parents.dam, '') = ''))
+        WHEN (ISEQUAL(d1.sire, d2.sire) AND NOT ISEQUAL(d1.dam, d2.dam))
             THEN 'Half-Sib Paternal'
-        WHEN (COALESCE(d1.id.parents.dam, '') = COALESCE(d2.id.parents.dam, '') AND COALESCE(d1.id.parents.dam, '') != '' AND (COALESCE(d1.id.parents.sire, '') != COALESCE(d2.id.parents.sire, '') OR COALESCE(d1.id.parents.sire, '') = ''))
+        WHEN (NOT ISEQUAL(d1.sire, d2.sire) AND ISEQUAL(d1.dam, d2.dam))
             THEN 'Half-Sib Maternal'
-        WHEN (COALESCE(d1.id.parents.sire, '') != COALESCE(d2.id.parents.sire, '') and COALESCE(d1.id.parents.dam, '') != COALESCE(d2.id.parents.dam, ''))
+        WHEN (NOT ISEQUAL(d1.sire, d2.sire) AND NOT ISEQUAL(d1.dam, d2.dam))
             THEN 'ERROR'
         END AS Relationship,
 

--- a/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
+++ b/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
@@ -25,6 +25,10 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
                 fieldLabel: 'Is Enabled?',
                 itemId: 'enabled'
             },{
+                xtype: 'checkbox',
+                fieldLabel: 'Kinship validation?',
+                itemId: 'kinshipValidation'
+            },{
                 xtype: 'numberfield',
                 hideTrigger: true,
                 fieldLabel: 'Hour Of Day',
@@ -79,6 +83,7 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
         this.down('#enabled').setValue(results.enabled);
         this.down('#hourOfDay').setValue(results.hourOfDay);
         this.down('#containerPath').setValue(results.containerPath);
+        this.down('#kinshipValidation').setValue(results.kinshipValidation);
     },
 
     saveData: function(){
@@ -88,7 +93,8 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
             params: {
                 containerPath: this.down('#containerPath').getValue(),
                 enabled: this.down('#enabled').getValue(),
-                hourOfDay: this.down('#hourOfDay').getValue()
+                hourOfDay: this.down('#hourOfDay').getValue(),
+                kinshipValidation: this.down('#kinshipValidation').getValue()
             },
             method : 'POST',
             scope: this,

--- a/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
+++ b/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
@@ -27,7 +27,17 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
             },{
                 xtype: 'checkbox',
                 fieldLabel: 'Kinship validation?',
-                itemId: 'kinshipValidation'
+                itemId: 'kinshipValidation',
+                listeners : {
+                    render: function(c) {
+                        Ext4.create('Ext.tip.ToolTip', {
+                            target: c.getEl(),
+                            html: 'This will iterate pedigree queries to ensure a minimum kinship coefficient exists for parents, ' +
+                                    'grandparents, offspring, full-siblings and half-siblings. This can significantly increase the time to ' +
+                                    'complete the kinship calculations so should only be used when validating kinship and pedigree.'
+                        });
+                    }
+                }
             },{
                 xtype: 'numberfield',
                 hideTrigger: true,

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -637,7 +637,7 @@ public class EHRController extends SpringActionController
                 errors.reject(ERROR_MSG, "Unable to find container for path: " + form.getContainerPath());
                 return null;
             }
-            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay());
+            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay(), form.isKinshipValidation());
 
             return new ApiSimpleResponse("success", true);
         }
@@ -756,6 +756,8 @@ public class EHRController extends SpringActionController
         private String containerPath;
         private int hourOfDay;
 
+        private boolean _kinshipValidation;
+
         public boolean isEnabled()
         {
             return _enabled;
@@ -785,6 +787,16 @@ public class EHRController extends SpringActionController
         {
             this.hourOfDay = hourOfDay;
         }
+
+        public boolean isKinshipValidation()
+        {
+            return _kinshipValidation;
+        }
+
+        public void setKinshipValidation(boolean kinshipValidation)
+        {
+            _kinshipValidation = kinshipValidation;
+        }
     }
 
     @RequiresPermission(AdminPermission.class)
@@ -802,6 +814,7 @@ public class EHRController extends SpringActionController
             ret.put("isScheduled", GeneticCalculationsJob.isScheduled());
             ret.put("enabled", GeneticCalculationsJob.isEnabled());
             ret.put("hourOfDay", GeneticCalculationsJob.getHourOfDay());
+            ret.put("kinshipValidation", GeneticCalculationsJob.isKinshipValidation());
 
             return new ApiSimpleResponse(ret);
         }

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -407,7 +407,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
         }
         catch (SQLException e)
         {
-            throw new RuntimeException(e);
+            throw new RuntimeSQLException(e);
         }
 
     }

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
@@ -19,6 +19,7 @@ import au.com.bytecode.opencsv.CSVWriter;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Selector;
+import org.labkey.api.data.Sort;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
 import org.labkey.api.pipeline.AbstractTaskFactory;
@@ -133,7 +134,7 @@ public class GeneticCalculationsInitTask extends PipelineJob.Task<GeneticCalcula
             {
                 throw new IllegalStateException("Could not find query 'pedigree' in study schema");
             }
-            TableSelector ts = new TableSelector(pedTable, PageFlowUtil.set("Id", "Dam", "Sire", "Gender", "Species"));
+            TableSelector ts = new TableSelector(pedTable, PageFlowUtil.set("Id", "Dam", "Sire", "Gender", "Species"), null, new Sort("Species, Id"));
 
             File outputFile = new File(support.getAnalysisDirectory(), GeneticCalculationsImportTask.PEDIGREE_FILE);
 

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
@@ -112,6 +112,16 @@ public class GeneticCalculationsJob implements Job
         return _jobKey != null;
     }
 
+    public static boolean isKinshipValidation()
+    {
+        Map<String, String> saved = PropertyManager.getProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN);
+
+        if (saved.containsKey("kinshipValidation"))
+            return Boolean.parseBoolean(saved.get("kinshipValidation"));
+        else
+            return false;
+    }
+
     public static boolean isEnabled()
     {
         Map<String, String> saved = PropertyManager.getProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN);
@@ -142,12 +152,13 @@ public class GeneticCalculationsJob implements Job
         return null;
     }
 
-    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay)
+    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay, Boolean isKinshipValidation)
     {
         PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN, true);
         props.put("enabled", isEnabled.toString());
         props.put("container", c.getId());
         props.put("hourOfDay", hourOfDay.toString());
+        props.put("kinshipValidation", isKinshipValidation.toString());
         props.save();
 
         //unschedule in case settings have changed


### PR DESCRIPTION
#### Rationale
Not sure if this is due to a change in the kinship2 library, but the kinship2 kinship function requires pedigree in a specific order to properly calculate all kinships across a pedigree. This PR does some refactoring in populateKinship.r to use more kinship2 built-in functionality. Additionally, an optional step added to kinship calculations to do some broad validation of coefficients across demographic family queries.

- This update will require EHR users to upgrade the related R packages and add an additional R package, dplyr

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/575

#### Changes
* Update populateKinship.r to use kinship2 fixParents and pedigree functions to prepare data for kinship calc.
* Update populateInbreeding to only calculate inbreeding for passed in Ids from pedigree.sql
* Add optional setting to do extra kinship validation with genetic calculations
* Add extra kinship validation to verify against demographicsFamily, demographicsSiblings and demographicsOffspring
* Add demographicsSibling and demographicsOffspring queries to EHR
