### PR TITLE
ViralLoadAssayTest fix - Handle JSONObject["viralLoad"] not found

### DIFF
--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/Viral_Load_Manager.java
@@ -102,9 +102,7 @@ public class Viral_Load_Manager
                         {
                             int decimals = new DecimalFormat(format).getMaximumFractionDigits();
                             JSONObject editor = new JSONObject().put("decimalPrecision", decimals);
-                            JSONObject col = resultsMeta.getJSONObject(column.getName());
-                            if (null == col)
-                                col = new JSONObject();
+                            JSONObject col = getJsonObject(resultsMeta, column.getName());
 
                             col.put("editorConfig", editor);
                             resultsMeta.put(column.getName(), col);


### PR DESCRIPTION
#### Rationale
Fix for ViralLoadAssayTest failure:
org.json.JSONException: JSONObject["viralLoad"] not found.
	at org.json.JSONObject.get(JSONObject.java:570) ~[json-20230227.jar:?]
	at org.labkey.viral_load_assay.Viral_Load_Manager.getDefaultAssayMetadata(Viral_Load_Manager.java:105) ~[Viral_Load_Assay-23.6-SNAPSHOT.jar:?]
	at org.labkey.viral_load_assay.assay.DefaultVLImportMethod.getMetadata(DefaultVLImportMethod.java:48) ~[Viral_Load_Assay-23.6-SNAPSHOT.jar:?]
	at org.labkey.viral_load_assay.assay.ABI7500ImportMethod.getMetadata(ABI7500ImportMethod.java:139) ~[Viral_Load_Assay-23.6-SNAPSHOT.jar:?]
	at org.labkey.api.laboratory.assay.DefaultAssayImportMethod.toJson(DefaultAssayImportMethod.java:199) ~[laboratory_api-23.6-SNAPSHOT.jar:?]
	at org.labkey.laboratory.LaboratoryController$GetImportMethodsAction.execute(LaboratoryController.java:1860) ~[laboratory-23.6-SNAPSHOT.jar:?]
	at org.labkey.laboratory.LaboratoryController$GetImportMethodsAction.execute(LaboratoryController.java:1813) ~[laboratory-23.6-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseApiAction.handlePost(BaseApiAction.java:238) [api-23.6-SNAPSHOT.jar:?]
	at org.labkey.api.action.BaseApiAction.handleRequest(BaseApiAction.java:128) [api-23.6-SNAPSHOT.jar:?]


#### Changes
* Use static getJsonObject() which returns a new JSONObject() if the column is not present (instead of resultsMeta.getJSONObject() which throws an error if the column is not present)
