### PR TITLE
Do not double-add records to DataEntryStore in CopyTaskWindow

### DIFF
--- a/ehr/resources/web/ehr/data/DataEntryServerStore.js
+++ b/ehr/resources/web/ehr/data/DataEntryServerStore.js
@@ -618,16 +618,28 @@ Ext4.define('EHR.data.DataEntryServerStore', {
         //}
     },
 
-    //creates and adds a model to the provided server store, handling any dependencies within other stores in the collection
-    addServerModel: function(data){
+    // creates a model for the provided server store, handling any dependencies within other stores in the collection
+    createServerModel: function(data, doesNotExistOnServer){
         data = data || {};
         if (EHR.debug)
             console.log('creating server model');
         var model = this.createModel(data);
+
+        // phantom is a property Ext4 stores use to identify whether a record exists on the server or not.
+        // This will default to undefined, but callers should consider setting this as appropriate:
+        if (doesNotExistOnServer) {
+            model.phantom = true;
+        }
+
         model.serverErrors = Ext4.create('EHR.data.Errors', {
             record: model
         });
 
+        return model;
+    },
+
+    addServerModel: function(data){
+        var model = this.createServerModel(data);
         this.add(model);
 
         return model;

--- a/ehr/resources/web/ehr/window/CopyTaskWindow.js
+++ b/ehr/resources/web/ehr/window/CopyTaskWindow.js
@@ -9,6 +9,7 @@ Ext4.define('EHR.window.CopyTaskWindow', {
     width: 600,
     noun: 'Task',
     queryName: 'tasks',
+    defaultQCStateLabel: null,
 
     initComponent: function(){
         Ext4.apply(this, {
@@ -250,6 +251,10 @@ Ext4.define('EHR.window.CopyTaskWindow', {
                                 obj.requestid = requestId;
                             }
 
+                            if (this.defaultQCStateLabel) {
+                                obj.QCStateLabel = this.defaultQCStateLabel;
+                            }
+
                             serverStore.getFields().each(function(field){
                                 if (blockList.indexOf(field.name.toLowerCase()) > -1){
                                     return;
@@ -259,7 +264,8 @@ Ext4.define('EHR.window.CopyTaskWindow', {
                                     obj[field.name] = row.getValue(field.name);
                             }, this);
 
-                            var model = serverStore.addServerModel({});
+                            // NOTE: models are created here but not added to the store until all queries return:
+                            var model = serverStore.createServerModel({}, true);
                             model.set(obj);
 
                             this.toAddMap[serverStore.storeId].push(model);


### PR DESCRIPTION
This is related to: https://github.com/LabKey/ehrModules/pull/638

When reviewing that PR, I noticed that CopyTaskWindow was double-adding new records to the serverStore. Previously, CopyTaskPanel would query the server, and in the successCallback for each query, it would call serverStore.addServerModel(). This ends up creating that record in the store; however, it also builds an internal map of those records (this.toAddMap). After the MultiRequest returns, onLoad is called and then the code re-adds all these records to the server store. I can only assume that some internal checks within the store prevent double-adding, or maybe there was a race condition happening around how and when StoreCollection.transformServerToClient is called/triggered, but this pattern doesnt make sense.

This PR:
- Separates DataEntryServerStore.addClientModel and createClientModel methods.
- Uses createClientModel here, avoiding adding records twice.
- Related to #638, this makes phantom more declarative as an argument in createClientModel, which it is marginally more verbose way to flag upstream code to be aware of phantom, and keeps 'phantom' internal within the store.
- Related to https://github.com/LabKey/onprcEHRModules/pull/759, some time ago ONPRC simply copy/pasted this entire file to make a minor change in behavior. This PR adds a 'defaultQCStateLabel' property to the window, which lets ONPRC set this, and avoids them copying the entire file. 