### PR TITLE
Issue 46960: EHR pedigree calculations using --vanilla flag which doesn't align with R package locations on hosted solutions

### DIFF
--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
@@ -126,7 +126,10 @@ public class GeneticCalculationsRTask extends WorkDirectoryTask<GeneticCalculati
 
         List<String> args = new ArrayList<>();
         args.add(exePath);
-        args.add("--vanilla");
+        args.add("--no-save"); // don't save workspace
+        args.add("--no-environ"); // Do not read any user file to set environment variables.
+        args.add("--no-init-file"); // Do not read the user’s profile at startup.
+        args.add("--no-restore"); // don't restore saved objects
         args.add(scriptPath);
         args.add("-f");
         args.add(tsvFile.getPath());


### PR DESCRIPTION
#### Rationale
--vanilla flag used in EHR pedigree calculations is causing Rscript to look in .Library for packages instead of .Library.site which is used on hosted servers. According to the docs at https://colinfay.me/intro-to-r/appendix-b-invoking-r.html, it bundles together a bunch of other command-line flags like –no-save, –no-environ, –no-site-file, –no-init-file and –no-restore. Out of those, we can skip  –no-site-file as the --no-site-file flag skips the execution of site-specific initialization files, including the loading of site-wide environment variables and settings.

By avoiding the --no-site-file flag, Rscript will load the appropriate packages from the .Library.site directory based on the site-wide settings. This will allow us to utilize the site library instead of the user library for package loading.

#### Changes
* replace --vanilla flag with --no-save, --no-environ, --no-init-file and --no-restore
