### PR TITLE
Fix WNPRC test failures due to study.treatmentSchedule

### DIFF
--- a/ehr/resources/queries/study/treatmentSchedule.sql
+++ b/ehr/resources/queries/study/treatmentSchedule.sql
@@ -9,7 +9,7 @@ d.id,
 d.calculated_status,
 s.*,
 s.objectid as treatmentid,
-(SELECT max(d.qcstate) as label FROM study.drug d WHERE s.objectid = d.treatmentid AND s.date = d.timeordered) as treatmentStatus
+(SELECT max(d.qcstate) as label FROM study.drug d WHERE s.objectid = d.treatmentid AND s.date = IFDEFINED(d.timeordered)) as treatmentStatus
 --(SELECT max(taskId) as taskId FROM study.drug d WHERE s.objectid = d.treatmentid AND s.date = d.timeordered) as taskId
 
 

--- a/ehr/resources/queries/study/treatmentSchedule.sql
+++ b/ehr/resources/queries/study/treatmentSchedule.sql
@@ -48,7 +48,7 @@ SELECT
 
   CASE
     WHEN snomed.code IS NOT NULL THEN 'Diet'
-    ELSE ifdefined(t1.category)
+    ELSE IFDEFINED(t1.category)
   END as category,
   --t1.category,
 
@@ -71,7 +71,7 @@ SELECT
   t1.qualifier,
 
   t1.route,
-  t1.reason,
+  IFDEFINED(t1.reason) AS reason,
   t1.performedby,
   t1.remark,
 

--- a/ehr/resources/queries/study/treatmentSchedule.sql
+++ b/ehr/resources/queries/study/treatmentSchedule.sql
@@ -48,7 +48,7 @@ SELECT
 
   CASE
     WHEN snomed.code IS NOT NULL THEN 'Diet'
-    ELSE t1.category
+    ELSE ifdefined(t1.category)
   END as category,
   --t1.category,
 


### PR DESCRIPTION
#### Rationale
WNPRC's EHR datasets don't match with the expectations `study.treatmentSchedule` that was recently introduced into the core EHR module. This gets the tests passing again, but we should circle back before too long to sync their datasets with production and make sure the query belongs in the core EHR.

#### Changes
* Use `IFDEFINED()` to be tolerant of missing columns on datasets