### PR TITLE
Ticket 47409: Overridable EHR flags trigger

### DIFF
--- a/ehr/resources/queries/study/flags.js
+++ b/ehr/resources/queries/study/flags.js
@@ -1,10 +1,10 @@
 
 require("ehr/triggers").initScript(this);
 
-function onAfterInsert(helper, errors, row){
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.AFTER_INSERT, 'study', 'flags', function(scriptErrors, helper, row, oldRow) {
     //if this category enforces only a single active flag at once, enforce it
     //note: if this flag has a future date, preemptively set enddate on flags, since isActive should handle this
     if (row.Id && row.flag && !row.enddate && row.date){
         helper.getJavaHelper().ensureSingleFlagCategoryActive(row.Id, row.flag, row.objectId, row.date);
     }
-}
+});

--- a/ehr/resources/queries/study/flags.js
+++ b/ehr/resources/queries/study/flags.js
@@ -1,7 +1,7 @@
 
 require("ehr/triggers").initScript(this);
 
-EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.AFTER_INSERT, 'study', 'flags', function(scriptErrors, helper, row, oldRow) {
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.AFTER_INSERT, 'study', 'flags', function(helper, scriptErrors, row, oldRow) {
     //if this category enforces only a single active flag at once, enforce it
     //note: if this flag has a future date, preemptively set enddate on flags, since isActive should handle this
     if (row.Id && row.flag && !row.enddate && row.date){


### PR DESCRIPTION
#### Rationale
A recent update added the EHR afterInsert flags. This needs to be converted to a trigger that can be unregistered.

#### Changes
* Register trigger instead of using onAfterInsert
