### PR TITLE
Issue 47697: JSON null handling for EHR forms

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/dataentry/FormElement.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/FormElement.java
@@ -47,7 +47,14 @@ public class FormElement
 
         DisplayColumn dc = _boundCol.getDisplayColumnFactory().createRenderer(_boundCol);
         dc.prepare(c);
-        JsonWriter.getMetaData(dc, null, true, true, true).forEach(json::put);
+        JsonWriter.getMetaData(dc, null, true, true, true).forEach((name, value) -> {
+            // The updated JSONObject library requires special handling for null values. If values are just set to Java null
+            // they will be excluded from the JSON. The EHR forms are expecting null values in the API response.
+            if (value == null)
+                value = JSONObject.NULL;
+
+            json.put(name, value);
+        });
 
         json.put("schemaName", _boundCol.getParentTable().getPublicSchemaName());
         json.put("queryName", _boundCol.getParentTable().getPublicName());

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/FormElement.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/FormElement.java
@@ -48,7 +48,7 @@ public class FormElement
         DisplayColumn dc = _boundCol.getDisplayColumnFactory().createRenderer(_boundCol);
         dc.prepare(c);
         JsonWriter.getMetaData(dc, null, true, true, true).forEach((name, value) -> {
-            // The updated JSONObject library requires special handling for null values. If values are just set to Java null
+            // The updated JSON library requires special handling for null values. If values are just set to Java null
             // they will be excluded from the JSON. The EHR forms are expecting null values in the API response.
             if (value == null)
                 value = JSONObject.NULL;

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/FormElement.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/FormElement.java
@@ -21,6 +21,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.DisplayColumn;
 import org.labkey.api.data.JsonWriter;
 import org.labkey.api.security.User;
+import org.labkey.api.util.JsonUtil;
 
 /**
  * Wrapper for the UI component for a single column in a query
@@ -43,18 +44,11 @@ public class FormElement
 
     public JSONObject toJSON(Container c, User u)
     {
-        JSONObject json = new JSONObject();
-
         DisplayColumn dc = _boundCol.getDisplayColumnFactory().createRenderer(_boundCol);
         dc.prepare(c);
-        JsonWriter.getMetaData(dc, null, true, true, true).forEach((name, value) -> {
-            // The updated JSON library requires special handling for null values. If values are just set to Java null
-            // they will be excluded from the JSON. The EHR forms are expecting null values in the API response.
-            if (value == null)
-                value = JSONObject.NULL;
 
-            json.put(name, value);
-        });
+        // Preserve nulls as some EHR forms are expecting null fields.
+        JSONObject json = JsonUtil.toJsonPreserveNulls(JsonWriter.getMetaData(dc, null, true, true, true));
 
         json.put("schemaName", _boundCol.getParentTable().getPublicSchemaName());
         json.put("queryName", _boundCol.getParentTable().getPublicName());


### PR DESCRIPTION
#### Rationale
Some inconsistencies in EHR forms due to the handling of null values on fields like defaultValue in column metadata. With the recent JSON library update, properties with null values are not added to the JSON objects unless JSONObject.NULL is used.  

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/666

#### Changes
* In EHR FormElement, add JSON null values where values are Java null
