### PR TITLE
EHR Lookups form updates and automatically close records 

### DIFF
--- a/ehr/resources/queries/ehr_lookups/editable_lookups.query.xml
+++ b/ehr/resources/queries/ehr_lookups/editable_lookups.query.xml
@@ -3,11 +3,6 @@
         <tables xmlns="http://labkey.org/data/xml">
             <table tableName="editable_lookups" tableDbType="TABLE">
                 <javaCustomizer class="org.labkey.ehr.table.DefaultEHRCustomizer" />
-                <columns>
-                    <column columnName="value">
-                        <columnTitle>Table</columnTitle>
-                    </column>
-                </columns>
             </table>
         </tables>
     </metadata>

--- a/ehr/resources/queries/ehr_lookups/editable_lookups/.qview.xml
+++ b/ehr/resources/queries/ehr_lookups/editable_lookups/.qview.xml
@@ -1,11 +1,10 @@
 <customView xmlns="http://labkey.org/data/xml/queryCustomView">
     <columns>
-        <column name="edit"/>
-        <column name="value"/>
+        <column name="title"/>
         <column name="category"/>
+        <column name="description"/>
     </columns>
     <sorts>
-        <sort column="category" descending="false"/>
-        <sort column="value" descending="false"/>
+        <sort column="title" descending="false"/>
     </sorts>
 </customView>

--- a/ehr/resources/queries/study/housing.js
+++ b/ehr/resources/queries/study/housing.js
@@ -111,24 +111,5 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
 });
 
 function onComplete(event, errors, helper){
-    if (!helper.isETL() && !helper.isValidateOnly()){
-        var housingRows = helper.getRows();
-        var idsToClose = [];
-        if (housingRows){
-            for (var i=0;i<housingRows.length;i++){
-                if (EHR.Server.Security.getQCStateByLabel(housingRows[i].row.QCStateLabel).PublicData && housingRows[i].row.date){
-                    idsToClose.push({
-                        Id: housingRows[i].row.Id,
-                        date: EHR.Server.Utils.datetimeToString(housingRows[i].row.date),  //stringify to serialize properly
-                        objectid: housingRows[i].row.objectid
-                    });
-                }
-            }
-        }
-
-        if (idsToClose.length){
-            //NOTE: this list should be limited to 1 row per animalId
-            helper.getJavaHelper().closeHousingRecords(idsToClose);
-        }
-    }
+    helper.closeRecordsOnComplete();
 }

--- a/ehr/resources/queries/study/housing.js
+++ b/ehr/resources/queries/study/housing.js
@@ -111,5 +111,5 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
 });
 
 function onComplete(event, errors, helper){
-    helper.closeRecordsOnComplete();
+    helper.closeRecordsOnComplete(false);
 }

--- a/ehr/resources/scripts/ehr/ScriptHelper.js
+++ b/ehr/resources/scripts/ehr/ScriptHelper.js
@@ -688,7 +688,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
             }
         },
 
-        closeRecordsOnComplete: function(){
+        closeRecordsOnComplete: function(publicData){
             if (!this.isValidateOnly() && !this.isETL() && !this.skipClosingRecords()){
                 console.log("closing records");
                 var rows = this.getRows();
@@ -707,7 +707,7 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
 
                 if (idsToClose.length){
                     //NOTE: this list should be limited to 1 row per animalId
-                    this.getJavaHelper().closePreviousDatasetRecords(this.getQueryName(), idsToClose, this.shouldRemoveTimeFromDate());
+                    this.getJavaHelper().closePreviousDatasetRecords(this.getQueryName(), idsToClose, this.shouldRemoveTimeFromDate(), publicData);
                 }
             }
         }

--- a/ehr/resources/scripts/ehr/ScriptHelper.js
+++ b/ehr/resources/scripts/ehr/ScriptHelper.js
@@ -609,22 +609,6 @@ EHR.Server.ScriptHelper = function(extraContext, event, EHR){
             }
         },
 
-        /**
-         * Some datasets will only have one active record per animal at a time. This is a helper function to close out
-         * old records for an animal in that dataset before entering a new record for that animal.
-         * @param participant The Id of the participant
-         * @param date The date of the event.
-         */
-        onClosePreviousRecords: function(dataset, id, date){
-            var changedTables = this.getJavaHelper().closeActiveDatasetRecords([dataset], id, date);
-            if (changedTables){
-                changedTables = changedTables.split(';');
-                for (var i=0;i<changedTables.length;i++){
-                    this.addTableModified('study', changedTables[i]);
-                }
-            }
-        },
-
         addTableModified: function(schemaName, queryName){
             props.tablesModified.push(schemaName + ';' + queryName);
         },

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -181,8 +181,8 @@ EHR.Server.Triggers.beforeInsert = function(row, errors){
     }
 
     // Automatically close out old dataset records before inserting new records
-    if (!helper.isValidateOnly() && helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1
-            && row.QCStateLabel === "Completed"
+    if (!helper.isValidateOnly() && !helper.isETL() && helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1
+            && EHR.Server.Security.getQCStateByLabel(row.QCStateLabel).PublicData
     ){
         row.date = EHR.Server.Utils.datetimeToString(row.date);
         helper.getJavaHelper().closePreviousDatasetRecords(helper.getQueryName(), [row], false);

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -474,7 +474,7 @@ EHR.Server.Triggers.complete = function(event, errors) {
 
     // Automatically close out old dataset records defined in datasetsToCloseOnNewEntry before inserting new records
     if (helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1){
-        helper.closeRecordsOnComplete()
+        helper.closeRecordsOnComplete(true);
     }
 
     if (helper.isRequiresStatusRecalc() && helper.getPublicParticipantsModified().length && !helper.isETL()){

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -181,9 +181,11 @@ EHR.Server.Triggers.beforeInsert = function(row, errors){
     }
 
     // Automatically close out old dataset records before inserting new records
-    if (!helper.isValidateOnly() && row.Id && row.date
-            && helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1){
-        helper.onClosePreviousRecords(helper.getQueryName(), row.Id, row.date);
+    if (!helper.isValidateOnly() && helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1
+            && EHR.Server.Security.getQCStateByLabel(row.QCStateLabel).PublicData
+    ){
+        row.date = EHR.Server.Utils.datetimeToString(row.date);
+        helper.getJavaHelper().closePreviousDatasetRecords(helper.getQueryName(), [row], false);
     }
 
     EHR.Server.Triggers.rowEnd.call(this, helper, errors, scriptErrors, row, null);

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -182,7 +182,7 @@ EHR.Server.Triggers.beforeInsert = function(row, errors){
 
     // Automatically close out old dataset records before inserting new records
     if (!helper.isValidateOnly() && helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1
-            && EHR.Server.Security.getQCStateByLabel(row.QCStateLabel).PublicData
+            && row.QCStateLabel === "Completed"
     ){
         row.date = EHR.Server.Utils.datetimeToString(row.date);
         helper.getJavaHelper().closePreviousDatasetRecords(helper.getQueryName(), [row], false);

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -180,14 +180,6 @@ EHR.Server.Triggers.beforeInsert = function(row, errors){
         }
     }
 
-    // Automatically close out old dataset records before inserting new records
-    if (!helper.isValidateOnly() && !helper.isETL() && helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1
-            && EHR.Server.Security.getQCStateByLabel(row.QCStateLabel).PublicData
-    ){
-        row.date = EHR.Server.Utils.datetimeToString(row.date);
-        helper.getJavaHelper().closePreviousDatasetRecords(helper.getQueryName(), [row], false);
-    }
-
     EHR.Server.Triggers.rowEnd.call(this, helper, errors, scriptErrors, row, null);
 };
 exports.beforeInsert = EHR.Server.Triggers.beforeInsert;
@@ -478,6 +470,11 @@ EHR.Server.Triggers.complete = function(event, errors) {
         for (var i=0;i<handlers.length;i++){
             handlers[i].call(this, event, errors, helper);
         }
+    }
+
+    // Automatically close out old dataset records defined in datasetsToCloseOnNewEntry before inserting new records
+    if (helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1){
+        helper.closeRecordsOnComplete()
     }
 
     if (helper.isRequiresStatusRecalc() && helper.getPublicParticipantsModified().length && !helper.isETL()){

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -180,6 +180,12 @@ EHR.Server.Triggers.beforeInsert = function(row, errors){
         }
     }
 
+    // Automatically close out old dataset records before inserting new records
+    if (!helper.isValidateOnly() && row.Id && row.date
+            && helper.getDatasetsToCloseOnNewEntry().indexOf(helper.getQueryName()) !== -1){
+        helper.onClosePreviousRecords(helper.getQueryName(), row.Id, row.date);
+    }
+
     EHR.Server.Triggers.rowEnd.call(this, helper, errors, scriptErrors, row, null);
 };
 exports.beforeInsert = EHR.Server.Triggers.beforeInsert;

--- a/ehr/src/client/EHRLookups/EHRLookupsPage.tsx
+++ b/ehr/src/client/EHRLookups/EHRLookupsPage.tsx
@@ -9,6 +9,7 @@ const modelId = 'editable_ehr_lookups'
 const queryConfig = {
         bindURL: false,
         id: modelId,
+        maxRows: 500,
         schemaQuery: SchemaQuery.create('ehr_lookups', 'editable_lookups'),
     };
 
@@ -20,6 +21,7 @@ export const EHRLookupsPage: FC = memo(() => {
                 title={'Select table to edit values'}
                 asPanel={true}
                 queryConfig={queryConfig}
+                allowSelections={false}
             />
         </div>
     );

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -1259,12 +1259,13 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
 
     private void customizeEditableLookups(AbstractTableInfo table)
     {
-        String name = "edit";
-        if (table.getColumn(name) == null)
+        String name = "title";
+        if (table.getColumn(name) != null)
         {
             DetailsURL url = DetailsURL.fromString("ehr-updateTable.view?schemaName=ehr_lookups&query.queryName=${value}");
-            MutableColumnInfo col = ((MutableColumnInfo) table.getColumn("value"));
+            MutableColumnInfo col = ((MutableColumnInfo) table.getColumn(name));
             col.setURL(url);
+            col.setLabel("Table");
         }
     }
 

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -2412,7 +2412,12 @@ public class TriggerScriptHelper
 
     public void closeHousingRecords(List<Map<String, Object>> records) throws Exception
     {
-        TableInfo housing = getTableInfo("study", "housing");
+        closePreviousDatasetRecords("housing", records, true);
+    }
+
+    public void closePreviousDatasetRecords(String dataset, List<Map<String, Object>> records, boolean validateDateTime) throws Exception
+    {
+        TableInfo datasetTi = getTableInfo("study", dataset);
         List<Map<String, Object>> toUpdate = new ArrayList<>();
         List<Map<String, Object>> oldKeys = new ArrayList<>();
 
@@ -2444,10 +2449,10 @@ public class TriggerScriptHelper
         {
             Date date = _dateTimeFormat.parse(row.get("date").toString());
             // TODO how do we override this a center specific module can opt out of this check?
-            if (date.getHours() == 0 && date.getMinutes() == 0)
+            if (validateDateTime && date.getHours() == 0 && date.getMinutes() == 0)
             {
                 Exception e = new Exception();
-                _log.warn("Attempting to terminate housing records with a rounded date.  This might indicate upstream code is rounding the date: " + _dateTimeFormat.format(date), e);
+                _log.warn("Attempting to terminate " + dataset + " records with a rounded date.  This might indicate upstream code is rounding the date: " + _dateTimeFormat.format(date), e);
             }
 
             SimpleFilter filter = new SimpleFilter(FieldKey.fromString("Id"), row.get("Id"));
@@ -2461,7 +2466,7 @@ public class TriggerScriptHelper
                 filter.addCondition(FieldKey.fromString("lsid"), encounteredLsids, CompareType.NOT_IN);
             }
 
-            TableSelector ts = new TableSelector(housing, Collections.singleton("lsid"), filter, null);
+            TableSelector ts = new TableSelector(datasetTi, Collections.singleton("lsid"), filter, null);
             List<String> ret = ts.getArrayList(String.class);
             if (!ret.isEmpty())
             {
@@ -2482,10 +2487,10 @@ public class TriggerScriptHelper
 
         if (!toUpdate.isEmpty())
         {
-            _log.info("closing housing records: " + toUpdate.size());
+            _log.info("closing " + dataset + " records: " + toUpdate.size());
             Map<String, Object> context = getExtraContext();
             context.put("skipAnnounceChangedParticipants", true);
-            housing.getUpdateService().updateRows(getUser(), getContainer(), toUpdate, oldKeys, null, context);
+            datasetTi.getUpdateService().updateRows(getUser(), getContainer(), toUpdate, oldKeys, null, context);
         }
     }
 

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -2412,10 +2412,10 @@ public class TriggerScriptHelper
 
     public void closeHousingRecords(List<Map<String, Object>> records) throws Exception
     {
-        closePreviousDatasetRecords("housing", records, true);
+        closePreviousDatasetRecords("housing", records, false, false);
     }
 
-    public void closePreviousDatasetRecords(String dataset, List<Map<String, Object>> records, boolean dateOnly) throws Exception
+    public void closePreviousDatasetRecords(String dataset, List<Map<String, Object>> records, boolean dateOnly, boolean publicData) throws Exception
     {
         TableInfo datasetTi = getTableInfo("study", dataset);
         List<Map<String, Object>> toUpdate = new ArrayList<>();
@@ -2460,6 +2460,10 @@ public class TriggerScriptHelper
             //we want to only close those records starting prior to this record
             filter.addCondition(FieldKey.fromString("date"), date, CompareType.LTE);
             filter.addCondition(FieldKey.fromString("objectid"), row.get("objectid"), CompareType.NEQ_OR_NULL);
+
+            if (publicData)
+                filter.addCondition(FieldKey.fromString("qcstate/publicdata"), true, CompareType.EQUAL);
+
             if (!encounteredLsids.isEmpty())
             {
                 filter.addCondition(FieldKey.fromString("lsid"), encounteredLsids, CompareType.NOT_IN);

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -2415,7 +2415,7 @@ public class TriggerScriptHelper
         closePreviousDatasetRecords("housing", records, true);
     }
 
-    public void closePreviousDatasetRecords(String dataset, List<Map<String, Object>> records, boolean validateDateTime) throws Exception
+    public void closePreviousDatasetRecords(String dataset, List<Map<String, Object>> records, boolean dateOnly) throws Exception
     {
         TableInfo datasetTi = getTableInfo("study", dataset);
         List<Map<String, Object>> toUpdate = new ArrayList<>();
@@ -2448,8 +2448,7 @@ public class TriggerScriptHelper
         for (Map<String, Object> row : records)
         {
             Date date = _dateTimeFormat.parse(row.get("date").toString());
-            // TODO how do we override this a center specific module can opt out of this check?
-            if (validateDateTime && date.getHours() == 0 && date.getMinutes() == 0)
+            if (!dateOnly && date.getHours() == 0 && date.getMinutes() == 0)
             {
                 Exception e = new Exception();
                 _log.warn("Attempting to terminate " + dataset + " records with a rounded date.  This might indicate upstream code is rounding the date: " + _dateTimeFormat.format(date), e);
@@ -2490,6 +2489,7 @@ public class TriggerScriptHelper
             _log.info("closing " + dataset + " records: " + toUpdate.size());
             Map<String, Object> context = getExtraContext();
             context.put("skipAnnounceChangedParticipants", true);
+            context.put("skipClosingRecords", true);
             datasetTi.getUpdateService().updateRows(getUser(), getContainer(), toUpdate, oldKeys, null, context);
         }
     }


### PR DESCRIPTION
#### Rationale
Update EHR Lookups UI to not show checkboxes and show all lookups on one page. Use title instead of value and display description for more human readable and easier filtering.

Add trigger property listing datasets that should automatically close out any previous records before entering a new record. 

#### Related Pull Requests
* https://github.com/LabKey/johnsHopkinsEHRModules/pull/57

#### Changes
* EHR Lookups: opt out of selection and show up to 500 values before pagination.
* EHR Lookups: Add edit link to title column and update default view to show title, category and description
* Add datasetsToCloseOnNewEntry trigger property and helper function to close all previous records for a given animal and dataset. Uses existing Java trigger helper to close records.
* In complete trigger automatically close specified records in datasetsToCloseOnNewEntry
* Refactor housing trigger to use the same record closing function 
