### PR TITLE
Wait for EHR bulk edit dialog to load

### DIFF
--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -17,7 +17,6 @@ package org.labkey.test.util.ehr;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
@@ -34,6 +33,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.text.SimpleDateFormat;
@@ -225,8 +225,7 @@ public class EHRTestHelper
     public void toggleBulkEditField(String label)
     {
         Locator.XPathLocator l = Ext4Helper.Locators.window("Bulk Edit").append(Locator.tagContainingText("label", label + ":").withClass("x4-form-item-label"));
-        Assert.assertEquals("More than 1 matching element found, use a more specific xpath", 1, l.findElements(_test.getDriver()).size());
-        _test.click(l);
+        _test.shortWait().until(ExpectedConditions.numberOfElementsToBe(l, 1)).get(0).click();
         _test.waitForElement(l.enabled());
     }
 


### PR DESCRIPTION
#### Rationale
The EHR bulk edit dialog takes a moment to render.
![image](https://user-images.githubusercontent.com/5263798/214150187-71c9f551-458b-45bc-b381-f53f7488a0c1.png)
```
java.lang.AssertionError: More than 1 matching element found, use a more specific xpath expected:<1> but was:<0>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:647)
  at org.labkey.test.util.ehr.EHRTestHelper.toggleBulkEditField(EHRTestHelper.java:228)
  at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.fillBulkEditForm(WNPRC_EHRTest.java:687)
  at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.testBulkEditChargesWithoutAnimalIds(WNPRC_EHRTest.java:784)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait for bulk-edit toggle button to render
