### PR TITLE
SimpleQueryForm double title

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/dataentry/SingleQueryFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/SingleQueryFormSection.java
@@ -16,6 +16,7 @@
 package org.labkey.api.ehr.dataentry;
 
 import org.json.JSONObject;
+import org.labkey.api.util.JsonUtil;
 import org.labkey.api.view.template.ClientDependency;
 
 import java.util.HashMap;
@@ -43,10 +44,10 @@ public class SingleQueryFormSection extends SimpleFormSection
         Map<String, Object> bindConfig = new HashMap<>();
         bindConfig.put("createRecordOnLoad", true);
         formConfig.put("bindConfig", bindConfig);
-        formConfig.put("title", JSONObject.NULL);
-        formConfig.put("label", JSONObject.NULL);
+        formConfig.put("title", null);
+        formConfig.put("label", null);
         formConfig.put("maxItemsPerCol", 8);
-        ret.put("formConfig", formConfig);
+        ret.put("formConfig", JsonUtil.toJsonPreserveNulls(formConfig));
 
         return ret;
     }

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/SingleQueryFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/SingleQueryFormSection.java
@@ -43,8 +43,8 @@ public class SingleQueryFormSection extends SimpleFormSection
         Map<String, Object> bindConfig = new HashMap<>();
         bindConfig.put("createRecordOnLoad", true);
         formConfig.put("bindConfig", bindConfig);
-        formConfig.put("title", null);
-        formConfig.put("label", null);
+        formConfig.put("title", JSONObject.NULL);
+        formConfig.put("label", JSONObject.NULL);
         formConfig.put("maxItemsPerCol", 8);
         ret.put("formConfig", formConfig);
 


### PR DESCRIPTION
#### Rationale
ExtJS form is expecting null value for title in order to not display panel header. The page already has a title on it.

#### Changes
* Preserve nulls
