### PR TITLE
Add parents to animal record in core EHR

### DIFF
--- a/ehr/resources/queries/study/demographicsParents.query.xml
+++ b/ehr/resources/queries/study/demographicsParents.query.xml
@@ -1,0 +1,31 @@
+<query xmlns="http://labkey.org/data/xml/query">
+    <metadata>
+        <tables xmlns="http://labkey.org/data/xml">
+            <table tableName="demographicsParents" tableDbType="NOT_IN_DB">
+                <tableTitle>Parents</tableTitle>
+                <columns>
+                    <column columnName="Id">
+                        <isHidden>true</isHidden>
+                    </column>
+                    <column columnName="dam">
+                        <fk>
+                            <fkDbSchema>study</fkDbSchema>
+                            <fkTable>animal</fkTable>
+                            <fkColumnName>id</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="sire">
+                        <fk>
+                            <fkDbSchema>study</fkDbSchema>
+                            <fkTable>animal</fkTable>
+                            <fkColumnName>id</fkColumnName>
+                        </fk>
+                    </column>
+                    <column columnName="numParents">
+                        <columnTitle>Number of Parents Known</columnTitle>
+                    </column>
+                </columns>
+            </table>
+        </tables>
+    </metadata>
+</query>

--- a/ehr/resources/queries/study/demographicsParents.sql
+++ b/ehr/resources/queries/study/demographicsParents.sql
@@ -26,7 +26,7 @@ SELECT
         END as numParents
 FROM study.demographics d
 
-UNION
+UNION ALL
 
 SELECT
     s.Id,

--- a/ehr/resources/queries/study/demographicsParents.sql
+++ b/ehr/resources/queries/study/demographicsParents.sql
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+SELECT
+    d.id,
+    d.dam as dam,
+    'Observed' as damType,
+    d.sire as sire,
+    'Observed' as sireType,
+    CASE
+        WHEN d.dam IS NOT NULL AND d.sire IS NOT NULL THEN 2
+        WHEN d.dam IS NOT NULL OR d.sire IS NOT NULL THEN 1
+        ELSE 0
+        END as numParents
+FROM study.demographics d
+

--- a/ehr/resources/queries/study/demographicsParents.sql
+++ b/ehr/resources/queries/study/demographicsParents.sql
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 SELECT
-    d.id,
-    d.dam as dam,
+    d.Id,
+    d.dam,
     'Observed' as damType,
-    d.sire as sire,
+    d.sire,
     'Observed' as sireType,
     CASE
         WHEN d.dam IS NOT NULL AND d.sire IS NOT NULL THEN 2
@@ -25,4 +25,19 @@ SELECT
         ELSE 0
         END as numParents
 FROM study.demographics d
+
+UNION
+
+SELECT
+    s.Id,
+    s.dam,
+    'Observed' as damType,
+    s.sire,
+    'Observed' as sireType,
+    CASE
+        WHEN s.dam IS NOT NULL AND s.sire IS NOT NULL THEN 2
+        WHEN s.dam IS NOT NULL OR s.sire IS NOT NULL THEN 1
+        ELSE 0
+        END as numParents
+FROM ehr.supplemental_pedigree s
 

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -1124,6 +1124,13 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
             return;
         }
 
+        if (ds.getColumn("parents") == null)
+        {
+            var col = getWrappedCol(us, ds, "Parents", "demographicsParents", "Id", "Id");
+            col.setLabel("Parents");
+            ds.addColumn(col);
+        }
+
         if (ds.getColumn("activeAnimalGroups") == null && -1 != StudyService.get().getDatasetIdByName( ds.getUserSchema().getContainer(), "animal_group_members"))
         {
             var col21 = getWrappedIdCol(us, ds, "activeAnimalGroups", "demographicsActiveAnimalGroups");


### PR DESCRIPTION
#### Rationale
Make demographicsParents query part of core EHR and add it to the animal record in core EHR. Most centers have demographicsParents already overwritten and are adding it as Parents to the animal record. This adds a base version of demographicsParents and will add it to the animal record if not already done so by the center. Includes supplemental pedigree.  

#### Changes
* demographicsParents query
* Add Parents to Animal table in DefaultEHRCustomizer
