### PR TITLE
Issue 349: Assignments Overlapping A Date Range does not match for project number

### DIFF
--- a/ehr/resources/queries/study/assignmentOverlapsById.sql
+++ b/ehr/resources/queries/study/assignmentOverlapsById.sql
@@ -20,7 +20,7 @@ FROM study.assignment a
 
 WHERE (
   -- Match on either project/protocol number or full display name, or skip the check if the user hasn't supplied a value
-  (a.project = PROJECT OR a.project.displayName = PROJECT OR PROJECT is null) AND
+  (CAST(a.project AS VARCHAR) = PROJECT OR a.project.displayName = PROJECT OR PROJECT is null) AND
   (a.project.protocol = PROTOCOL OR a.project.protocol.displayName = PROTOCOL OR PROTOCOL IS NULL OR PROTOCOL = '') AND
 
   (a.enddateCoalesced >= cast(StartDate as date)) AND

--- a/ehr/resources/queries/study/assignmentOverlapsById.sql
+++ b/ehr/resources/queries/study/assignmentOverlapsById.sql
@@ -19,8 +19,9 @@ count(*) as totalAssignments
 FROM study.assignment a
 
 WHERE (
-  (a.project.displayName = PROJECT OR PROJECT is null) AND
-  (a.project.protocol.displayName = PROTOCOL OR PROTOCOL IS NULL OR PROTOCOL = '') AND
+  -- Match on either project/protocol number or full display name, or skip the check if the user hasn't supplied a value
+  (a.project = PROJECT OR a.project.displayName = PROJECT OR PROJECT is null) AND
+  (a.project.protocol = PROTOCOL OR a.project.protocol.displayName = PROTOCOL OR PROTOCOL IS NULL OR PROTOCOL = '') AND
 
   (a.enddateCoalesced >= cast(StartDate as date)) AND
   (a.dateOnly <= cast(coalesce(EndDate, curdate()) as date))


### PR DESCRIPTION
#### Rationale
Different use cases have slightly different data available when building the parameters for this query. For a new use case, users can easily enter the project number but not the full display name. We can reuse the same query by supporting either value

#### Changes
* Match on either the full display name for projects and protocols, or just their numbers