### PR TITLE
Issue 408: Support deleting of records within a request

### DIFF
--- a/ehr/resources/web/ehr/data/DataEntryClientStore.js
+++ b/ehr/resources/web/ehr/data/DataEntryClientStore.js
@@ -334,6 +334,10 @@ Ext4.define('EHR.data.DataEntryClientStore', {
     },
 
     safeRemove: function(records){
+
+        let undeletableCount = 0;
+        let undeletableIds = {};
+
         Ext4.Array.forEach(records, function(r){
             // First check if the record is attached to a request
             if (!r.phantom && r.get('requestid')) {
@@ -342,12 +346,14 @@ Ext4.define('EHR.data.DataEntryClientStore', {
                 if (this.storeCollection.getRequestId &&
                         this.storeCollection.getRequestId() === r.get('requestid')) {
                     if (r.get('taskid')) {
-                        Ext4.Msg.alert('Unable to delete', 'The record is already attached to a task. It will be detached from the task but not deleted when saved.');
+                        let id = r.get('id') || 'Blank';
+                        undeletableIds[id] = true;
+                        undeletableCount++;
                         r.isRemovedRequest = true;
                     }
                     else {
-                        // Do nothing special. This will be a true delete, because we're editing the request its request
-                        // form, and the row isn't yet attached to a task
+                        // Do nothing special. This will be a true delete, because we're editing the request via its
+                        // request form, and the row isn't yet attached to a task
                     }
                 }
                 else {
@@ -355,6 +361,10 @@ Ext4.define('EHR.data.DataEntryClientStore', {
                 }
             }
         }, this);
+
+        if (undeletableCount > 0) {
+            Ext4.Msg.alert('Unable to delete some records', 'There are ' + undeletableCount + ' record(s) already attached to a task. They be detached from the task but not deleted when saved. IDs involved: ' + Object.keys(undeletableIds).join(','));
+        }
 
         this.remove(records);
     },

--- a/ehr/resources/web/ehr/data/DataEntryClientStore.js
+++ b/ehr/resources/web/ehr/data/DataEntryClientStore.js
@@ -335,9 +335,24 @@ Ext4.define('EHR.data.DataEntryClientStore', {
 
     safeRemove: function(records){
         Ext4.Array.forEach(records, function(r){
-            var recs = [];
-            if (!r.phantom && r.get('requestid')){
-                r.isRemovedRequest = true;
+            // First check if the record is attached to a request
+            if (!r.phantom && r.get('requestid')) {
+
+                // Check if we're editing via request form, which will be using RequestStoreCollection
+                if (this.storeCollection.getRequestId &&
+                        this.storeCollection.getRequestId() === r.get('requestid')) {
+                    if (r.get('taskid')) {
+                        Ext4.Msg.alert('Unable to delete', 'The record is already attached to a task. It will be detached from the task but not deleted when saved.');
+                        r.isRemovedRequest = true;
+                    }
+                    else {
+                        // Do nothing special. This will be a true delete, because we're editing the request its request
+                        // form, and the row isn't yet attached to a task
+                    }
+                }
+                else {
+                    r.isRemovedRequest = true;
+                }
             }
         }, this);
 

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -430,17 +430,11 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         Locator completeDiv = Locator.tagContainingText("div", "Populate Complete");
         List<WebElement> completeEl = completeDiv.findElements(getDriver());
         clickButton("Populate " + tableLabel, 0);
-        confirmPopulate();
         if (completeEl.size() > 0)
             longWait().until(ExpectedConditions.stalenessOf(completeEl.get(0)));
         waitForElement(completeDiv, POPULATE_TIMEOUT_MS);
         Assert.assertFalse("Error populating " + tableLabel, elementContains(Locator.id("msgbox"), "ERROR"));
         resumeJsErrorChecker();
-    }
-
-    protected void confirmPopulate()
-    {
-        // Confirmation only necessary in CNPRC
     }
 
     @LogMethod(quiet = true)
@@ -450,17 +444,11 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         Locator completeDiv = Locator.tagContainingText("div", "Delete Complete");
         List<WebElement> completeEl = completeDiv.findElements(getDriver());
         clickButton(("All".equals(tableLabel) ? "Delete " : "Delete Data From ") + tableLabel, 0);
-        confirmDelete();
         if (completeEl.size() > 0)
             longWait().until(ExpectedConditions.stalenessOf(completeEl.get(0)));
         waitForElement(completeDiv, POPULATE_TIMEOUT_MS);
         Assert.assertFalse("Error deleting " + tableLabel, elementContains(Locator.id("msgbox"), "ERROR"));
         resumeJsErrorChecker();
-    }
-
-    protected void confirmDelete()
-    {
-        //Confirmation only necessary in CNPRC
     }
 
     @LogMethod(quiet = true)

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -172,13 +172,17 @@ public class EHRTestHelper
 
     public void addBatchToGrid(Ext4GridRef grid)
     {
-        String btnLable = "Add Batch";
-        grid.clickTbarButton(btnLable);
+        grid.clickTbarButton("Add Batch");
+    }
+
+    public void deleteSelectedFromGrid(Ext4GridRef grid)
+    {
+        grid.clickTbarButton("Delete Selected");
     }
 
     public void addRecordToGrid(Ext4GridRef grid, String btnLabel)
     {
-        Integer count = grid.getRowCount();
+        int count = grid.getRowCount();
         grid.clickTbarButton(btnLabel);
         grid.waitForRowCount(count + 1);
         grid.cancelEdit();


### PR DESCRIPTION
#### Rationale
Users sometimes need to completely delete a record from within a request. We can support this when it hasn't yet been attached to a task

#### Changes
* Differentiate between a record that's scoped to just the current request form vs other scenarios (like task-based forms)
* Give better feedback when we aren't going to actually delete