### PR TITLE
Fix VL Assay Test

### DIFF
--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
@@ -102,7 +102,7 @@ public class Viral_Load_Manager
                         {
                             int decimals = new DecimalFormat(format).getMaximumFractionDigits();
                             JSONObject editor = new JSONObject().put("decimalPrecision", decimals);
-                            var col = (JSONObject) resultsMeta.get(column.getName());
+                            JSONObject col = resultsMeta.optJSONObject(column.getName());
                             if (null == col)
                                 col = new JSONObject();
 


### PR DESCRIPTION
I noticed the Viral Load assay test began to fail. I did not really investigate what triggered this, and why it only happened now, but I believe we should do this to handle the JSONObject migration. TeamCity should tell us if this works.

Example failure: 

https://teamcity.labkey.org/buildConfiguration/LabKey_233Release_Premium_Ehr_DailyEhrPostgres/2451168?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true