### PR TITLE
Handle Bulk Edit even if there are more than one values in the selected rows

### DIFF
--- a/ehr/resources/web/ehr/panel/BulkEditPanel.js
+++ b/ehr/resources/web/ehr/panel/BulkEditPanel.js
@@ -29,9 +29,6 @@ Ext4.define('EHR.panel.BulkEditPanel', {
     title: 'Bulk Edit',
 
     initComponent: function(){
-
-        LDK.Assert.assertTrue('formConfig has no fields', this.formConfig.fieldConfigs.length > 0);
-
         Ext4.apply(this, {
             itemId: 'formPanel',
             border: false,
@@ -113,7 +110,6 @@ Ext4.define('EHR.panel.BulkEditPanel', {
     getFieldConfigs: function(){
         var fields = this.callParent(arguments);
         var newItems = [];
-        LDK.Assert.assertTrue('Fields not found for bulk editing', fields.length > 0);
         Ext4.Array.forEach(fields, function(item){
             item.originalDisabled = item.disabled;
             item.disabled = true;

--- a/ehr/resources/web/ehr/panel/BulkEditPanel.js
+++ b/ehr/resources/web/ehr/panel/BulkEditPanel.js
@@ -29,6 +29,9 @@ Ext4.define('EHR.panel.BulkEditPanel', {
     title: 'Bulk Edit',
 
     initComponent: function(){
+
+        LDK.Assert.assertTrue('formConfig has no fields', this.formConfig.fieldConfigs.length > 0);
+
         Ext4.apply(this, {
             itemId: 'formPanel',
             border: false,
@@ -80,7 +83,10 @@ Ext4.define('EHR.panel.BulkEditPanel', {
                 }, this);
 
                 var keys = Ext4.Object.getKeys(values);
-                if (keys.length == 1){
+
+                // there can be more than one value for certain fields, ex. Date field with the time component,
+                // there might be different times in the selected rows, so pick one as a default value
+                if (keys.length >= 1){
                     valMap[field.name] = values[keys[0]];
                 }
             }, this);
@@ -107,6 +113,7 @@ Ext4.define('EHR.panel.BulkEditPanel', {
     getFieldConfigs: function(){
         var fields = this.callParent(arguments);
         var newItems = [];
+        LDK.Assert.assertTrue('Fields not found for bulk editing', fields.length > 0);
         Ext4.Array.forEach(fields, function(item){
             item.originalDisabled = item.disabled;
             item.disabled = true;

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -230,7 +230,7 @@ public class EHRTestHelper
         grid.clickTbarButton(btnLabel);
         grid.waitForRowCount(count + 1);
         grid.cancelEdit();
-        _test.sleep(700);
+        _test.sleep(200);
     }
 
     public void clickExt4WindowBtn(String title, String label)

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -230,7 +230,7 @@ public class EHRTestHelper
         grid.clickTbarButton(btnLabel);
         grid.waitForRowCount(count + 1);
         grid.cancelEdit();
-        _test.sleep(200);
+        _test.sleep(700);
     }
 
     public void clickExt4WindowBtn(String title, String label)


### PR DESCRIPTION
#### Rationale
Bulk Edit on WNPRC Billing's Data Entry form 'Enter Charges without Animal Ids ' crashes when the selected rows with Date field has more than one date, and this is because the Date field also has the time component to it, which can be different if the rows were selected at different times; and Bulk Edit expects it to be the same value across selected rows.

#### Changes
* Set default value even if there is more than one value in the selected rows for a field.