### PR TITLE
Avoid sending conflicting copies of the SNOMED code lists

### DIFF
--- a/ehr/resources/web/ehr/form/field/SnomedCodesEditor.js
+++ b/ehr/resources/web/ehr/form/field/SnomedCodesEditor.js
@@ -108,6 +108,10 @@ Ext4.define('EHR.window.SnomedCodeWindow', {
                     }
 
                     win.boundRec.set(win.boundColumn, codes.length ? codes.join(';') : null);
+                    if (win.boundColumn !== 'codesRaw') {
+                        // Reduce ambiguity by not sending conflicting sets of codes in the combined and per-category fields
+                        win.boundRec.set('codesRaw', null);
+                    }
                     win.close();
                 }
             },{


### PR DESCRIPTION
#### Rationale
As a followup to https://github.com/LabKey/ehrModules/pull/613, it's easier to debug behavior if we don't send conflicting values for `codesRaw` (the original, complete set of SNOMED codes) and the category-specific codes like `etiologyRaw` which contain the edits

#### Changes
* Clear out the combined `codesRaw` field when we're submitting the updates for an individual category's codes