### PR TITLE
Issue 47264: Clinical history overflow cutoff when printing

### DIFF
--- a/ehr/resources/views/clinicalHistoryExport.html
+++ b/ehr/resources/views/clinicalHistoryExport.html
@@ -52,8 +52,7 @@
                     sortMode: LABKEY.ActionURL.getParameter('sortMode'),
                     checkedItems: LABKEY.ActionURL.getParameter('checkedItems') ? LABKEY.ActionURL.getParameter('checkedItems').split(';') : null,
                     hrefTarget: '_blank',
-                    style: 'margin-bottom: 20px;',
-                    printView: true
+                    style: 'margin-bottom: 20px;'
                 });
             }
             else {
@@ -75,6 +74,8 @@
         Ext4.create('Ext.panel.Panel', {
             border: false,
             style: 'width: 8in;',
+            cls: 'clinical-history-print',
+            bodyCls: 'clinical-history-print',
             items: toAdd
         }).render(webpart.wrapperDivId);
     });

--- a/ehr/resources/web/ehr/data/ClinicalHistoryStore.js
+++ b/ehr/resources/web/ehr/data/ClinicalHistoryStore.js
@@ -25,10 +25,6 @@ Ext4.define('EHR.data.ClinicalHistoryStore', {
         this.model.prototype.idProperty = 'idfield';
 
         this.changeMode(config.sortMode || 'date');
-
-        if (this.onDataUpdate){
-            this.on('datachanged', this.onDataUpdate, this);
-        }
     },
 
     /**

--- a/ehr/resources/web/ehr/panel/ClinicalHistoryPanel.js
+++ b/ehr/resources/web/ehr/panel/ClinicalHistoryPanel.js
@@ -22,8 +22,6 @@ Ext4.define('EHR.panel.ClinicalHistoryPanel', {
 
     showMaxDate: false,
 
-    printView: false,  // Height adjustment when in print view
-
     initComponent: function(){
         this.sortMode = this.sortMode || 'date';
 
@@ -253,13 +251,7 @@ Ext4.define('EHR.panel.ClinicalHistoryPanel', {
             type: 'ehr-clinicalhistorystore',
             containerPath: this.containerPath,
             redacted: this.redacted,
-            sortMode: this.sortMode,
-            onDataUpdate: function(store) {
-                var grid = me.down('grid');
-                var panel = me.up('panel');
-                if (me.printView && !store.isLoading() && grid && panel)
-                    grid.setHeight(panel.getHeight() * 1.05);
-            }
+            sortMode: this.sortMode
         };
     },
 

--- a/ehr/resources/web/ehr/stylesheet.css
+++ b/ehr/resources/web/ehr/stylesheet.css
@@ -200,3 +200,19 @@ a:hover .ehr-tool-icon-lg {
 .x-status-error-list li a {
     color: #15428B;
 }
+
+.x4-panel.clinical-history-print {
+    overflow: visible !important;
+}
+
+.x4-panel-body.clinical-history-print {
+    overflow: visible !important;
+}
+
+.clinical-history-print .x4-panel{
+    overflow: visible !important;
+}
+
+.clinical-history-print .x4-panel-body{
+    overflow: visible !important;
+}


### PR DESCRIPTION
#### Rationale
This is a better fix then adjusting height (previous fix attempt). This ensure overflow is visible when printing clinical history.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/525

#### Changes
* Back out changes from first fix attempt
* Add new CSS rules to ensure overflow is visible in ext4 panels
* Apply CSS class in export clinical history page
