### PR TITLE
Fix WNPRC_PurchasingTest.testEmailCustomizationLineItemUpdate

### DIFF
--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
@@ -1,38 +1,18 @@
 package org.labkey.ehr_purchasing;
 
-import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.query.FieldKey;
 import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.SimpleQueryUpdateService;
-import org.labkey.api.security.User;
-import org.labkey.api.security.permissions.UpdatePermission;
 
 public class EHR_PurchasingTable extends SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema>
 {
-    public EHR_PurchasingTable(EHR_PurchasingUserSchema schema, TableInfo table, ContainerFilter cf, boolean needUpdatePerm)
-    {
-        super(schema, table, cf);
-
-//        if (needUpdatePerm && !schema.getContainer().hasPermission(schema.getUser(), UpdatePermission.class))
-//        {
-//            //Non-updaters can only see rows created by them
-//            SimpleFilter filter = SimpleFilter.createContainerFilter(schema.getContainer());
-//            filter.addCondition(FieldKey.fromString("createdBy"), table.getUserSchema().getUser());
-//            addCondition(filter);
-//        }
-
-    }
-
     public EHR_PurchasingTable(EHR_PurchasingUserSchema schema, TableInfo table, ContainerFilter cf)
     {
-        this(schema, table, cf, false);
+        super(schema, table, cf);
     }
-
 
     @Override
     public QueryUpdateService getUpdateService()

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
@@ -4,6 +4,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
+import org.labkey.api.query.FieldKey;
 import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
@@ -26,6 +26,8 @@ public class EHR_PurchasingTable extends SimpleUserSchema.SimpleTable<EHR_Purcha
                     @Override
                     protected boolean supportUpdateUsingDIB()
                     {
+                        // ehr_purchasing.purchasingRequests has a custom query definition in wnprc_purchusing that adds special calculated columns.
+                        // The email notifications sent are dependent on those calculated columns, which aren't returned by updateRows using data iterator / prepared statement
                         return false;
                     }
                 };

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
@@ -27,6 +27,11 @@ public class EHR_PurchasingTable extends SimpleUserSchema.SimpleTable<EHR_Purcha
 
     }
 
+    public EHR_PurchasingTable(EHR_PurchasingUserSchema schema, TableInfo table, ContainerFilter cf)
+    {
+        this(schema, table, cf, false);
+    }
+
 
     @Override
     public QueryUpdateService getUpdateService()

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
@@ -17,7 +17,6 @@ public class EHR_PurchasingTable extends SimpleUserSchema.SimpleTable<EHR_Purcha
     @Override
     public QueryUpdateService getUpdateService()
     {
-        // UNDONE: add an 'isUserEditable' bit to the schema and table?
         if (!isReadOnly())
         {
             TableInfo table = getRealTable();

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
@@ -18,13 +18,13 @@ public class EHR_PurchasingTable extends SimpleUserSchema.SimpleTable<EHR_Purcha
     {
         super(schema, table, cf);
 
-        if (needUpdatePerm && !schema.getContainer().hasPermission(schema.getUser(), UpdatePermission.class))
-        {
-            //Non-updaters can only see rows created by them
-            SimpleFilter filter = SimpleFilter.createContainerFilter(schema.getContainer());
-            filter.addCondition(FieldKey.fromString("createdBy"), table.getUserSchema().getUser());
-            addCondition(filter);
-        }
+//        if (needUpdatePerm && !schema.getContainer().hasPermission(schema.getUser(), UpdatePermission.class))
+//        {
+//            //Non-updaters can only see rows created by them
+//            SimpleFilter filter = SimpleFilter.createContainerFilter(schema.getContainer());
+//            filter.addCondition(FieldKey.fromString("createdBy"), table.getUserSchema().getUser());
+//            addCondition(filter);
+//        }
 
     }
 

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingTable.java
@@ -1,0 +1,50 @@
+package org.labkey.ehr_purchasing;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.data.ContainerFilter;
+import org.labkey.api.data.SimpleFilter;
+import org.labkey.api.data.TableInfo;
+import org.labkey.api.data.DatabaseTableType;
+import org.labkey.api.query.QueryUpdateService;
+import org.labkey.api.query.SimpleUserSchema;
+import org.labkey.api.query.SimpleQueryUpdateService;
+import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.UpdatePermission;
+
+public class EHR_PurchasingTable extends SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema>
+{
+    public EHR_PurchasingTable(EHR_PurchasingUserSchema schema, TableInfo table, ContainerFilter cf, boolean needUpdatePerm)
+    {
+        super(schema, table, cf);
+
+        if (needUpdatePerm && !schema.getContainer().hasPermission(schema.getUser(), UpdatePermission.class))
+        {
+            //Non-updaters can only see rows created by them
+            SimpleFilter filter = SimpleFilter.createContainerFilter(schema.getContainer());
+            filter.addCondition(FieldKey.fromString("createdBy"), table.getUserSchema().getUser());
+            addCondition(filter);
+        }
+
+    }
+
+
+    @Override
+    public QueryUpdateService getUpdateService()
+    {
+        // UNDONE: add an 'isUserEditable' bit to the schema and table?
+        if (!isReadOnly())
+        {
+            TableInfo table = getRealTable();
+            if (table != null && table.getTableType() == DatabaseTableType.TABLE)
+                return new SimpleQueryUpdateService(this, table)
+                {
+                    @Override
+                    protected boolean supportUpdateUsingDIB()
+                    {
+                        return false;
+                    }
+                };
+        }
+        return null;
+    }
+}

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
@@ -82,7 +82,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                TableInfo table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf).init();
+                SimpleTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf).init();
                 return getPermissionFilteredTable(table);
             }
         },
@@ -91,14 +91,14 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                TableInfo table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf).init();
+                SimpleTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf).init();
                 return getPermissionFilteredTable(table);
             }
         };
 
         public abstract TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf);
 
-        private static TableInfo getPermissionFilteredTable(TableInfo table)
+        private static TableInfo getPermissionFilteredTable(SimpleTable table)
         {
             //Updaters can see all the rows
             if (table.getContainer().hasPermission(table.getUserSchema().getUser(), UpdatePermission.class))

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
@@ -42,11 +42,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema> table =
-                        new SimpleUserSchema.SimpleTable<>(
-                                schema, EHR_PurchasingSchema.getInstance().getVendorTable(), cf).init();
-
-                return table;
+                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getVendorTable(), cf).init();
             }
         },
         shippingInfo
@@ -54,11 +50,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema> table =
-                        new SimpleUserSchema.SimpleTable<>(
-                                schema, EHR_PurchasingSchema.getInstance().getShippingInfoTable(), cf).init();
-
-                return table;
+                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getShippingInfoTable(), cf).init();
             }
         },
         units
@@ -66,10 +58,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema> table =
-                        new SimpleUserSchema.SimpleTable<>(
-                                schema, EHR_PurchasingSchema.getInstance().getItemUnitsTable(), cf).init();
-                return table;
+                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getItemUnitsTable(), cf).init();
             }
         },
         userAccountAssociations
@@ -77,10 +66,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema> table =
-                        new SimpleUserSchema.SimpleTable<>(
-                                schema, EHR_PurchasingSchema.getInstance().getUserAccountAssociationsTable(), cf).init();
-                return table;
+                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getUserAccountAssociationsTable(), cf).init();
             }
         },
         lineItemStatus
@@ -88,10 +74,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema> table =
-                        new SimpleUserSchema.SimpleTable<>(
-                                schema, EHR_PurchasingSchema.getInstance().getLineItemStatusTable(), cf).init();
-                return table;
+                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemStatusTable(), cf).init();
             }
         },
         lineItems
@@ -99,11 +82,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema> table =
-                        new SimpleUserSchema.SimpleTable<>(
-                                schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf).init();
-
-                return getPermissionFilteredTable(table);
+                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf, true).init();
             }
         },
         purchasingRequests
@@ -111,28 +90,11 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                SimpleUserSchema.SimpleTable<EHR_PurchasingUserSchema> table =
-                        new SimpleUserSchema.SimpleTable<>(
-                                schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf).init();
-
-                return getPermissionFilteredTable(table);
+                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf, true).init();
             }
         };
 
         public abstract TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf);
-
-        private static SimpleTable<EHR_PurchasingUserSchema> getPermissionFilteredTable(SimpleTable<EHR_PurchasingUserSchema> table)
-        {
-            //Updaters can see all the rows
-            if (table.getContainer().hasPermission(table.getUserSchema().getUser(), UpdatePermission.class))
-                return table;
-
-            //Non-updaters can only see rows created by them
-            SimpleFilter filter = SimpleFilter.createContainerFilter(table.getContainer());
-            filter.addCondition(FieldKey.fromString("createdBy"), table.getUserSchema().getUser());
-            table.addCondition(filter);
-            return table;
-        }
     }
 
     @Override

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
@@ -82,7 +82,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf, true).init();
+                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf).init();
                 return getPermissionFilteredTable(table);
             }
         },
@@ -91,7 +91,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf, true).init();
+                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf).init();
                 return getPermissionFilteredTable(table);
             }
         };

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
@@ -82,7 +82,8 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf, true).init();
+                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf, true).init();
+                return getPermissionFilteredTable(table);
             }
         },
         purchasingRequests
@@ -90,11 +91,26 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                return new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf, true).init();
+                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf, true).init();
+                return getPermissionFilteredTable(table);
             }
         };
 
         public abstract TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf);
+
+        private static EHR_PurchasingTable getPermissionFilteredTable(EHR_PurchasingTable table)
+        {
+            //Updaters can see all the rows
+            if (table.getContainer().hasPermission(table.getUserSchema().getUser(), UpdatePermission.class))
+                return table;
+
+            //Non-updaters can only see rows created by them
+            SimpleFilter filter = SimpleFilter.createContainerFilter(table.getContainer());
+            filter.addCondition(FieldKey.fromString("createdBy"), table.getUserSchema().getUser());
+            table.addCondition(filter);
+            return table;
+        }
+
     }
 
     @Override

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingUserSchema.java
@@ -82,7 +82,7 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf).init();
+                TableInfo table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getLineItemsTable(), cf).init();
                 return getPermissionFilteredTable(table);
             }
         },
@@ -91,14 +91,14 @@ public class EHR_PurchasingUserSchema extends SimpleUserSchema
             @Override
             public TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf)
             {
-                EHR_PurchasingTable table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf).init();
+                TableInfo table = new EHR_PurchasingTable(schema, EHR_PurchasingSchema.getInstance().getPurchasingRequestsTable(), cf).init();
                 return getPermissionFilteredTable(table);
             }
         };
 
         public abstract TableInfo createTable(EHR_PurchasingUserSchema schema, ContainerFilter cf);
 
-        private static EHR_PurchasingTable getPermissionFilteredTable(EHR_PurchasingTable table)
+        private static TableInfo getPermissionFilteredTable(TableInfo table)
         {
             //Updaters can see all the rows
             if (table.getContainer().hasPermission(table.getUserSchema().getUser(), UpdatePermission.class))

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -1284,7 +1284,10 @@ public class EHRManager
 
                 if (!requestsToQueue.isEmpty())
                 {
-                    ti.getUpdateService().updateRows(u, c, requestsToQueue, requestsToQueue, null, new HashMap<>());
+                    BatchValidationException batchValidationException = new BatchValidationException();
+                    ti.getUpdateService().updateRows(u, c, requestsToQueue, requestsToQueue, batchValidationException, null, new HashMap<>());
+                    if (batchValidationException.hasErrors())
+                        throw batchValidationException;
                 }
             }
             catch (InvalidKeyException | QueryUpdateServiceException | BatchValidationException e)
@@ -1514,7 +1517,12 @@ public class EHRManager
         try
         {
             if (rows.size() > 0)
-                flagsTable.getUpdateService().updateRows(u, flagsTable.getUserSchema().getContainer(), rows, oldKeys, null, getExtraContext());
+            {
+                BatchValidationException batchValidationException = new BatchValidationException();
+                flagsTable.getUpdateService().updateRows(u, flagsTable.getUserSchema().getContainer(), rows, oldKeys, batchValidationException, null, getExtraContext());
+                if (batchValidationException.hasErrors())
+                    throw batchValidationException;
+            }
 
             return distinctIds;
         }

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -910,7 +910,10 @@ public class TriggerScriptHelper
 
         if (!newRows.isEmpty())
         {
-            ti.getUpdateService().updateRows(getUser(), getContainer(), newRows, keyRows, null, getExtraContext());
+            BatchValidationException batchValidationException = new BatchValidationException();
+            ti.getUpdateService().updateRows(getUser(), getContainer(), newRows, keyRows, batchValidationException, null, getExtraContext());
+            if (batchValidationException.hasErrors())
+                throw batchValidationException;
             // Prime the cache for the updated IDs
             EHRDemographicsService.get().getAnimals(getContainer(), ids);
         }
@@ -1724,7 +1727,11 @@ public class TriggerScriptHelper
         if (!rows.isEmpty())
         {
             TableInfo ti = getTableInfo("study", "Demographics");
-            ti.getUpdateService().updateRows(getUser(), getContainer(), rows, rows, null, getExtraContext());
+
+            BatchValidationException batchValidationException = new BatchValidationException();
+            ti.getUpdateService().updateRows(getUser(), getContainer(), rows, rows, batchValidationException, null, getExtraContext());
+            if (batchValidationException.hasErrors())
+                throw batchValidationException;
             EHRDemographicsServiceImpl.get().getAnimals(getContainer(), ids);
         }
         else
@@ -2477,7 +2484,10 @@ public class TriggerScriptHelper
             _log.info("closing housing records: " + toUpdate.size());
             Map<String, Object> context = getExtraContext();
             context.put("skipAnnounceChangedParticipants", true);
-            housing.getUpdateService().updateRows(getUser(), getContainer(), toUpdate, oldKeys, null, context);
+            BatchValidationException batchValidationException = new BatchValidationException();
+            housing.getUpdateService().updateRows(getUser(), getContainer(), toUpdate, oldKeys, batchValidationException, null, context);
+            if (batchValidationException.hasErrors())
+                throw batchValidationException;
         }
     }
 
@@ -2560,7 +2570,10 @@ public class TriggerScriptHelper
                 {
                     Map<String, Object> extraContext = getExtraContext();
                     extraContext.put("skipAnnounceChangedParticipants", true);
-                    qus.updateRows(getUser(), flagsTable.getUserSchema().getContainer(), rows, oldKeys, null, extraContext);
+                    BatchValidationException batchValidationException = new BatchValidationException();
+                    qus.updateRows(getUser(), flagsTable.getUserSchema().getContainer(), rows, oldKeys, batchValidationException, null, extraContext);
+                    if (batchValidationException.hasErrors())
+                        throw batchValidationException;
                 }
             }
             catch (InvalidKeyException e)


### PR DESCRIPTION
#### Rationale
ehr_purchasing.purchasingRequests has a custom query definition in wnprc_purchusing that adds special calculated columns. The email notifications sent are dependent on those calculated columns, which aren't returned by updateRows using prepared statement. This PR flag all ehr_purchasing tables to use the old row-by-row updates, instead of prepared statement.

TC failure:
https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_EhrPostgres/2274993?buildTab=tests&status=failed

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/529
* https://github.com/LabKey/wnprc-modules/pull/251

#### Changes
* update updateRows parameters to match updated signature
* don't use data iterator to update ehr_purchasing tables
