### PR TITLE
Make module specific animal history reports override core EHR reports

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1599,7 +1599,7 @@ public class EHRController extends SpringActionController
                         context = new DataIteratorContext(batchErrors);
                         context.setConfigParameters(configParameters);
                         context.setInsertOption(QueryUpdateService.InsertOption.REPLACE);
-                        context.setAlternateKeys(Set.of("reportname"));
+                        context.getAlternateKeys().add("reportname");
 
                         loader = DataLoader.get().createLoader(_additionalReportsResource, true, null, TabLoader.TSV_FILE_TYPE);
                         AbstractQueryImportAction.importData(loader, table, updateService, context, auditEvent, getUser(), getContainer());


### PR DESCRIPTION
#### Rationale
This is the next iteration on the new paradigm of maintaining a core set of animal history reports and adding additional reports in the individual PRC modules. This PR allows overriding the core reports with those defined in additionalReports based on the report name.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4139

#### Changes
* Update PopulateReportsAction to merge in additionalReports (based on reportname) with the replace option
