### PR TITLE
Additional template and script property functionality

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -211,6 +211,10 @@ abstract public class EHRService
 
     abstract public void registerDefaultFieldKeys(String schemaName, String queryName, List<FieldKey> keys);
 
+    abstract public void registerTriggerScriptOption(String name, Object value);
+
+    abstract public Map<String, Object> getTriggerScriptOptions();
+
     public enum FORM_SECTION_LOCATION
     {
         Header(),

--- a/ehr/resources/reports/reports.tsv
+++ b/ehr/resources/reports/reports.tsv
@@ -13,7 +13,7 @@ departure	General	query	Departures	true		study	departure			date	false	false		qcs
 currentBlood	Clinical	js	Current Blood	true		study	currentBlood			date	false	false		qcstate/publicdata	This report contains a summary of the current available blood for each animal
 bloodDraws	Clinical	query	Blood Draws	TRUE		study	blood			date	FALSE	FALSE		qcstate/publicdata	This report displays blood draw data for the selected animal
 biopsy	Clinical	query	Biopsies	TRUE		study	biopsy			date	FALSE	FALSE		qcstate/publicdata	This report displays biopsy data for the selected animal
-obs	Clinical	query	Observations	TRUE		study	obs			date	FALSE	FALSE		qcstate/publicdata	This report displays observations for the selected animal
+obs	Clinical	query	Observations	TRUE		study	clinical_observations			date	FALSE	FALSE		qcstate/publicdata	This report displays observations for the selected animal
 alopecia	Clinical	query	Alopecia Scores	TRUE		study	alopecia			date	FALSE	FALSE		qcstate/publicdata	This report contains the alopecia scores for the animal
 pairings	Colony Management	query	Pairings	TRUE		study	pairings			date	FALSE	FALSE		qcstate/publicdata	This report displays pairings for the selected animal
 breeder	Colony Management	query	Breeder	TRUE		study	breeder			date	FALSE	FALSE		qcstate/publicdata	This report displays breeding data for the selected animal

--- a/ehr/resources/scripts/ehr/ScriptHelper.js
+++ b/ehr/resources/scripts/ehr/ScriptHelper.js
@@ -112,6 +112,10 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
         extraDemographicsFieldMappings: {}
     };
 
+    // Load scriptOptions registered in the module
+    var moduleScriptOptions = props.javaHelper.getScriptOptions()
+    for (var opt in moduleScriptOptions) { scriptOptions[opt] = moduleScriptOptions[opt]; }
+
     var cachedValues = {
         liveBirths: {},
         deaths: {},

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -116,6 +116,7 @@ public class EHRServiceImpl extends EHRService
     private final Map<String, Map<String, List<ButtonConfigFactory>>> _tbarButtons = new CaseInsensitiveHashMap<>();
     private final Set<Module> _modulesRequiringLegacyExt3UI = new HashSet<>();
     private final Set<Module> _modulesRequiringFormEditUI = new HashSet<>();
+    private final Map<String, Object> _triggerScriptOptions = new CaseInsensitiveHashMap<>();
 
     private ProjectValidator _projectValidator = null;
 
@@ -561,6 +562,18 @@ public class EHRServiceImpl extends EHRService
     public ActionURL getDataEntryFormActionURL(Container c)
     {
         return new ActionURL(EHRController.DataEntryFormAction.class, c);
+    }
+
+    @Override
+    public void registerTriggerScriptOption(String name, Object value)
+    {
+        _triggerScriptOptions.put(name, value);
+    }
+
+    @Override
+    public Map<String, Object> getTriggerScriptOptions()
+    {
+        return _triggerScriptOptions;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -2697,4 +2697,9 @@ public class TriggerScriptHelper
 
         return date1.compareTo(date2);
     }
+
+    public Map<String, Object> getScriptOptions()
+    {
+        return EHRService.get().getTriggerScriptOptions();
+    }
 }

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -708,6 +708,11 @@ public class TriggerScriptHelper
 
     public void createHousingRecord(String id, Date date, @Nullable Date enddate, String room, @Nullable String cage, @Nullable String cond) throws QueryUpdateServiceException, DuplicateKeyException, SQLException, BatchValidationException
     {
+        createHousingRecord(id, date, enddate, room, cage, cond, null);
+    }
+
+    public void createHousingRecord(String id, Date date, @Nullable Date enddate, String room, @Nullable String cage, @Nullable String cond, @Nullable String taskId) throws QueryUpdateServiceException, DuplicateKeyException, SQLException, BatchValidationException
+    {
         if (id == null || date == null || room == null)
             return;
 
@@ -752,6 +757,9 @@ public class TriggerScriptHelper
 
         if (cage != null)
             row.put("cage", cage);
+
+        if (taskId != null)
+            row.put("taskId", taskId);
 
         List<Map<String, Object>> rows = new ArrayList<>();
         rows.add(row);


### PR DESCRIPTION
#### Rationale
Make it easier to update existing section and form templates by adding capability to overwrite an existing template through the UI (instead of just throwing unique constraint error). Add ability to register trigger script properties in the java module file.

#### Related Pull Requests
* https://github.com/LabKey/johnsHopkinsEHRModules/pull/44

#### Changes
* Add registration mechanism to register trigger script options in the module and getter in java trigger helper.
* Update ScriptHelper to apply registered script options.
* For both form and section templates, first check if the template name already exists for that form or section. If so, then confirm with user to overwrite it with the current form/section values. On yes, delete old template and insert new template. Other scenarios are the same behavior.
