### PR TITLE
Backport `EHRTestHelper.toggleBulkEditField` race fix

### DIFF
--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -17,7 +17,6 @@ package org.labkey.test.util.ehr;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.Connection;
@@ -44,6 +43,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.io.IOException;
@@ -273,9 +273,7 @@ public class EHRTestHelper
     public void toggleBulkEditField(String label)
     {
         Locator.XPathLocator l = Ext4Helper.Locators.window("Bulk Edit").append(Locator.tagContainingText("label", label + ":").withClass("x4-form-item-label"));
-        _test.assertElementPresent(l);
-        Assert.assertEquals("More than 1 matching element found, use a more specific xpath", 1, _test.getElementCount(l));
-        _test.click(l);
+        _test.shortWait().until(ExpectedConditions.numberOfElementsToBe(l, 1)).get(0).click();
         _test.waitForElement(l.enabled());
     }
 


### PR DESCRIPTION
#### Rationale
This failure is regularly occurring in 22.7 and 22.11:
```
java.lang.AssertionError: More than 1 matching element found, use a more specific xpath expected:<1> but was:<0>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:647)
  at org.labkey.test.util.ehr.EHRTestHelper.toggleBulkEditField(EHRTestHelper.java:228)
  at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.fillBulkEditForm(WNPRC_EHRTest.java:687)
  at org.labkey.test.tests.wnprc_ehr.WNPRC_EHRTest.testBulkEditChargesWithoutAnimalIds(WNPRC_EHRTest.java:784)
```
WNPRC is still active in those releases, so backporting this fix will clean up TeamCity a bit.

#### Related Pull Requests
* #511 

#### Changes
* Backport `EHRTestHelper.toggleBulkEditField` race fix
