### PR TITLE
Issue 47264: EHR Clinical History print page is cutting off bottom

### DIFF
--- a/ehr/resources/views/clinicalHistoryExport.html
+++ b/ehr/resources/views/clinicalHistoryExport.html
@@ -52,7 +52,8 @@
                     sortMode: LABKEY.ActionURL.getParameter('sortMode'),
                     checkedItems: LABKEY.ActionURL.getParameter('checkedItems') ? LABKEY.ActionURL.getParameter('checkedItems').split(';') : null,
                     hrefTarget: '_blank',
-                    style: 'margin-bottom: 20px;'
+                    style: 'margin-bottom: 20px;',
+                    printView: true
                 });
             }
             else {

--- a/ehr/resources/web/ehr/data/ClinicalHistoryStore.js
+++ b/ehr/resources/web/ehr/data/ClinicalHistoryStore.js
@@ -25,6 +25,10 @@ Ext4.define('EHR.data.ClinicalHistoryStore', {
         this.model.prototype.idProperty = 'idfield';
 
         this.changeMode(config.sortMode || 'date');
+
+        if (this.onDataUpdate){
+            this.on('datachanged', this.onDataUpdate, this);
+        }
     },
 
     /**

--- a/ehr/resources/web/ehr/panel/ClinicalHistoryPanel.js
+++ b/ehr/resources/web/ehr/panel/ClinicalHistoryPanel.js
@@ -22,6 +22,8 @@ Ext4.define('EHR.panel.ClinicalHistoryPanel', {
 
     showMaxDate: false,
 
+    printView: false,  // Height adjustment when in print view
+
     initComponent: function(){
         this.sortMode = this.sortMode || 'date';
 
@@ -246,11 +248,18 @@ Ext4.define('EHR.panel.ClinicalHistoryPanel', {
     },
 
     getStoreConfig: function(){
+        var me = this;
         return {
             type: 'ehr-clinicalhistorystore',
             containerPath: this.containerPath,
             redacted: this.redacted,
-            sortMode: this.sortMode
+            sortMode: this.sortMode,
+            onDataUpdate: function(store) {
+                var grid = me.down('grid');
+                var panel = me.up('panel');
+                if (me.printView && !store.isLoading() && grid && panel)
+                    grid.setHeight(panel.getHeight() * 1.05);
+            }
         };
     },
 

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
@@ -93,6 +93,8 @@ public class GeneticCalculationsRunnable
                 return;
             }
 
+            protocol.setTimestampLog(true);
+
             File fileParameters = protocol.getParametersFile(root.getRootPath(), root);
             if (!fileParameters.exists())
             {


### PR DESCRIPTION
#### Rationale
When printing clinical history the bottom rows are being cutoff. This adds an extra 5% height to the clinical history height when in print mode.

Also adding timestamp logging for EHR kinship/inbreeding job for better tracking of issues.

#### Changes
* When clinical history store is loaded add another 5% of height beyond what the panel height is.
* Set timestamp logging on genetic calculations.
