### PR TITLE
EHR Reports - Set import option

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1579,7 +1579,7 @@ public class EHRController extends SpringActionController
 
                     Map<Enum, Object> configParameters = new HashMap<>();
                     configParameters.put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, behaviorType);
-                    configParameters.put(QueryUpdateService.ConfigParameters.SkipInsertOptionValidation, Boolean.TRUE);
+
                     context.setConfigParameters(configParameters);
                     context.setInsertOption(QueryUpdateService.InsertOption.INSERT);
 
@@ -1598,6 +1598,8 @@ public class EHRController extends SpringActionController
                             auditEvent = createTransactionAuditEvent(getContainer(), QueryService.AuditAction.INSERT);
 
                         context = new DataIteratorContext(batchErrors);
+                        configParameters.put(QueryUpdateService.ConfigParameters.SkipInsertOptionValidation, Boolean.TRUE);
+
                         context.setConfigParameters(configParameters);
                         context.setInsertOption(QueryUpdateService.InsertOption.REPLACE);
                         context.getAlternateKeys().add("reportname");

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1598,8 +1598,6 @@ public class EHRController extends SpringActionController
                             auditEvent = createTransactionAuditEvent(getContainer(), QueryService.AuditAction.INSERT);
 
                         context = new DataIteratorContext(batchErrors);
-                        configParameters.put(QueryUpdateService.ConfigParameters.SkipInsertOptionValidation, Boolean.TRUE);
-
                         context.setConfigParameters(configParameters);
                         context.setInsertOption(QueryUpdateService.InsertOption.REPLACE);
                         context.getAlternateKeys().add("reportname");

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1579,6 +1579,7 @@ public class EHRController extends SpringActionController
 
                     Map<Enum, Object> configParameters = new HashMap<>();
                     configParameters.put(DetailedAuditLogDataIterator.AuditConfigs.AuditBehavior, behaviorType);
+                    configParameters.put(QueryUpdateService.ConfigParameters.SkipInsertOptionValidation, Boolean.TRUE);
                     context.setConfigParameters(configParameters);
                     context.setInsertOption(QueryUpdateService.InsertOption.INSERT);
 

--- a/ehr/src/org/labkey/ehr/query/EHRCustomPermissionsTable.java
+++ b/ehr/src/org/labkey/ehr/query/EHRCustomPermissionsTable.java
@@ -17,6 +17,10 @@ public class EHRCustomPermissionsTable<SchemaType extends UserSchema> extends Cu
     public EHRCustomPermissionsTable(SchemaType schema, TableInfo table, ContainerFilter cf)
     {
         super(schema, table, cf);
+
+        setAllowedInsertOption(QueryUpdateService.InsertOption.MERGE);
+        setAllowedInsertOption(QueryUpdateService.InsertOption.REPLACE);
+        setAllowedInsertOption(QueryUpdateService.InsertOption.UPSERT);
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/query/EHRCustomPermissionsTable.java
+++ b/ehr/src/org/labkey/ehr/query/EHRCustomPermissionsTable.java
@@ -17,10 +17,6 @@ public class EHRCustomPermissionsTable<SchemaType extends UserSchema> extends Cu
     public EHRCustomPermissionsTable(SchemaType schema, TableInfo table, ContainerFilter cf)
     {
         super(schema, table, cf);
-
-        setAllowedInsertOption(QueryUpdateService.InsertOption.MERGE);
-        setAllowedInsertOption(QueryUpdateService.InsertOption.REPLACE);
-        setAllowedInsertOption(QueryUpdateService.InsertOption.UPSERT);
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -56,6 +56,7 @@ import org.labkey.api.query.QueryDefinition;
 import org.labkey.api.query.QueryException;
 import org.labkey.api.query.QueryForeignKey;
 import org.labkey.api.query.QueryService;
+import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.settings.LookAndFeelProperties;
@@ -141,6 +142,10 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         else if (matches(table, "ehr", "protocol"))
         {
             customizeProtocolTable((AbstractTableInfo) table);
+        }
+        else if (matches(table, "ehr", "reports"))
+        {
+            customizeReportsTable((AbstractTableInfo) table);
         }
         else if (matches(table, "ehr_lookups", "procedures"))
         {
@@ -1402,6 +1407,13 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
             displayCol.setLabel("Short Name");
             table.addColumn(displayCol);
         }
+    }
+
+    private void customizeReportsTable(AbstractTableInfo table)
+    {
+        // Enabling this option for populating reports from additionalReports.tsv. This is set here while data iterator
+        // refinements are being made and may be removed in the future.
+        table.setAllowedInsertOption(QueryUpdateService.InsertOption.REPLACE);
     }
 
     private void customizeProtocolTable(AbstractTableInfo table)


### PR DESCRIPTION
#### Rationale
EHR Reports uses the Replace option when inserting additionalReports. This option now needs to be enabled for this table.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3996

#### Changes
* Enable replace import option in table customizer
