### PR TITLE
Prefer the fully concatenated SNOMED code list to category-specific

### DIFF
--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -769,7 +769,7 @@ EHR.Server.Triggers.rowInit = function(helper, scriptErrors, row, oldRow){
 
     var incrementSnomedIndex = true;
 
-    if (row && helper.getSNOMEDSubsetCodeFieldNames() && helper.getSNOMEDSubsetCodeFieldNames().length) {
+    if (row && !row.codesRaw && helper.getSNOMEDSubsetCodeFieldNames() && helper.getSNOMEDSubsetCodeFieldNames().length) {
         var newCodes = [];
         for (var i = 0; i < helper.getSNOMEDSubsetCodeFieldNames().length; i++) {
             var fieldName =  helper.getSNOMEDSubsetCodeFieldNames()[i];

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -2320,7 +2320,7 @@ public class TriggerScriptHelper
             {
                 new SqlExecutor(ti.getSchema()).execute(new SQLFragment("DELETE FROM ehr.snomed_tags WHERE objectid = ?", pk));
             }
-            _log.info("deleted " + pks.size() + "snomed tags for record: " + objectid);
+            _log.info("deleted " + pks.size() + " snomed tags for record: " + objectid);
         }
     }
 


### PR DESCRIPTION
#### Rationale
A single-row edit pathway is passing the codesRaw value without passing category-specific breakouts. We want to preserve this values instead of losing all the code values.

#### Changes
* Preserve the `codesRaw` value when supplied