### PR TITLE
EHR SM Searchable Columns

### DIFF
--- a/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
+++ b/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
@@ -12,6 +12,10 @@
                 <property name="columnTitle" value="Species"/>
             </properties>
         </column>
-        <column name="Id/Demographics/calculated_status"/>
+        <column name="Id/Demographics/calculated_status/code">
+            <properties>
+                <property name="columnTitle" value="Status"/>
+            </properties>
+        </column>
     </columns>
 </customView>

--- a/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
+++ b/EHR_SM/resources/queries/exp/data/Animal/.qview.xml
@@ -2,8 +2,16 @@
     <columns>
         <column name="name"/>
         <column name="Id"/>
-        <column name="Id/Demographics/gender"/>
-        <column name="Id/Demographics/species"/>
+        <column name="Id/Demographics/gender/meaning">
+            <properties>
+                <property name="columnTitle" value="Sex"/>
+            </properties>
+        </column>
+        <column name="Id/Demographics/species/common">
+            <properties>
+                <property name="columnTitle" value="Species"/>
+            </properties>
+        </column>
         <column name="Id/Demographics/calculated_status"/>
     </columns>
 </customView>


### PR DESCRIPTION
#### Rationale
SM Sample Finder only searches using non-lookup values. Use resolved lookup values in default Animal view.

#### Changes
* Update default Animal view
