### PR TITLE
Improve stability of VL Test

### DIFF
--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -583,8 +583,8 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
         waitForText("Group By Category");
         Ext4FieldRef.getForLabel(this, "Group By Category").setChecked(true);
         waitForText("Below are the sample categories");
-        Ext4FieldRef ctlField = Ext4FieldRef.getForLabel(this, "Neg Control (2)");
-        ctlField.setValue(8); //A8
+        Ext4ComboRef ctlField = Ext4ComboRef.getForLabel(this, "Neg Control (2)");
+        ctlField.setComboByDisplayValue("A8");
         waitAndClick(Ext4Helper.Locators.ext4Button("Submit"));
         assertAlert("Error: Neg Control conflicts with an existing sample in well: A8");
 


### PR DESCRIPTION
An example failure is here: https://teamcity.labkey.org/buildConfiguration/LabKey_237Release_External_Discvr_ExternalModulesTestSqlserver/2611285?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true&expandBuildChangesSection=true. I'm pretty sure this will improve that. The same field is set on line 444 using setByDisplayValue(), which should be a more stable way to do this.