### PR TITLE
Idea for more rapid testing of housing triggers

### DIFF
--- a/ehr/resources/views/testHousingTriggers.html
+++ b/ehr/resources/views/testHousingTriggers.html
@@ -212,6 +212,48 @@ $(document).ready(function() {
         });
     }
     $('#doTest3').click(doTest3)
+
+    function doTest4() {
+        $('#msgArea').html('Start Test 4');
+        LABKEY.Query.saveRows({
+            commands: [{
+                schemaName: 'study',
+                queryName: 'housing',
+                command: 'insert',
+                rows: [
+                    // NOTE: this record has the same date as the existing active record. I bet this doesnt work right.
+                    {Id: 'TestAnimal1', room: 'Rm1', comment: 'Created for testing purposes', date: baseDate}
+                ]
+            }],
+            failure: LDK.Utils.getErrorCallback(),
+            success: function () {
+                LABKEY.Query.selectRows({
+                    schemaName: 'study',
+                    queryName: 'housing',
+                    filterArray: [LABKEY.Filter.create('Id', 'TestAnimal1', LABKEY.Filter.Types.EQUALS)],
+                    sort: 'Date',
+                    scope: this,
+                    failure: LDK.Utils.getErrorCallback(),
+                    success: function(results){
+                        var rec1 = results.rows[0];
+                        var rec2 = results.rows[1];
+
+                        if (rec1.enddate !== rec2.date) {
+                            alert('Earlier housing record was not terminated correctly');
+                        }
+
+                        if (rec2.enddate) {
+                            alert('The second housing record should not have been terminated');
+                        }
+
+                        LABKEY.DataRegions['housingDR'].refresh();
+                    }
+                })
+                $('#msgArea').html('Test Complete');
+            }
+        });
+    }
+    $('#doTest4').click(doTest4)
 });
 
 </script>
@@ -230,6 +272,9 @@ This page is designed to test expected behaviors around EHR housing data entry
 <br>
 
 <button id="doTest3">Test 3</button>
+<br>
+
+<button id="doTest4">Test 4</button>
 <br>
 
 <div id="msgArea"></div>

--- a/ehr/resources/views/testHousingTriggers.html
+++ b/ehr/resources/views/testHousingTriggers.html
@@ -1,0 +1,238 @@
+<script type="text/javascript">
+
+$(document).ready(function() {
+    const baseDate = new Date('2020-01-01 13:00');
+    new LABKEY.QueryWebPart({
+        name: 'housingDR',
+        title: 'Housing Records',
+        schemaName: 'study',
+        queryName: 'housing',
+        removeableSort: 'Id,date',
+        filterArray: [LABKEY.Filter.create('Id', 'TestAnimal1;TestAnimal2;TestAnimal3', LABKEY.Filter.Types.EQUALS_ONE_OF)],
+        renderTo: 'qwpDiv',
+        failure: LDK.Utils.getErrorCallback()
+    });
+
+    function resetHousing() {
+        $('#msgArea').html('');
+        LABKEY.Ajax.request({
+            url: LABKEY.ActionURL.buildURL("query", "truncateTable.api"),
+            scope: this,
+            success: function() {
+                $('#msgArea').html('Truncate Housing Complete');
+            },
+            failure: LDK.Utils.getErrorCallback(),
+            jsonData: {
+                schemaName: 'study',
+                queryName: 'housing'
+            },
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            success: LABKEY.Utils.getCallbackWrapper(function(){
+                LABKEY.Query.saveRows({
+                    commands: [{
+                        schemaName: 'study',
+                        queryName: 'housing',
+                        command: 'insert',
+                        rows: [
+                            {Id: 'TestAnimal1', room: 'Rm1', comment: 'This should get closed by test1', date: baseDate},
+                            {Id: 'TestAnimal2', room: 'Rm1', comment: 'Created for testing purposes', date: baseDate},
+                            {Id: 'TestAnimal3', room: 'Rm1', comment: 'Created for testing purposes', date: baseDate}
+                        ]
+                    }],
+                    failure: LDK.Utils.getErrorCallback(),
+                    success: function () {
+                        $('#msgArea').html('Housing Reset Complete');
+                        LABKEY.DataRegions['housingDR'].refresh();
+                    }
+                });
+            }, this),
+        });
+    }
+    $('#resetHousing').click(resetHousing)
+
+    function populateDemographics() {
+        $('#msgArea').html('');
+        LABKEY.Query.saveRows({
+            commands: [{
+                schemaName: 'study',
+                queryName: 'demographics',
+                command: 'insert',
+                rows: [
+                    {Id: 'TestAnimal1', gender: 'm', comment: 'Created for testing purposes', date: baseDate},
+                    {Id: 'TestAnimal2', gender: 'm', comment: 'Created for testing purposes', date: baseDate},
+                    {Id: 'TestAnimal3', gender: 'm', comment: 'Created for testing purposes', date: baseDate}
+                ]
+            }],
+            failure: LDK.Utils.getErrorCallback(),
+            success: function () {
+                $('#msgArea').html('Populate Demographics Complete');
+            }
+        });
+    }
+    $('#populateDemographics').click(populateDemographics)
+
+    function doTest1() {
+        // Do a simple insert, which should close the prior record
+        $('#msgArea').html('Start Test 1');
+        LABKEY.Query.saveRows({
+            commands: [{
+                schemaName: 'study',
+                queryName: 'housing',
+                command: 'insert',
+                rows: [
+                    {Id: 'TestAnimal1', room: 'Rm1', comment: 'Created for testing purposes', date: new Date('2020-01-02 16:00')}
+                ]
+            }],
+            failure: LDK.Utils.getErrorCallback(),
+            success: function () {
+                LABKEY.Query.selectRows({
+                    schemaName: 'study',
+                    queryName: 'housing',
+                    filterArray: [LABKEY.Filter.create('Id', 'TestAnimal1', LABKEY.Filter.Types.EQUALS)],
+                    sort: 'Date',
+                    scope: this,
+                    failure: LDK.Utils.getErrorCallback(),
+                    success: function(results){
+                        console.log(results);
+                        if (results.rows[0].enddate !== results.rows[1].date) {
+                            alert('Earlier housing record was not terminated');
+                        }
+
+                        if (results.rows[1].enddate) {
+                            alert('The last housing record should not have been terminated');
+                        }
+
+                        LABKEY.DataRegions['housingDR'].refresh();
+                    }
+                })
+                $('#msgArea').html('Test Complete');
+            }
+        });
+
+    }
+    $('#doTest1').click(doTest1)
+
+    function doTest2() {
+        // Do a simple insert, with multiple rows/animal
+        $('#msgArea').html('Start Test 2');
+        LABKEY.Query.saveRows({
+            commands: [{
+                schemaName: 'study',
+                queryName: 'housing',
+                command: 'insert',
+                rows: [
+                    // NOTE the newer record is first and both lack endddate
+                    {Id: 'TestAnimal2', room: 'Rm1', comment: 'Created for testing purposes', date: new Date('2020-01-03 16:00')},
+                    {Id: 'TestAnimal2', room: 'Rm1', comment: 'Created for testing purposes', date: new Date('2020-01-02 16:00')}
+                ]
+            }],
+            failure: LDK.Utils.getErrorCallback(),
+            success: function () {
+                LABKEY.Query.selectRows({
+                    schemaName: 'study',
+                    queryName: 'housing',
+                    filterArray: [LABKEY.Filter.create('Id', 'TestAnimal2', LABKEY.Filter.Types.EQUALS)],
+                    sort: 'Date',
+                    scope: this,
+                    failure: LDK.Utils.getErrorCallback(),
+                    success: function(results){
+                        console.log(results);
+                        var rec1 = results.rows[0];
+                        var rec2 = results.rows[1];
+                        var rec3 = results.rows[2];
+
+                        if (rec1.enddate !== rec2.date) {
+                            alert('Earlier housing record was not terminated correctly');
+                        }
+
+                        if (rec2.enddate !== rec3.date) {
+                            alert('Earlier housing record was not terminated correctly');
+                        }
+
+                        if (rec3.enddate) {
+                            alert('The last housing record should not have been terminated');
+                        }
+
+                        LABKEY.DataRegions['housingDR'].refresh();
+                    }
+                })
+                $('#msgArea').html('Test Complete');
+            }
+        });
+    }
+    $('#doTest2').click(doTest2)
+
+    function doTest3() {
+        // Do a simple insert, with multiple rows/animal
+        $('#msgArea').html('Start Test 3');
+        LABKEY.Query.saveRows({
+            commands: [{
+                schemaName: 'study',
+                queryName: 'housing',
+                command: 'insert',
+                rows: [
+                    // NOTE the newer record is first and both lack endddate. The newest record is draft, and therefore should not terminate the prior records
+                    {Id: 'TestAnimal2', room: 'Rm1', comment: 'Created for testing purposes', date: new Date('2020-01-02 16:00')},
+                    {Id: 'TestAnimal2', room: 'Rm1', comment: 'Created for testing purposes', date: new Date('2020-01-03 16:00'), QCStateLabel: 'In Progress'}
+                ]
+            }],
+            failure: LDK.Utils.getErrorCallback(),
+            success: function () {
+                LABKEY.Query.selectRows({
+                    schemaName: 'study',
+                    queryName: 'housing',
+                    filterArray: [LABKEY.Filter.create('Id', 'TestAnimal2', LABKEY.Filter.Types.EQUALS)],
+                    sort: 'Date',
+                    scope: this,
+                    failure: LDK.Utils.getErrorCallback(),
+                    success: function(results){
+                        var rec1 = results.rows[0];
+                        var rec2 = results.rows[1];
+                        var rec3 = results.rows[2];
+
+                        if (rec1.enddate !== rec2.date) {
+                            alert('Earlier housing record was not terminated correctly');
+                        }
+
+                        if (rec2.enddate) {
+                            alert('The second housing record should not have been terminated since the last record is Draft');
+                        }
+
+                        if (rec3.enddate) {
+                            alert('The last housing record should not have been terminated');
+                        }
+
+                        LABKEY.DataRegions['housingDR'].refresh();
+                    }
+                })
+                $('#msgArea').html('Test Complete');
+            }
+        });
+    }
+    $('#doTest3').click(doTest3)
+});
+
+</script>
+
+This page is designed to test expected behaviors around EHR housing data entry
+<br>
+<button id="populateDemographics">Populate Demographics</button>
+<br>
+<button id="resetHousing">Reset Housing Table</button>
+<br>
+
+<button id="doTest1">Test 1</button>
+<br>
+
+<button id="doTest2">Test 2</button>
+<br>
+
+<button id="doTest3">Test 3</button>
+<br>
+
+<div id="msgArea"></div>
+
+<p/>
+<div id="qwpDiv"></div>

--- a/ehr/resources/views/testHousingTriggers.view.xml
+++ b/ehr/resources/views/testHousingTriggers.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+    <dependencies>
+        <dependency path="internal/jQuery"/>
+        <dependency path="ehr.context" />
+    </dependencies>
+</view>


### PR DESCRIPTION
@labkey-martyp and @labkey-jeckels: we recently talked about highly specific behaviors in how EHR housing triggers work. It seems like this discussion ought to be driven around specific use cases and whether changes do or do not support/break those cases. I also think EHR would benefit from more simple automated testing. Those test cases ought to help inform this conversation, and should serve to prevent future breaking changes. 

Figuring out how to generate these tests in a way that's not too burdensome to developers is a challenge. EHR needs a lot of context to work, so unit/integration testing is tricky. Selenium tests can use the client APIs; however, that is not a practical way for a developer to quickly iterate and write the actual server-side code. It's just too much of a pain to practically write this while coding the feature.

I wrote this PR as an idea to throw out there. Code like this is used for testing QueryWebPart and possibly other places. The idea is to have a simple HTML page that can directly exercise specific use-cases. In the case of housing, I wrote some really simple cases that insert different combinations of records, and has extremely basic validation on the results. The advantage here is that I can interactively code, refresh this page, and use this as a tool that actually helps me develop the server-side code, as opposed to making test writing a separate activity that adds time. When the feature work is one, one could relatively easily add actual selenium coverage that loads this page and executes the tests. This particular page is not particularly elegant, but I believe does work. 

What do you think about trying to include some things along these lines in appropriate places of future EHR dev? Obviously this isnt appropriate for all features, but for certain kinds of features, especially those touching trigger code, this seems like it could actually make the developer more efficient and create a durable test.

