### PR TITLE
Set phantom explicitly for new records

### DIFF
--- a/ehr/resources/web/ehr/window/CopyTaskWindow.js
+++ b/ehr/resources/web/ehr/window/CopyTaskWindow.js
@@ -261,6 +261,8 @@ Ext4.define('EHR.window.CopyTaskWindow', {
 
                             var model = serverStore.addServerModel({});
                             model.set(obj);
+                            // this is a new record, so we need to mark it as phantom
+                            model.phantom = true;
 
                             this.toAddMap[serverStore.storeId].push(model);
                         }, this);


### PR DESCRIPTION
#### Rationale
When copy previous request/task button is used in data entry forms containing tables and study datasets. The saveRows commands built for tables are for update as the new row is not marked as phantom for non-datasets. This PR explicitly marks the records as phantom.

