### PR TITLE
Issue 47728: LSID column should be selectable in ehr_billing.ChargeUnits

### DIFF
--- a/ehr_billing/resources/schemas/ehr_billing.xml
+++ b/ehr_billing/resources/schemas/ehr_billing.xml
@@ -703,7 +703,6 @@
                 <isReadOnly>true</isReadOnly>
                 <isHidden>true</isHidden>
                 <isUserEditable>false</isUserEditable>
-                <isUnselectable>true</isUnselectable>
                 <fk>
                     <fkColumnName>ObjectUri</fkColumnName>
                     <fkTable>Object</fkTable>


### PR DESCRIPTION
#### Rationale
Extensible tables don't work when the LSID column isn't selectable

#### Changes
* Update the one straggling table, ehr_billing.ChargeUnits, to make LSID selectable (though hidden)