### PR TITLE
Improve null requestid tolerance by checking the actual instead of expected

### DIFF
--- a/ehr/resources/web/ehr/data/RequestStoreCollection.js
+++ b/ehr/resources/web/ehr/data/RequestStoreCollection.js
@@ -31,7 +31,7 @@ Ext4.define('EHR.data.RequestStoreCollection', {
                     cs.each(function(r){
                         var actualRequestId = r.get('requestid');
                         if (requestid !== actualRequestId) {
-                            if (actualRequestId && actualRequestId.length > 0) { // Tolerate null values
+                            if (actualRequestId) { // Tolerate null/blank values
                                 LDK.Assert.assertEquality('Incorrect requestid for client store:' + cs.storeId, requestid, actualRequestId);
                             }
                             r.beginEdit();
@@ -51,7 +51,7 @@ Ext4.define('EHR.data.RequestStoreCollection', {
 
                         var actualRequestId = r.get('requestid');
                         if (requestid !== actualRequestId) {
-                            if (actualRequestId && actualRequestId.length > 0) { // Tolerate null values
+                            if (actualRequestId) { // Tolerate null/blank values
                                 LDK.Assert.assertEquality('Incorrect requestid for server store:' + cs.storeId, requestid, actualRequestId);
                             }
                             r.beginEdit();

--- a/ehr/resources/web/ehr/data/RequestStoreCollection.js
+++ b/ehr/resources/web/ehr/data/RequestStoreCollection.js
@@ -29,9 +29,10 @@ Ext4.define('EHR.data.RequestStoreCollection', {
             this.clientStores.each(function(cs){
                 if (cs.getFields().get('requestid') != null){
                     cs.each(function(r){
-                        if (requestid !== r.get('requestid')) {
-                            if (requestid) { // Tolerate null values
-                                LDK.Assert.assertEquality('Incorrect requestid for client store:' + cs.storeId, requestid, r.get('requestid'));
+                        var actualRequestId = r.get('requestid');
+                        if (requestid !== actualRequestId) {
+                            if (actualRequestId && actualRequestId.length > 0) { // Tolerate null values
+                                LDK.Assert.assertEquality('Incorrect requestid for client store:' + cs.storeId, requestid, actualRequestId);
                             }
                             r.beginEdit();
                             r.set('requestid', this.getRequestId());
@@ -48,9 +49,10 @@ Ext4.define('EHR.data.RequestStoreCollection', {
                             return;  //do not check these records.  they have deliberately been separated.
                         }
 
-                        if (requestid !== r.get('requestid')) {
-                            if (requestid) { // Tolerate null values
-                                LDK.Assert.assertEquality('Incorrect requestid for server store:' + cs.storeId, requestid, r.get('requestid'));
+                        var actualRequestId = r.get('requestid');
+                        if (requestid !== actualRequestId) {
+                            if (actualRequestId && actualRequestId.length > 0) { // Tolerate null values
+                                LDK.Assert.assertEquality('Incorrect requestid for server store:' + cs.storeId, requestid, actualRequestId);
                             }
                             r.beginEdit();
                             r.set('requestid', this.getRequestId());


### PR DESCRIPTION
#### Rationale
We have intermittent test failures after saving a request form. Everything works OK in practice, but it's logging a warning to the server log, which the test finds at the end of its run and fails.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_Ehr_OnprcEhrSqlserver/2307349?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true#%2FONPRC_EHRTest.tar.gz;%2FtomcatLogs.tar.gz

I tried to be tolerant of this back late in 2021 but checked the wrong value in the comparison.

https://github.com/LabKey/ehrModules/pull/300

#### Changes
* Check the actual value instead of the expected