### PR TITLE
Changes to Viral_Load_Assay test

### DIFF
--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -47,6 +47,7 @@ import org.labkey.test.util.ext4cmp.Ext4GridRef;
 import org.labkey.test.util.external.labModules.LabModuleHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +64,7 @@ import static org.junit.Assert.assertNotNull;
 @Category({External.class, EHR.class, LabModule.class})
 public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 {
-    private static final String ASSAY_NAME = "Viral Load Test";
+    private static final String ASSAY_NAME = "Viral_Load_Test";
     private static final String LC480 = "LC480";
     private static final String LC96 = "LC96";
     private String DETECTOR_NAME = "PIATAK SIVGAG";
@@ -293,7 +294,9 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         Map<String, FieldDefinition.ColumnType> resultFields = new HashMap<>();
         resultFields.put("uniqueSample", FieldDefinition.ColumnType.String);
         resultFields.put("nucleicAcidVol", FieldDefinition.ColumnType.Decimal);
-        defineViralAssayWithAdditionalFields("Viral Loads",  LC480 + " " + ASSAY_NAME, null, null, resultFields);
+        Map<String, FieldDefinition.ColumnType> runFields = new HashMap<>();
+        runFields.put("exptNumber", FieldDefinition.ColumnType.String);
+        defineViralAssayWithAdditionalFields("Viral Loads",  LC480 + "_" + ASSAY_NAME, null, runFields, resultFields);
     }
 
     public void defineViralAssayWithAdditionalFields(String provider, String label, Map<String, FieldDefinition.ColumnType> batchFields, Map<String, FieldDefinition.ColumnType> runFields, Map<String, FieldDefinition.ColumnType> resultFields)
@@ -349,7 +352,10 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         resultFields.put("samplePrepNotes", FieldDefinition.ColumnType.String);
         resultFields.put("number", FieldDefinition.ColumnType.Integer);
 
-        defineViralAssayWithAdditionalFields("Viral Loads", LC96 + " " + ASSAY_NAME, null, null, resultFields);
+        Map<String, FieldDefinition.ColumnType> runFields = new HashMap<>();
+        runFields.put("exptNumber", FieldDefinition.ColumnType.String);
+
+        defineViralAssayWithAdditionalFields("Viral Loads", LC96 + "_" + ASSAY_NAME, null, runFields, resultFields);
     }
 
     private void ensureABI7500Records() throws CommandException, IOException
@@ -534,7 +540,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 
     private void createWNPRCPlateTemplate(String instrument)
     {
-        String fullAssayName = instrument + " " + ASSAY_NAME;
+        String fullAssayName = instrument + "_" + ASSAY_NAME;
         _helper.goToLabHome();
         _helper.clickNavPanelItem(fullAssayName + ":", IMPORT_DATA_TEXT);
         click(Ext4Helper.Locators.menuItem("Prepare Run"));
@@ -803,7 +809,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 
     private void importWNPRCResults(String instrument) throws Exception
     {
-        String fullAssayName = instrument + " " + ASSAY_NAME;
+        String fullAssayName = instrument + "_" + ASSAY_NAME;
         log("Verifying " + instrument + " Import");
         _helper.goToLabHome();
         _helper.clickNavPanelItem(fullAssayName + ":", IMPORT_DATA_TEXT);
@@ -839,6 +845,11 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 
         log("Saving valid data");
         textarea.setValue(text);
+
+        WebElement newCategoryField = Locator.xpath("//input[contains(@id, 'textfield') and @name='exptNumber']").notHidden().waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
+        setFormElementJS(newCategoryField, "1000");
+        fireEvent(newCategoryField, SeleniumEvent.blur);
+
         waitAndClick(Ext4Helper.Locators.ext4Button("Upload"));
         waitForElement(Ext4Helper.Locators.window("Success"));
         clickAndWait(Ext4Helper.Locators.ext4Button("OK"));

--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -67,6 +67,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
     private static final String ASSAY_NAME = "Viral Load Test";
     private static final String LC480 = "LC480";
     private static final String LC96 = "LC96";
+    private static final String VIRAL_LOAD_GENERIC = "Viral_Load";
     private String DETECTOR_NAME = "PIATAK SIVGAG";
 
     private static final String[][] TEMPLATE_DATA = new String[][]{
@@ -273,10 +274,12 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         setUpTest();
         createPlateTemplate();
         importABI7500Results();
-        createWNPRCPlateTemplate(LC480);
-        importWNPRCResults(LC480);
-        createWNPRCPlateTemplate(LC96);
-        importWNPRCResults(LC96);
+        createWNPRCPlateTemplate(LC480, LC480);
+        importWNPRCResults(LC480, LC480);
+        createWNPRCPlateTemplate(LC96, LC96);
+        importWNPRCResults(LC96, LC96);
+        createWNPRCPlateTemplate(VIRAL_LOAD_GENERIC, LC96);
+        importWNPRCResults(VIRAL_LOAD_GENERIC, LC96);
     }
 
     @Override
@@ -287,6 +290,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         ensureABI7500Records();
         setUpLC480Assay();
         setUpLC96Assay();
+        setUpGenericAssay();
     }
 
     private void setUpLC480Assay() throws Exception
@@ -296,7 +300,16 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         resultFields.put("nucleicAcidVol", FieldDefinition.ColumnType.Decimal);
         Map<String, FieldDefinition.ColumnType> runFields = new HashMap<>();
         runFields.put("exptNumber", FieldDefinition.ColumnType.String);
-        defineViralAssayWithAdditionalFields("Viral Loads",  LC480 + " " + ASSAY_NAME, null, runFields, resultFields);
+        defineViralAssayWithAdditionalFields("Viral Loads",  LC480, null, runFields, resultFields);
+    }
+    private void setUpGenericAssay() throws Exception
+    {
+        Map<String, FieldDefinition.ColumnType> resultFields = new HashMap<>();
+        resultFields.put("uniqueSample", FieldDefinition.ColumnType.String);
+        resultFields.put("nucleicAcidVol", FieldDefinition.ColumnType.Decimal);
+        Map<String, FieldDefinition.ColumnType> runFields = new HashMap<>();
+        runFields.put("exptNumber", FieldDefinition.ColumnType.String);
+        defineViralAssayWithAdditionalFields("Viral Loads",  VIRAL_LOAD_GENERIC, null, runFields, resultFields);
     }
 
     public void defineViralAssayWithAdditionalFields(String provider, String label, Map<String, FieldDefinition.ColumnType> batchFields, Map<String, FieldDefinition.ColumnType> runFields, Map<String, FieldDefinition.ColumnType> resultFields)
@@ -354,8 +367,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 
         Map<String, FieldDefinition.ColumnType> runFields = new HashMap<>();
         runFields.put("exptNumber", FieldDefinition.ColumnType.String);
-
-        defineViralAssayWithAdditionalFields("Viral Loads", LC96 + " " + ASSAY_NAME, null, runFields, resultFields);
+        defineViralAssayWithAdditionalFields("Viral Loads", LC96, null, runFields, resultFields);
     }
 
     private void ensureABI7500Records() throws CommandException, IOException
@@ -538,9 +550,9 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         }
     }
 
-    private void createWNPRCPlateTemplate(String instrument)
+    private void createWNPRCPlateTemplate(String instrument, String importMethod)
     {
-        String fullAssayName = instrument + " " + ASSAY_NAME;
+        String fullAssayName = instrument;
         _helper.goToLabHome();
         _helper.clickNavPanelItem(fullAssayName + ":", IMPORT_DATA_TEXT);
         click(Ext4Helper.Locators.menuItem("Prepare Run"));
@@ -561,7 +573,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         Ext4ComboRef.waitForField(this, "Import Method");
         Ext4ComboRef importMethodField = Ext4ComboRef.getForLabel(this, "Import Method");
         importMethodField.clickTrigger();
-        getDriver().findElement(By.xpath("//li[text()='" + instrument + "']")).click();
+        getDriver().findElement(By.xpath("//li[text()='" + importMethod + "']")).click();
 
         waitForElement(Locator.xpath("//span[contains(text(), 'Source Material') and contains(@class, 'x4-column-header-text')]")); //ensure grid loaded
         _helper.addRecordsToAssayTemplate(WNPRC_TEMPLATE_DATA, expectedCols);
@@ -807,9 +819,9 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         assertEquals("Run plan not marked completed", 0, dr2.getDataRowCount());
     }
 
-    private void importWNPRCResults(String instrument) throws Exception
+    private void importWNPRCResults(String instrument, String importMethod) throws Exception
     {
-        String fullAssayName = instrument + " " + ASSAY_NAME;
+        String fullAssayName = instrument;
         log("Verifying " + instrument + " Import");
         _helper.goToLabHome();
         _helper.clickNavPanelItem(fullAssayName + ":", IMPORT_DATA_TEXT);
@@ -822,7 +834,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 
         waitForViralLoadAssayPageWithSavedTemplate();
 
-        assertEquals("Incorrect value for field", instrument, Ext4FieldRef.getForLabel(this, "Instrument").getValue());
+        assertEquals("Incorrect value for field", importMethod, Ext4FieldRef.getForLabel(this, "Instrument").getValue());
         assertEquals("Incorrect value for field", Long.valueOf(50), Ext4FieldRef.getForLabel(this, "Eluate Volume").getValue());
         assertEquals("Incorrect value for field", Long.valueOf(5), Ext4FieldRef.getForLabel(this, "Sample Vol Per Rxn").getValue());
 

--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -846,9 +846,9 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         log("Saving valid data");
         textarea.setValue(text);
 
-        WebElement newCategoryField = Locator.xpath("//input[contains(@id, 'textfield') and @name='exptNumber']").notHidden().waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
-        setFormElementJS(newCategoryField, "1000");
-        fireEvent(newCategoryField, SeleniumEvent.blur);
+        WebElement exptNumberField = Locator.xpath("//input[contains(@id, 'textfield') and @name='exptNumber']").notHidden().waitForElement(getDriver(), WAIT_FOR_JAVASCRIPT);
+        setFormElementJS(exptNumberField, "1000");
+        fireEvent(exptNumberField, SeleniumEvent.blur);
 
         waitAndClick(Ext4Helper.Locators.ext4Button("Upload"));
         waitForElement(Ext4Helper.Locators.window("Success"));

--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -64,7 +64,7 @@ import static org.junit.Assert.assertNotNull;
 @Category({External.class, EHR.class, LabModule.class})
 public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 {
-    private static final String ASSAY_NAME = "Viral_Load_Test";
+    private static final String ASSAY_NAME = "Viral Load Test";
     private static final String LC480 = "LC480";
     private static final String LC96 = "LC96";
     private String DETECTOR_NAME = "PIATAK SIVGAG";
@@ -296,7 +296,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         resultFields.put("nucleicAcidVol", FieldDefinition.ColumnType.Decimal);
         Map<String, FieldDefinition.ColumnType> runFields = new HashMap<>();
         runFields.put("exptNumber", FieldDefinition.ColumnType.String);
-        defineViralAssayWithAdditionalFields("Viral Loads",  LC480 + "_" + ASSAY_NAME, null, runFields, resultFields);
+        defineViralAssayWithAdditionalFields("Viral Loads",  LC480 + " " + ASSAY_NAME, null, runFields, resultFields);
     }
 
     public void defineViralAssayWithAdditionalFields(String provider, String label, Map<String, FieldDefinition.ColumnType> batchFields, Map<String, FieldDefinition.ColumnType> runFields, Map<String, FieldDefinition.ColumnType> resultFields)
@@ -355,7 +355,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         Map<String, FieldDefinition.ColumnType> runFields = new HashMap<>();
         runFields.put("exptNumber", FieldDefinition.ColumnType.String);
 
-        defineViralAssayWithAdditionalFields("Viral Loads", LC96 + "_" + ASSAY_NAME, null, runFields, resultFields);
+        defineViralAssayWithAdditionalFields("Viral Loads", LC96 + " " + ASSAY_NAME, null, runFields, resultFields);
     }
 
     private void ensureABI7500Records() throws CommandException, IOException
@@ -540,7 +540,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 
     private void createWNPRCPlateTemplate(String instrument)
     {
-        String fullAssayName = instrument + "_" + ASSAY_NAME;
+        String fullAssayName = instrument + " " + ASSAY_NAME;
         _helper.goToLabHome();
         _helper.clickNavPanelItem(fullAssayName + ":", IMPORT_DATA_TEXT);
         click(Ext4Helper.Locators.menuItem("Prepare Run"));
@@ -809,7 +809,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
 
     private void importWNPRCResults(String instrument) throws Exception
     {
-        String fullAssayName = instrument + "_" + ASSAY_NAME;
+        String fullAssayName = instrument + " " + ASSAY_NAME;
         log("Verifying " + instrument + " Import");
         _helper.goToLabHome();
         _helper.clickNavPanelItem(fullAssayName + ":", IMPORT_DATA_TEXT);


### PR DESCRIPTION
#### Rationale
I am looking to pull in assay data using the Viral_Load_Assay test, there are a couple changes I needed to make, one was a constraint with the actual assay name and teasing apart the import method for a generic test assay. Extending this test class for the WNPRC_Virology test seems to work pretty nicely, I just need a few extra things.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add new assay to match the assay name in this file, and set the import methods up so they can change between different assays, the assay name is used [here](https://github.com/LabKey/wnprc-modules/blob/ccdd334916249354f34ed1b1ccdc988f0afb1d1b/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql#L24)
* Add exptNumber field to the assay design results since this is needed to test some of the functionality of the EHR to RSEHR ETL. It's used at WNPRC for QC and experiment number tracking and referenced [here](https://github.com/LabKey/wnprc-modules/blob/ccdd334916249354f34ed1b1ccdc988f0afb1d1b/WNPRC_Virology/resources/queries/lists/rsehr_viral_loads.sql#LL21C43-L21C43)
