### PR TITLE
Issue 47192: Clinical history date parsing

### DIFF
--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -108,7 +108,8 @@ Ext4.define('EHR.grid.Panel', {
         // on store validation complete as this covers initial load and adding new rows scenario. Also done on cell edit
         // for long text cells.
         var view = this.getView();
-        view.setHeight(view.body.getHeight());
+        if (view.body)
+            view.setHeight(view.body.getHeight());
     },
 
     handleSectionChangeEvent: function(sm, models){

--- a/ehr/resources/web/ehr/panel/ClinicalHistoryPanel.js
+++ b/ehr/resources/web/ehr/panel/ClinicalHistoryPanel.js
@@ -26,9 +26,9 @@ Ext4.define('EHR.panel.ClinicalHistoryPanel', {
         this.sortMode = this.sortMode || 'date';
 
         if (this.minDate && !Ext4.isDate(this.minDate))
-            this.minDate = LDK.ConvertUtils.parseDate(this.minDate);
+            this.minDate = LDK.ConvertUtils.parseDate(this.minDate, LABKEY.extDefaultDateFormat);
         if (this.maxDate && !Ext4.isDate(this.maxDate))
-            this.maxDate = LDK.ConvertUtils.parseDate(this.maxDate);
+            this.maxDate = LDK.ConvertUtils.parseDate(this.maxDate, LABKEY.extDefaultDateFormat);
 
         Ext4.apply(this, {
             border: false,


### PR DESCRIPTION
#### Rationale
When passing in min and max date to clinical history, such as when doing a print version, the date format parsing ignores the look and feel values set for the project. This can cause these dates to be ignored. This passes the project level date format to the parser.

Fix an error on some panel height resizing.

#### Changes
* Pass project date format to parser
* Ensure view.body is not undefined before getting height
