### PR TITLE
Remove unneeded semi-colon to pass stricter SQLFragment validation

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -889,7 +889,7 @@ public class EHRManager
                     if (ds != null)
                     {
                         _log.info("increasing size of remark column for dataset: " + label);
-                        SQLFragment sql = new SQLFragment("ALTER TABLE studydataset." + ds.getDomain().getStorageTableName() + " ALTER COLUMN remark NVARCHAR(max);");
+                        SQLFragment sql = new SQLFragment("ALTER TABLE studydataset." + ds.getDomain().getStorageTableName() + " ALTER COLUMN remark NVARCHAR(max)");
                         SqlExecutor se = new SqlExecutor(DbScope.getLabKeyScope());
                         se.execute(sql);
                     }


### PR DESCRIPTION
#### Rationale
SQLFragment is doing more validation and we don't need the trailing semi-colon anyway.

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_EhrSqlserver/2444605?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true