### PR TITLE
Populate EHR Lookups alternate manifest

### DIFF
--- a/ehr/resources/queries/auditLog/DemographicsDeleted.sql
+++ b/ehr/resources/queries/auditLog/DemographicsDeleted.sql
@@ -1,10 +1,10 @@
 SELECT
-    Date,
-    substring(DataChanges, IdStart, CAST(LOCATE('&', DataChanges, LOCATE('&Id=', DataChanges) + 1) - IdStart AS INTEGER)) as Id
+    a.Date,
+    substring(a.DataChanges, a.IdStart, CAST(LOCATE('&', a.DataChanges, LOCATE('&Id=', a.DataChanges) + 1) - a.IdStart AS INTEGER)) as Id
 FROM (
     SELECT Date,
     DataChanges,
     LOCATE('&Id=', DataChanges) + LENGTH('&Id=') as IdStart
     FROM DatasetAuditEvent
     WHERE DatasetId.Name = 'demographics' AND Comment = 'A dataset record was deleted'
-    )
+    ) a

--- a/ehr/resources/views/populateLookupData.html
+++ b/ehr/resources/views/populateLookupData.html
@@ -28,6 +28,8 @@
     }
 
     function populateLookups(isDelete) {
+        const manifest = LABKEY.ActionURL.getParameter('manifest');
+
         const container = "<%=containerPath%>";
         let result;
         if (isDelete) {
@@ -43,7 +45,8 @@
                 url: LABKEY.ActionURL.buildURL("ehr", "populateLookups", container),
                 method: 'POST',
                 jsonData: {
-                    delete: isDelete
+                    delete: isDelete,
+                    manifest: manifest || null
                 },
                 timeout: 100000,
                 success: LABKEY.Utils.getCallbackWrapper((response) => {
@@ -68,6 +71,6 @@
         </b></h5>
     </div>
     <div>
-        <textarea class="form-control" id="populateLookupResults" rows="20"></textarea>
+        <textarea class="form-control" id="populateLookupResults" name="populateLookupResults" rows="20"></textarea>
     </div>
 </html>

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1290,6 +1290,7 @@ public class EHRController extends SpringActionController
     public static class PopulateLookupsForm
     {
         private boolean _delete;
+        private String _manifest;
 
         public boolean isDelete()
         {
@@ -1300,12 +1301,24 @@ public class EHRController extends SpringActionController
         {
             _delete = delete;
         }
+
+        public String getManifest()
+        {
+            return _manifest;
+        }
+
+        public void setManifest(String manifest)
+        {
+            _manifest = manifest;
+        }
     }
 
     @RequiresPermission(AdminPermission.class)
     public class PopulateLookupsAction extends MutatingApiAction<PopulateLookupsForm>
     {
-        private final String _manifestPath = "data/lookupsManifest.tsv";
+        private final String _manifestDirectory = "data/";
+        private final String _manifestDefault = "lookupsManifest";
+        private final String _manifestFileExt = ".tsv";
         private final String _lookupSetsPath = "data/lookup_sets.tsv";
         private Resource _lookupsManifest;
         private Resource _lookupSets;
@@ -1330,7 +1343,14 @@ public class EHRController extends SpringActionController
                     _lookupsManifestModule = ModuleLoader.getInstance().getModule(mp.getEffectiveValue(getContainer()));
                     if (null != _lookupsManifestModule)
                     {
-                        _lookupsManifest = _lookupsManifestModule.getModuleResource(_manifestPath);
+                        if (form.getManifest() != null)
+                        {
+                            _lookupsManifest = _lookupsManifestModule.getModuleResource(_manifestDirectory + form.getManifest() + _manifestFileExt);
+                        }
+                        else
+                        {
+                            _lookupsManifest = _lookupsManifestModule.getModuleResource(_manifestDirectory + _manifestDefault + _manifestFileExt);
+                        }
                         _lookupSets = _lookupsManifestModule.getModuleResource(_lookupSetsPath);
                     }
                 }
@@ -1342,7 +1362,14 @@ public class EHRController extends SpringActionController
 
                 if (_lookupsManifest == null || !_lookupsManifest.exists() || _lookupSets == null || !_lookupSets.exists())
                 {
-                    _lookupsManifest = ehrModule.getModuleResource(_manifestPath);
+                    if (form.getManifest() != null)
+                    {
+                        _lookupsManifest = _lookupsManifestModule.getModuleResource(_manifestDirectory + form.getManifest() + _manifestFileExt);
+                    }
+                    else
+                    {
+                        _lookupsManifest = _lookupsManifestModule.getModuleResource(_manifestDirectory + _manifestDefault + _manifestFileExt);
+                    }
                     _lookupSets = ehrModule.getModuleResource(_lookupSetsPath);
                     _lookupsManifestModule = ehrModule;
                 }

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -401,8 +401,9 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
 
         doExtraPreStudyImportSetup();
 
-        populateInitialData();
         defineQCStates();
+        populateInitialData();
+
         // Do this first to establish the QC states before importing
         importStudy();
         disableMiniProfiler();

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -401,6 +401,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
 
         doExtraPreStudyImportSetup();
 
+        // QC States added before populating data where they may be needed
         defineQCStates();
         populateInitialData();
 


### PR DESCRIPTION
#### Rationale
Update loading ehr lookups API to allow passing in a different (test) manifest to separate setting up a project from scratch (test) vs updating lookups in an existing EHR project. Setup lookups manifest URL parameter on populate lookups for testing. Minor tweaks for testing.

#### Related Pull Requests
* https://github.com/LabKey/johnsHopkinsEHRModules/pull/51

#### Changes
* Update PopulateLookupsAction as described above.
* Pass manifest to PopulateLookupsAction in UI if defined as URL parameter
* Tweaks for testing and query validation
