### PR TITLE
Refactor genetics calculations to allow import to be triggered separately

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRDemographicsService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRDemographicsService.java
@@ -50,4 +50,9 @@ abstract public class EHRDemographicsService
     abstract public AnimalRecord getAnimal(Container c, String id);
 
     abstract public List<AnimalRecord> getAnimals(Container c, Collection<String> ids);
+
+    /**
+     *
+     */
+    abstract public void recalculateForAllIdsInCache(final Container c, final String schema, final String query, final boolean async);
 }

--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.api.ehr;
 
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.AbstractTableInfo;
@@ -31,6 +32,7 @@ import org.labkey.api.ehr.demographics.ProjectValidator;
 import org.labkey.api.ehr.history.*;
 import org.labkey.api.ldk.table.ButtonConfigFactory;
 import org.labkey.api.module.Module;
+import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DetailsURL;
 import org.labkey.api.query.ExprColumn;
@@ -43,6 +45,7 @@ import org.labkey.api.util.URLHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.template.ClientDependency;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Date;
@@ -324,4 +327,14 @@ abstract public class EHRService
 
     /** The EHR expects certain QC states to exist. This will inspect the current study and create any missing QC states. **/
     abstract public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges);
+
+    /**
+     * The EHR has a built-in GeneticsCalculations pipeline job that computes inbreeding and kinship based on the pedigree.
+     * These are normally calculated in R, saved as TSVs, and imported using java code. This method is a separate entrypoint
+     * that allows other code perform the calculations, save the results as TSVs, and then trigger import here.
+     *
+     * A use case is a separate pipeline server that performs the R computation on a cluster, and then triggers the main webserver to import
+     * those results.
+     */
+    abstract public void standaloneProcessKinshipAndInbreeding(Container c, User u, File pipelineDir, Logger log) throws PipelineJobException;
 }

--- a/ehr/resources/pipeline/kinship/populateInbreeding.r
+++ b/ehr/resources/pipeline/kinship/populateInbreeding.r
@@ -7,47 +7,46 @@
 # This R script will calculate and store inbreeding coefficients for all animals in the colony.  This data will be compared against
 # the information currently stored in the DB and the minimal number of inserts/updates/deletes are then performed.  This script is designed
 # to run as a daily cron job.
-
-
-options(error = dump.frames);
-library(pedigree);
-library(getopt);
-library(Matrix);
+options(error = dump.frames)
+library(pedigree)
+library(getopt)
+library(Matrix)
 library(dplyr)
 
 spec <- matrix(c(
-'inputFile', '-f', 1, "character"
-), ncol=4, byrow=TRUE);
-opts = getopt(spec, commandArgs(trailingOnly = TRUE));
+  'inputFile', '-f', 1, 'character'
+), ncol=4, byrow=TRUE)
+opts <- getopt(spec, commandArgs(trailingOnly = TRUE))
 
-allPed <- read.table(opts$inputFile);
+allPed <- read.table(opts$inputFile)
 colnames(allPed)<-c('Id', 'Dam', 'Sire', 'Gender')
 
-is.na(allPed$Id)<-which(allPed$Id=="")
-is.na(allPed$Dam)<-which(allPed$Dam=="")
-is.na(allPed$Sire)<-which(allPed$Sire=="")
-is.na(allPed$Gender)<-which(allPed$Gender=="")
+allPed$Id[allPed$Id == ""] <- NA
+allPed$Id[allPed$Dam == ""] <- NA
+allPed$Id[allPed$Sire == ""] <- NA
+allPed$Id[allPed$Gender == ""] <- NA
 
-df <- data.frame(id=as.character(allPed$Id), 'id parent1'=allPed$Dam, 'id parent2'=allPed$Sire, stringsAsFactors=FALSE);
-colnames(df)<-c("id", "id parent1", "id parent2")
-
-originalIds <-as.data.frame(df[,1,drop=FALSE])
+df <- data.frame(id=as.character(allPed$Id), 'id parent1'=allPed$Dam, 'id parent2'=allPed$Sire, stringsAsFactors=FALSE)
+originalIds <- df$id
 
 #this is a function in the pedigree package designed to add missing parents to the dataframe
 #see pedigree package documentation for more detail
-df <- add.Inds(df);
+df <- add.Inds(df)
 ord <- orderPed(df)
 df <- df[order(ord),]
 
 #use an existing package to calculate inbreeding
-ib = calcInbreeding(df);
-
-newRecords <- data.frame(Id=as.character(df$id), coefficient=ib, stringsAsFactors=FALSE);
+ib <- calcInbreeding(df)
 
 #only calculate inbreeding for Ids at the center
-newRecords <- dplyr::filter(newRecords, Id %in% originalIds$id)
+newRecords <- data.frame(Id=as.character(df$id), coefficient=ib, stringsAsFactors=FALSE) %>%
+  dplyr::filter(Id %in% originalIds)
 
-# write TSV to disk
-print("Output table:");
-print(str(newRecords));
-write.table(newRecords, file = "inbreeding.txt", append = FALSE,row.names=F,quote=F,sep="\t");
+print("Output table:")
+print(str(newRecords))
+
+if (nrow(newRecords) != length(originalIds)) {
+  stop(paste0('Output dataframe and input IDs not the same length! Expected: ', length(originalIds), ', was: ', nrow(newRecords)))
+}
+
+write.table(newRecords, file = "inbreeding.txt", append = FALSE, row.names=F, quote=F, sep="\t")

--- a/ehr/resources/pipeline/kinship/populateInbreeding.r
+++ b/ehr/resources/pipeline/kinship/populateInbreeding.r
@@ -7,7 +7,6 @@
 # This R script will calculate and store inbreeding coefficients for all animals in the colony.  This data will be compared against
 # the information currently stored in the DB and the minimal number of inserts/updates/deletes are then performed.  This script is designed
 # to run as a daily cron job.
-options(error = dump.frames)
 library(pedigree)
 library(getopt)
 library(Matrix)
@@ -28,6 +27,7 @@ allPed$Id[allPed$Gender == ""] <- NA
 
 df <- data.frame(id=as.character(allPed$Id), 'id parent1'=allPed$Dam, 'id parent2'=allPed$Sire, stringsAsFactors=FALSE)
 originalIds <- df$id
+print(paste0('Input IDs: ', nrow(df)))
 
 #this is a function in the pedigree package designed to add missing parents to the dataframe
 #see pedigree package documentation for more detail
@@ -41,9 +41,6 @@ ib <- calcInbreeding(df)
 #only calculate inbreeding for Ids at the center
 newRecords <- data.frame(Id=as.character(df$id), coefficient=ib, stringsAsFactors=FALSE) %>%
   dplyr::filter(Id %in% originalIds)
-
-print("Output table:")
-print(str(newRecords))
 
 if (nrow(newRecords) != length(originalIds)) {
   stop(paste0('Output dataframe and input IDs not the same length! Expected: ', length(originalIds), ', was: ', nrow(newRecords)))

--- a/ehr/resources/pipeline/kinship/populateInbreeding.r
+++ b/ehr/resources/pipeline/kinship/populateInbreeding.r
@@ -21,9 +21,9 @@ allPed <- read.table(opts$inputFile)
 colnames(allPed)<-c('Id', 'Dam', 'Sire', 'Gender')
 
 allPed$Id[allPed$Id == ""] <- NA
-allPed$Id[allPed$Dam == ""] <- NA
-allPed$Id[allPed$Sire == ""] <- NA
-allPed$Id[allPed$Gender == ""] <- NA
+allPed$Dam[allPed$Dam == ""] <- NA
+allPed$Sire[allPed$Sire == ""] <- NA
+allPed$Gender[allPed$Gender == ""] <- NA
 
 df <- data.frame(id=as.character(allPed$Id), 'id parent1'=allPed$Dam, 'id parent2'=allPed$Sire, stringsAsFactors=FALSE)
 originalIds <- df$id

--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -7,30 +7,24 @@
 # This R script will calculate and store kinship coefficients (aka. relatedness) for all animals in the colony.  This is a large, sparse matrix.
 # The matrix is converted into a very long 3-column dataframe (animal1, animal2, coefficient).  This dataframe is output to a TSV file,
 # which is normally imported into ehr.kinship by java code in GeneticCalculationsImportTask
-
-
-#options(echo=TRUE);
-options(error = dump.frames);
-library(methods);
-library(kinship2);
-library(getopt);
-library(Matrix);
-library(dplyr);
+options(error = dump.frames)
+library(kinship2)
+library(getopt)
+library(Matrix)
+library(dplyr)
 
 spec <- matrix(c(
-#'containerPath', '-c', 1, "character",
-#'baseUrl', '-b', 1, "character"
-'inputFile', '-f', 1, "character"
-), ncol=4, byrow=TRUE);
-opts = getopt(spec, commandArgs(trailingOnly = TRUE));
+    'inputFile', '-f', 1, "character"
+), ncol=4, byrow=TRUE)
+opts <- getopt(spec, commandArgs(trailingOnly = TRUE))
 
-allPed <- read.table(opts$inputFile, quote="\"");
-colnames(allPed)<-c('Id', 'Dam', 'Sire', 'Gender', 'Species');
+allPed <- read.table(opts$inputFile, quote="\"")
+colnames(allPed)<-c('Id', 'Dam', 'Sire', 'Gender', 'Species')
 
-is.na(allPed$Id)<-which(allPed$Id=="")
-is.na(allPed$Dam)<-which(allPed$Dam=="")
-is.na(allPed$Sire)<-which(allPed$Sire=="")
-is.na(allPed$Gender)<-which(allPed$Gender=="")
+allPed$Id[allPed$Id == ""] <- NA
+allPed$Id[allPed$Dam == ""] <- NA
+allPed$Id[allPed$Sire == ""] <- NA
+allPed$Id[allPed$Gender == ""] <- NA
 
 allPed$Species <- as.character(allPed$Species)
 allPed$Species[is.na(allPed$Species)] <- c('Unknown')
@@ -38,10 +32,10 @@ allPed$Species <- as.factor(allPed$Species)
 
 # In order to reduce the max matrix size, calculate famids using makefamid, then analyze each group separately
 # It resizes the biggest matrix from 12000^2 to 8200^2 thus reduces the memory used by half
-newRecords=NULL
+newRecords <- NULL
 for (species in unique(allPed$Species)){
-    print(paste0('processing species: ', species))
     allRecordsForSpecies <- allPed[allPed$Species == species,]
+    print(paste0('Processing species: ', species, ', with ', nrow(allRecordsForSpecies), ' IDs'))
 
     # Add missing parents for accurate kinship calculations
     fixedRecords <- with(allRecordsForSpecies, fixParents(id = Id, dadid = Sire, momid = Dam, sex = Gender))
@@ -49,25 +43,80 @@ for (species in unique(allPed$Species)){
     # Kinship is expecting records to be sorted IAW it's own pedigree function
     recordsForSpecies <- with(fixedRecords, pedigree(id=id,dadid=dadid,momid=momid,sex=sex,missid=0))
 
-    temp.kin=kinship(recordsForSpecies)
+    temp.kin <- kinship(recordsForSpecies)
 
     # Add rownames to make matrix symmetric, which is required downstream
     rownames(temp.kin) <- colnames(temp.kin)
 
     # Convert kinship matrix to a triplet list of two ids and their coefficient
-    summaryDf = as.data.frame(summary(as(temp.kin, "dgCMatrix")))
+    summaryDf <- as.data.frame(summary(as(temp.kin, "dgCMatrix")))
     idList <- rownames(temp.kin)
-    temp.tri = data.frame(Id=idList[summaryDf$i], Id2=idList[summaryDf$j], coefficient=summaryDf$x)
+    temp.tri <- data.frame(Id=idList[summaryDf$i], Id2=idList[summaryDf$j], coefficient=summaryDf$x)
 
     # Now filter out parents added for kinship calculation
     temp.tri <- dplyr::filter(temp.tri, grepl("^(?!addin).*$", Id, perl = TRUE))
     temp.tri <- dplyr::filter(temp.tri, grepl("^(?!addin).*$", Id2, perl = TRUE))
 
-    newRecords=rbind(newRecords,temp.tri)
-    print(paste0('total subjects: ', nrow(allRecordsForSpecies)))
+    newRecords <- rbind(newRecords,temp.tri)
+    print(paste0('Total subjects: ', nrow(allRecordsForSpecies)))
+}
+
+generateExpectedKinship <- function(pedDf) {
+    parentChild <- rbind(
+      data.frame(Id = pedDf$Id, Id2 = pedDf$Dam, Species = pedDf$Species, Relationship = 'Child/Parent'),
+      data.frame(Id = pedDf$Id, Id2 = pedDf$Sire, Species = pedDf$Species, Relationship = 'Child/Parent')
+    ) %>% filter(!is.na(Id2)) %>% mutate(ExpectedCoefficient = 0.5)
+
+    grandParentOffspring1 <- merge(pedDf[!is.na(pedDf$Dam),], pedDf, by.x = c('Dam', 'Species'), by.y = c('Id', 'Species'), all.x = F, all.y = F)
+    grandParentOffspring1 <- rbind(
+      grandParentOffspring1 %>% select(Id, Dam.y, Species) %>% filter(!is.na(Dam.y)) %>% rename(Id2 = Dam.y) %>% mutate(Relationship = 'Grandchild/Maternal Granddam'),
+      grandParentOffspring1 %>% select(Id, Sire.y, Species) %>% filter(!is.na(Sire.y)) %>% rename(Id2 = Sire.y) %>% mutate(Relationship = 'Grandchild/Maternal Grandsire')
+    ) %>% mutate(ExpectedCoefficient = 0.25)
+
+    grandParentOffspring2 <- merge(pedDf[!is.na(pedDf$Sire),], pedDf, by.x = c('Sire', 'Species'), by.y = c('Id', 'Species'), all.x = F, all.y = F)
+    grandParentOffspring2 <- rbind(
+      grandParentOffspring2 %>% select(Id, Dam.y, Species) %>% filter(!is.na(Dam.y)) %>% rename(Id2 = Dam.y) %>% mutate(Relationship = 'Grandchild/Paternal Granddam'),
+      grandParentOffspring2 %>% select(Id, Sire.y, Species) %>% filter(!is.na(Sire.y)) %>% rename(Id2 = Sire.y) %>% mutate(Relationship = 'Grandchild/Paternal Grandsire')
+    ) %>% mutate(ExpectedCoefficient = 0.25)
+
+    fullSibs <- merge(pedDf[!is.na(pedDf$Dam) & !is.na(pedDf$Sire),], pedDf[!is.na(pedDf$Dam) & !is.na(pedDf$Sire),], by = c('Sire', 'Dam', 'Species'), all.x = F, all.y = F) %>%
+      select(Id.x, Id.y, Species) %>%
+      rename(Id = Id.x, Id2 = Id.y) %>%
+      mutate(Relationship = 'Full sib', ExpectedCoefficient = 0.25)
+
+    ret <- rbind(
+      parentChild,
+      grandParentOffspring1,
+      grandParentOffspring2,
+      fullSibs
+    )
+
+    # Generate the reciprocal of relationships as well:
+    ret2 <- data.frame(Id = ret$Id2, Id2 = ret$Id, Species = ret$Species, Relationship = ret$Relationship, ExpectedCoefficient = ret$ExpectedCoefficient)
+    ret2$Relationship <- sapply(ret2$Relationship, function(x){
+        x <- unlist(strsplit(x, split = '/'))
+        if (length(x) == 1) {
+            return(x)
+        }
+
+        return(paste0(x[2], '/', x[1]))
+    })
+
+    return(rbind(ret, ret2))
+}
+
+# Basic validation:
+toValidate <- merge(newRecords, generateExpectedKinship(pedDf), by = c('Id', 'Id2', 'Species'), all.x = T, all.y = T) %>%
+    filter(!is.na(ExpectedCoefficient)) %>%
+    mutate(MinCoefficient = ExpectedCoefficient / 2) %>%
+    filter(is.na(coefficient) | coefficient < MinCoefficient)
+
+if (nrow(toValidate) > 0) {
+    print(paste0('There were unexpected kinship values! See the file kinshipErrors.txt for more information'))
+    write.table(newRecords, file = "kinshipErrors.txt", append = FALSE, row.names=F, quote=F, sep='\t')
 }
 
 # write TSV to disk
-print("Output table:");
-print(str(newRecords));
-write.table(newRecords, file = "kinship.txt", append = FALSE,row.names=F,quote=F,sep="\t");
+print("Output table:")
+print(str(newRecords))
+write.table(newRecords, file = "kinship.txt", append = FALSE, row.names = FALSE, quote = FALSE, sep='\t')

--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -13,9 +13,19 @@ library(Matrix)
 library(dplyr)
 
 spec <- matrix(c(
-    'inputFile', '-f', 1, "character"
+    'inputFile', '-f', 1, 'character',
+    'mergeSpeciesWithHybrids', '-m', 0, 'logical',
+    'performKinshipValidation', '-v', 0, 'logical'
 ), ncol=4, byrow=TRUE)
 opts <- getopt(spec, commandArgs(trailingOnly = TRUE))
+
+if (is.null(opts$mergeSpeciesWithHybrids)){
+    opts$mergeSpeciesWithHybrids <- FALSE
+}
+
+if (is.null(opts$performKinshipValidation)){
+    opts$performKinshipValidation <- FALSE
+}
 
 allPed <- read.table(opts$inputFile, quote="\"")
 colnames(allPed)<-c('Id', 'Dam', 'Sire', 'Gender', 'Species')
@@ -23,24 +33,171 @@ colnames(allPed)<-c('Id', 'Dam', 'Sire', 'Gender', 'Species')
 allPed$Id[allPed$Id == ""] <- NA
 allPed$Dam[allPed$Dam == ""] <- NA
 allPed$Sire[allPed$Sire == ""] <- NA
-allPed$Gender[allPed$Gender == ""] <- NA
+allPed$Gender[allPed$Gender == "" | is.na(allPed$Gender)] <- 3 # 3 = unknown
 
 allPed$Species <- as.character(allPed$Species)
 allPed$Species[is.na(allPed$Species)] <- c('Unknown')
 allPed$Species <- as.factor(allPed$Species)
 
-# In order to reduce the max matrix size, calculate famids using makefamid, then analyze each group separately
-# It resizes the biggest matrix from 12000^2 to 8200^2 thus reduces the memory used by half
+if (any(allPed$Species == 'Unknown')) {
+    print(paste0('There are ', sum(allPed$Species == 'Unknown'), ' Ids with species = Unknown'))
+}
+
+# The purpose of this function is to handle instances where there was cross-breeding.
+# While this is probably rare, it can occur. When this happens, simply merge the entire species together and process as one unit.
+# This ensures that all relevant ancestors from both species are present
+generateSpeciesToProcess <- function(allPed, mergeSpeciesWithHybrids) {
+    hybridParents <- dplyr::bind_rows(
+      merge(allPed, allPed, by.x = 'Dam', by.y = 'Id') %>% filter(Species.x != Species.y) %>% select(Id, Dam, Species.x, Species.y) %>% rename(Parent = Dam) %>% mutate(ParentType = 'Dam'),
+      merge(allPed, allPed, by.x = 'Sire', by.y = 'Id') %>% filter(Species.x != Species.y) %>% select(Id, Sire, Species.x, Species.y) %>% rename(Parent = Sire) %>% mutate(ParentType = 'Sire')
+    )
+
+    if (nrow(hybridParents) > 0) {
+        print(paste0('There were ', nrow(hybridParents), ' records with parents of a different species'))
+    }
+
+    if (mergeSpeciesWithHybrids && nrow(hybridParents) > 0) {
+        speciesGroups <- as.list(as.character(unique(allPed$Species)))
+        toMerge <- unique(hybridParents[c('Species.x', 'Species.y')])
+        for (idx in 1:nrow(toMerge)){
+            speciesToCollapse <- as.character(unlist(toMerge[idx,,drop = TRUE]))
+            matchingIdx <- sapply(speciesGroups, function(x){
+                return(length(intersect(speciesToCollapse, x)) > 0)
+            })
+
+            speciesToCollapse <- sort(unique(c(speciesToCollapse, unlist(speciesGroups[matchingIdx]))))
+            speciesGroups <- speciesGroups[!matchingIdx]
+            speciesGroups <- append(speciesGroups, list(speciesToCollapse))
+        }
+
+        print('These species will be merged for processing:')
+        invisible(lapply(speciesGroups, function(x){
+            if (length(x) > 1) {
+                print(x)
+            }
+        }))
+
+        return(speciesGroups)
+    } else {
+        return(unique(allPed$Species[allPed$Species != 'Unknown']))
+    }
+}
+
+validateExpectedKinshipSubset <- function(dataToTest, expectedValues, errorRows, testReciprocal = TRUE) {
+    # Generate the reciprocal of relationships as well:
+    if (testReciprocal) {
+        ret2 <- data.frame(Id = expectedValues$Id2, Id2 = expectedValues$Id, Relationship = expectedValues$Relationship, ExpectedCoefficient = expectedValues$ExpectedCoefficient)
+        ret2$Relationship <- sapply(expectedValues$Relationship, function(x){
+            x <- unlist(strsplit(x, split = '/'))
+            if (length(x) == 1) {
+                return(x)
+            }
+
+            return(paste0(x[2], '/', x[1]))
+        })
+        expectedValues <- dplyr::bind_rows(expectedValues, ret2)
+        rm(ret2)
+    }
+
+    dat <- merge(dataToTest, expectedValues, by = c('Id', 'Id2'), all.x = T, all.y = T) %>%
+      filter(!is.na(ExpectedCoefficient)) %>%
+      filter(is.na(coefficient) | coefficient < ExpectedCoefficient)
+
+    if (nrow(dat) == 0) {
+        return(errorRows)
+    }
+
+    if (all(is.null(errorRows))) {
+        return(dat)
+    }
+
+    return(dplyr::bind_rows(errorRows, dat))
+}
+
+validateExpectedKinship <- function(pedDf, dataToTest) {
+    errorRows <- NULL
+
+    # See reference: https://en.wikipedia.org/wiki/Coefficient_of_relationship#Kinship_coefficient
+    self <- data.frame(Id = pedDf$Id, Id2 = pedDf$Id, Relationship = 'Self', ExpectedCoefficient = 0.5)
+    errorRows <- validateExpectedKinshipSubset(dataToTest, self, errorRows, testReciprocal = FALSE)
+    rm(self)
+
+    parentChild <- dplyr::bind_rows(
+      data.frame(Id = pedDf$Id, Id2 = pedDf$Dam, Relationship = 'Child/Parent'),
+      data.frame(Id = pedDf$Id, Id2 = pedDf$Sire, Relationship = 'Child/Parent')
+    ) %>% filter(!is.na(Id2)) %>% mutate(ExpectedCoefficient = 0.25)
+    errorRows <- validateExpectedKinshipSubset(dataToTest, parentChild, errorRows)
+    rm(parentChild)
+
+    grandParentOffspring1 <- merge(pedDf[!is.na(pedDf$Dam),], pedDf, by.x = c('Dam'), by.y = c('Id'), all.x = F, all.y = F)
+    grandParentOffspring1 <- dplyr::bind_rows(
+      grandParentOffspring1 %>% select(Id, Dam.y) %>% filter(!is.na(Dam.y)) %>% rename(Id2 = Dam.y) %>% mutate(Relationship = 'Grandchild/Maternal Granddam'),
+      grandParentOffspring1 %>% select(Id, Sire.y) %>% filter(!is.na(Sire.y)) %>% rename(Id2 = Sire.y) %>% mutate(Relationship = 'Grandchild/Maternal Grandsire')
+    ) %>% mutate(ExpectedCoefficient = 0.125)
+    errorRows <- validateExpectedKinshipSubset(dataToTest, grandParentOffspring1, errorRows)
+    rm(grandParentOffspring1)
+
+    grandParentOffspring2 <- merge(pedDf[!is.na(pedDf$Sire),], pedDf, by.x = c('Sire'), by.y = c('Id'), all.x = F, all.y = F)
+    grandParentOffspring2 <- dplyr::bind_rows(
+      grandParentOffspring2 %>% select(Id, Dam.y) %>% filter(!is.na(Dam.y)) %>% rename(Id2 = Dam.y) %>% mutate(Relationship = 'Grandchild/Paternal Granddam'),
+      grandParentOffspring2 %>% select(Id, Sire.y) %>% filter(!is.na(Sire.y)) %>% rename(Id2 = Sire.y) %>% mutate(Relationship = 'Grandchild/Paternal Grandsire')
+    ) %>% mutate(ExpectedCoefficient = 0.125)
+    errorRows <- validateExpectedKinshipSubset(dataToTest, grandParentOffspring2, errorRows)
+    rm(grandParentOffspring2)
+
+    fullSibs <- merge(pedDf[!is.na(pedDf$Dam) & !is.na(pedDf$Sire),], pedDf[!is.na(pedDf$Dam) & !is.na(pedDf$Sire),], by = c('Sire', 'Dam'), all.x = F, all.y = F) %>%
+      select(Id.x, Id.y) %>%
+      rename(Id = Id.x, Id2 = Id.y) %>%
+      filter(Id != Id2) %>%
+      mutate(Relationship = 'Full sib', ExpectedCoefficient = 0.25)
+    errorRows <- validateExpectedKinshipSubset(dataToTest, fullSibs, errorRows)
+    rm(fullSibs)
+
+    halfSibs1 <- merge(pedDf[!is.na(pedDf$Dam),], pedDf[!is.na(pedDf$Dam),], by = c('Dam'), all.x = F, all.y = F) %>%
+      filter(Sire.x != Sire.y) %>%
+      select(Id.x, Id.y) %>%
+      rename(Id = Id.x, Id2 = Id.y) %>%
+      filter(Id != Id2) %>%
+      mutate(Relationship = 'Half sib', ExpectedCoefficient = 0.125)
+    errorRows <- validateExpectedKinshipSubset(dataToTest, halfSibs1, errorRows)
+    rm(halfSibs1)
+
+    halfSibs2 <- merge(pedDf[!is.na(pedDf$Sire),], pedDf[!is.na(pedDf$Sire),], by = c('Sire'), all.x = F, all.y = F) %>%
+      filter(Dam.x != Dam.y) %>%
+      select(Id.x, Id.y) %>%
+      rename(Id = Id.x, Id2 = Id.y) %>%
+      filter(Id != Id2) %>%
+      mutate(Relationship = 'Half sib', ExpectedCoefficient = 0.125)
+    errorRows <- validateExpectedKinshipSubset(dataToTest, halfSibs2, errorRows)
+    rm(halfSibs2)
+
+    return(errorRows)
+}
+
+speciesToProcess <- generateSpeciesToProcess(allPed, opts$mergeSpeciesWithHybrids)
+
 newRecords <- NULL
-for (species in unique(allPed$Species)){
-    allRecordsForSpecies <- allPed[allPed$Species == species,]
-    print(paste0('Processing species: ', species, ', with ', nrow(allRecordsForSpecies), ' IDs'))
+for (speciesSet in speciesToProcess){
+    allRecordsForSpecies <- allPed[allPed$Species %in% speciesSet,]
+    print(paste0('Processing species set: ', paste0(speciesSet, collapse = ','), ', with ', nrow(allRecordsForSpecies), ' IDs'))
+    if (nrow(allRecordsForSpecies) == 1) {
+        print('single record, skipping')
+        newRecords <- dplyr::bind_rows(newRecords,data.frame(Id = allRecordsForSpecies$Id, Id2 = allRecordsForSpecies$Id, coefficient = 0.5, Species = allRecordsForSpecies$Species))
+        next
+    }
+
+    pctMissingSex <- sum(allRecordsForSpecies$Gender > 2) / nrow(allRecordsForSpecies)
+    if (pctMissingSex > 0.25) {
+        paste0('More than 25% of this species group are missing sex and cannot be processed by fixParents(), skipping')
+        newRecords <- dplyr::bind_rows(newRecords,data.frame(Id = allRecordsForSpecies$Id, Id2 = allRecordsForSpecies$Id, coefficient = 0.5, Species = allRecordsForSpecies$Species))
+        next
+    }
 
     # Add missing parents for accurate kinship calculations
     fixedRecords <- with(allRecordsForSpecies, fixParents(id = Id, dadid = Sire, momid = Dam, sex = Gender))
 
     # Kinship is expecting records to be sorted IAW it's own pedigree function
-    recordsForSpecies <- with(fixedRecords, pedigree(id=id,dadid=dadid,momid=momid,sex=sex,missid=0))
+    recordsForSpecies <- with(fixedRecords, pedigree(id = id, dadid = dadid, momid = momid, sex = sex, missid = 0))
 
     temp.kin <- kinship(recordsForSpecies)
 
@@ -55,74 +212,23 @@ for (species in unique(allPed$Species)){
     # Now filter out parents added for kinship calculation
     temp.tri <- dplyr::filter(temp.tri, grepl("^(?!addin).*$", Id, perl = TRUE))
     temp.tri <- dplyr::filter(temp.tri, grepl("^(?!addin).*$", Id2, perl = TRUE))
-    temp.tri$Species <- species
+    temp.tri <- merge(temp.tri, allRecordsForSpecies[c('Id', 'Species')], by = 'Id', all.x = TRUE)
 
-    newRecords <- rbind(newRecords,temp.tri)
-}
+    newRecords <- dplyr::bind_rows(newRecords,temp.tri)
 
-generateExpectedKinship <- function(pedDf) {
-    # See reference: https://en.wikipedia.org/wiki/Coefficient_of_relationship#Kinship_coefficient
-    self <- data.frame(Id = pedDf$Id, Id2 = pedDf$Id, Species = pedDf$Species, Relationship = 'Self', ExpectedCoefficient = 0.5)
-
-    parentChild <- rbind(
-      data.frame(Id = pedDf$Id, Id2 = pedDf$Dam, Species = pedDf$Species, Relationship = 'Child/Parent'),
-      data.frame(Id = pedDf$Id, Id2 = pedDf$Sire, Species = pedDf$Species, Relationship = 'Child/Parent')
-    ) %>% filter(!is.na(Id2)) %>% mutate(ExpectedCoefficient = 0.25)
-
-    grandParentOffspring1 <- merge(pedDf[!is.na(pedDf$Dam),], pedDf, by.x = c('Dam', 'Species'), by.y = c('Id', 'Species'), all.x = F, all.y = F)
-    grandParentOffspring1 <- rbind(
-      grandParentOffspring1 %>% select(Id, Dam.y, Species) %>% filter(!is.na(Dam.y)) %>% rename(Id2 = Dam.y) %>% mutate(Relationship = 'Grandchild/Maternal Granddam'),
-      grandParentOffspring1 %>% select(Id, Sire.y, Species) %>% filter(!is.na(Sire.y)) %>% rename(Id2 = Sire.y) %>% mutate(Relationship = 'Grandchild/Maternal Grandsire')
-    ) %>% mutate(ExpectedCoefficient = 0.125)
-
-    grandParentOffspring2 <- merge(pedDf[!is.na(pedDf$Sire),], pedDf, by.x = c('Sire', 'Species'), by.y = c('Id', 'Species'), all.x = F, all.y = F)
-    grandParentOffspring2 <- rbind(
-      grandParentOffspring2 %>% select(Id, Dam.y, Species) %>% filter(!is.na(Dam.y)) %>% rename(Id2 = Dam.y) %>% mutate(Relationship = 'Grandchild/Paternal Granddam'),
-      grandParentOffspring2 %>% select(Id, Sire.y, Species) %>% filter(!is.na(Sire.y)) %>% rename(Id2 = Sire.y) %>% mutate(Relationship = 'Grandchild/Paternal Grandsire')
-    ) %>% mutate(ExpectedCoefficient = 0.125)
-
-    fullSibs <- merge(pedDf[!is.na(pedDf$Dam) & !is.na(pedDf$Sire),], pedDf[!is.na(pedDf$Dam) & !is.na(pedDf$Sire),], by = c('Sire', 'Dam', 'Species'), all.x = F, all.y = F) %>%
-      select(Id.x, Id.y, Species) %>%
-      rename(Id = Id.x, Id2 = Id.y) %>%
-      filter(Id != Id2) %>%
-      mutate(Relationship = 'Full sib', ExpectedCoefficient = 0.25)
-
-    ret <- rbind(
-      parentChild,
-      grandParentOffspring1,
-      grandParentOffspring2,
-      fullSibs
-    )
-
-    # Generate the reciprocal of relationships as well:
-    ret2 <- data.frame(Id = ret$Id2, Id2 = ret$Id, Species = ret$Species, Relationship = ret$Relationship, ExpectedCoefficient = ret$ExpectedCoefficient)
-    ret2$Relationship <- sapply(ret2$Relationship, function(x){
-        x <- unlist(strsplit(x, split = '/'))
-        if (length(x) == 1) {
-            return(x)
+    # NOTE: perform per-species to save memory
+    if (opts$performKinshipValidation) {
+        print('Validating coefficients against expected values')
+        errorRows <- validateExpectedKinship(allRecordsForSpecies, temp.tri)
+        if (!all(is.null(errorRows))) {
+            fileName <- paste0('kinshipErrors_', paste0(speciesSet, collapse = '.'), '.txt')
+            print(paste0('There were unexpected kinship values! See the file ', fileName, ' for more information'))
+            write.table(newRecords, file = fileName, row.names = FALSE, quote = FALSE, sep = '\t')
+        } else {
+            print('All coefficients were within expected ranges from predicted values')
         }
-
-        return(paste0(x[2], '/', x[1]))
-    })
-
-    return(rbind(self, ret, ret2))
+    }
 }
-
-# Basic validation:
-toValidate <- merge(newRecords, generateExpectedKinship(allPed), by = c('Id', 'Id2', 'Species'), all.x = T, all.y = T)
-write.table(file = 'kinshipWithExpectedValues.txt', toValidate, sep = '\t', quote = F)
-
-toValidate <- toValidate %>%
-    filter(!is.na(ExpectedCoefficient)) %>%
-    filter(is.na(coefficient) | coefficient < ExpectedCoefficient)
-
-if (nrow(toValidate) > 0) {
-    print(paste0('There were unexpected kinship values! See the file kinshipErrors.txt for more information'))
-    write.table(newRecords, file = "kinshipErrors.txt", append = FALSE, row.names = FALSE, quote = FALSE, sep = '\t')
-} else {
-    print('All coefficients were within expected ranges from predicted values')
-}
-newRecords$Species <- NULL
 
 # write TSV to disk
 write.table(newRecords, file = "kinship.txt", append = FALSE, row.names = FALSE, quote = FALSE, sep = '\t')

--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -21,9 +21,9 @@ allPed <- read.table(opts$inputFile, quote="\"")
 colnames(allPed)<-c('Id', 'Dam', 'Sire', 'Gender', 'Species')
 
 allPed$Id[allPed$Id == ""] <- NA
-allPed$Id[allPed$Dam == ""] <- NA
-allPed$Id[allPed$Sire == ""] <- NA
-allPed$Id[allPed$Gender == ""] <- NA
+allPed$Dam[allPed$Dam == ""] <- NA
+allPed$Sire[allPed$Sire == ""] <- NA
+allPed$Gender[allPed$Gender == ""] <- NA
 
 allPed$Species <- as.character(allPed$Species)
 allPed$Species[is.na(allPed$Species)] <- c('Unknown')

--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -84,6 +84,10 @@ generateSpeciesToProcess <- function(allPed, mergeSpeciesWithHybrids) {
 }
 
 validateExpectedKinshipSubset <- function(dataToTest, expectedValues, errorRows, testReciprocal = TRUE) {
+    if (nrow(dataToTest) == 0 || nrow(expectedValues) == 0) {
+        return(errorRows)
+    }
+
     # Generate the reciprocal of relationships as well:
     if (testReciprocal) {
         ret2 <- data.frame(Id = expectedValues$Id2, Id2 = expectedValues$Id, Relationship = expectedValues$Relationship, ExpectedCoefficient = expectedValues$ExpectedCoefficient)

--- a/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
+++ b/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
@@ -26,6 +26,10 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
                 itemId: 'enabled'
             },{
                 xtype: 'checkbox',
+                fieldLabel: 'Allow Import During Business Hours?',
+                itemId: 'allowImportDuringBusinessHours'
+            },{
+                xtype: 'checkbox',
                 fieldLabel: 'Kinship validation?',
                 itemId: 'kinshipValidation',
                 listeners: {
@@ -107,6 +111,7 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
         this.down('#containerPath').setValue(results.containerPath);
         this.down('#kinshipValidation').setValue(results.kinshipValidation);
         this.down('#mergeSpeciesWithHybrids').setValue(results.mergeSpeciesWithHybrids);
+        this.down('#allowImportDuringBusinessHours').setValue(results.allowImportDuringBusinessHours)
     },
 
     saveData: function(){
@@ -118,7 +123,8 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
                 enabled: this.down('#enabled').getValue(),
                 hourOfDay: this.down('#hourOfDay').getValue(),
                 kinshipValidation: this.down('#kinshipValidation').getValue(),
-                mergeSpeciesWithHybrids: this.down('#mergeSpeciesWithHybrids').getValue()
+                mergeSpeciesWithHybrids: this.down('#mergeSpeciesWithHybrids').getValue(),
+                allowImportDuringBusinessHours: this.down('#allowImportDuringBusinessHours').getValue()
             },
             method : 'POST',
             scope: this,

--- a/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
+++ b/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
@@ -28,13 +28,25 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
                 xtype: 'checkbox',
                 fieldLabel: 'Kinship validation?',
                 itemId: 'kinshipValidation',
-                listeners : {
+                listeners: {
                     render: function(c) {
                         Ext4.create('Ext.tip.ToolTip', {
                             target: c.getEl(),
                             html: 'This will iterate pedigree queries to ensure a minimum kinship coefficient exists for parents, ' +
                                     'grandparents, offspring, full-siblings and half-siblings. This can significantly increase the time to ' +
                                     'complete the kinship calculations so should only be used when validating kinship and pedigree.'
+                        });
+                    }
+                }
+            },{
+                xtype: 'checkbox',
+                fieldLabel: 'Merge Species With Hybrids?',
+                itemId: 'mergeSpeciesWithHybrids',
+                listeners: {
+                    render: function (c) {
+                        Ext4.create('Ext.tip.ToolTip', {
+                            target: c.getEl(),
+                            html: 'If any hybrid animals are detected, these species groups will be merged and processed as one unit. Merging all these species together ensures that the correct ancestors from each side are present'
                         });
                     }
                 }
@@ -94,6 +106,7 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
         this.down('#hourOfDay').setValue(results.hourOfDay);
         this.down('#containerPath').setValue(results.containerPath);
         this.down('#kinshipValidation').setValue(results.kinshipValidation);
+        this.down('#mergeSpeciesWithHybrids').setValue(results.mergeSpeciesWithHybrids);
     },
 
     saveData: function(){
@@ -104,7 +117,8 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
                 containerPath: this.down('#containerPath').getValue(),
                 enabled: this.down('#enabled').getValue(),
                 hourOfDay: this.down('#hourOfDay').getValue(),
-                kinshipValidation: this.down('#kinshipValidation').getValue()
+                kinshipValidation: this.down('#kinshipValidation').getValue(),
+                mergeSpeciesWithHybrids: this.down('#mergeSpeciesWithHybrids').getValue()
             },
             method : 'POST',
             scope: this,

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -639,7 +639,7 @@ public class EHRController extends SpringActionController
                 errors.reject(ERROR_MSG, "Unable to find container for path: " + form.getContainerPath());
                 return null;
             }
-            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay(), form.isKinshipValidation());
+            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay(), form.isKinshipValidation(), form.isMergeSpeciesWithHybrids());
 
             return new ApiSimpleResponse("success", true);
         }
@@ -759,6 +759,7 @@ public class EHRController extends SpringActionController
         private int hourOfDay;
 
         private boolean _kinshipValidation;
+        private boolean _mergeSpeciesWithHybrids;
 
         public boolean isEnabled()
         {
@@ -799,6 +800,16 @@ public class EHRController extends SpringActionController
         {
             _kinshipValidation = kinshipValidation;
         }
+
+        public boolean isMergeSpeciesWithHybrids()
+        {
+            return _mergeSpeciesWithHybrids;
+        }
+
+        public void setMergeSpeciesWithHybrids(boolean mergeSpeciesWithHybrids)
+        {
+            _mergeSpeciesWithHybrids = mergeSpeciesWithHybrids;
+        }
     }
 
     @RequiresPermission(AdminPermission.class)
@@ -817,6 +828,7 @@ public class EHRController extends SpringActionController
             ret.put("enabled", GeneticCalculationsJob.isEnabled());
             ret.put("hourOfDay", GeneticCalculationsJob.getHourOfDay());
             ret.put("kinshipValidation", GeneticCalculationsJob.isKinshipValidation());
+            ret.put("mergeSpeciesWithHybrids", GeneticCalculationsJob.isMergeSpeciesWithHybrids());
 
             return new ApiSimpleResponse(ret);
         }

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -83,6 +83,7 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.settings.AppProps;
 import org.labkey.api.study.DatasetTable;
 import org.labkey.api.util.ExceptionUtil;
+import org.labkey.api.util.HtmlString;
 import org.labkey.api.util.HtmlStringBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
@@ -639,7 +640,7 @@ public class EHRController extends SpringActionController
                 errors.reject(ERROR_MSG, "Unable to find container for path: " + form.getContainerPath());
                 return null;
             }
-            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay(), form.isKinshipValidation(), form.isMergeSpeciesWithHybrids());
+            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay(), form.isKinshipValidation(), form.isMergeSpeciesWithHybrids(), form.isAllowImportDuringBusinessHours());
 
             return new ApiSimpleResponse("success", true);
         }
@@ -760,6 +761,7 @@ public class EHRController extends SpringActionController
 
         private boolean _kinshipValidation;
         private boolean _mergeSpeciesWithHybrids;
+        private boolean _allowImportDuringBusinessHours;
 
         public boolean isEnabled()
         {
@@ -810,6 +812,16 @@ public class EHRController extends SpringActionController
         {
             _mergeSpeciesWithHybrids = mergeSpeciesWithHybrids;
         }
+
+        public boolean isAllowImportDuringBusinessHours()
+        {
+            return _allowImportDuringBusinessHours;
+        }
+
+        public void setAllowImportDuringBusinessHours(boolean allowImportDuringBusinessHours)
+        {
+            _allowImportDuringBusinessHours = allowImportDuringBusinessHours;
+        }
     }
 
     @RequiresPermission(AdminPermission.class)
@@ -829,6 +841,7 @@ public class EHRController extends SpringActionController
             ret.put("hourOfDay", GeneticCalculationsJob.getHourOfDay());
             ret.put("kinshipValidation", GeneticCalculationsJob.isKinshipValidation());
             ret.put("mergeSpeciesWithHybrids", GeneticCalculationsJob.isMergeSpeciesWithHybrids());
+            ret.put("allowImportDuringBusinessHours", GeneticCalculationsJob.isAllowImportDuringBusinessHours());
 
             return new ApiSimpleResponse(ret);
         }
@@ -1262,7 +1275,7 @@ public class EHRController extends SpringActionController
         @Override
         public ModelAndView getConfirmView(Object form, BindException errors)
         {
-            return new HtmlView("This will cause the system to recalculate kinship and inbreeding coefficients on the colony.  Do you want to continue?");
+            return new HtmlView(HtmlString.of("This will cause the system to recalculate kinship and inbreeding coefficients on the colony.  Do you want to continue?"));
         }
 
         @Override

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -50,6 +50,7 @@ import org.labkey.api.module.ModuleHtmlView;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.module.ModuleProperty;
 import org.labkey.api.pipeline.PipeRoot;
+import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.pipeline.PipelineService;
 import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.query.DetailsURL;
@@ -78,10 +79,12 @@ import org.labkey.ehr.history.DefaultEncountersDataSource;
 import org.labkey.ehr.history.DefaultObservationsDataSource;
 import org.labkey.ehr.history.DefaultPregnanciesDataSource;
 import org.labkey.ehr.history.LabworkManager;
+import org.labkey.ehr.pipeline.GeneticCalculationsImportTask;
 import org.labkey.ehr.security.EHRSecurityManager;
 import org.labkey.ehr.table.DefaultEHRCustomizer;
 import org.labkey.ehr.table.SNOMEDCodesDisplayColumn;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -1049,5 +1052,11 @@ public class EHRServiceImpl extends EHRService
             simpleRawCol.setDisplayWidth("250");
             ti.addColumn(simpleRawCol);
         }
+    }
+
+    @Override
+    public void standaloneProcessKinshipAndInbreeding(Container c, User u, File pipelineDir, Logger log) throws PipelineJobException
+    {
+        GeneticCalculationsImportTask.standaloneProcessKinshipAndInbreeding(c, u, pipelineDir, log);
     }
 }

--- a/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
@@ -235,6 +235,13 @@ public class EHRDemographicsServiceImpl extends EHRDemographicsService
         reportDataChange(c, Collections.singletonList(Pair.of(schema, query)), ids, false);
     }
 
+    @Override
+    public void recalculateForAllIdsInCache(final Container c, final String schema, final String query, final boolean async)
+    {
+        List<String> cachedIds = _cache.getKeys().stream().map(x -> x.replaceAll(getCacheKeyPrefix(c), "")).toList();
+        reportDataChange(c, Collections.singletonList(Pair.of(schema, query)), cachedIds, async);
+    }
+
     public void reportDataChange(final Container c, final List<Pair<String, String>> changed, final List<String> ids, boolean async)
     {
         final User u = EHRService.get().getEHRUser(c);

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -153,8 +153,10 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
             processInbreeding(job.getContainer(), job.getUser(), support.getAnalysisDirectoryPath().toFile(), job.getLogger());
             processKinship(job.getContainer(), job.getUser(), support.getAnalysisDirectoryPath().toFile(), job.getLogger());
 
-            if (GeneticCalculationsJob.isKinshipValidation())
+            if (Boolean.parseBoolean(getJob().getParameters().get("kinshipValidation")))
+            {
                 validateKinship();
+            }
         }
 
         return new RecordedActionSet(actions);

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -16,6 +16,7 @@
 package org.labkey.ehr.pipeline;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
@@ -50,6 +51,7 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
+import org.labkey.api.reader.Readers;
 import org.labkey.api.security.User;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.PageFlowUtil;
@@ -116,7 +118,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public PipelineJob.Task<?> createTask(PipelineJob job)
         {
             GeneticCalculationsImportTask task = new GeneticCalculationsImportTask(this, job);
             setJoin(false);
@@ -145,8 +147,11 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
         }
         else
         {
-            processInbreeding();
-            processKinship();
+            PipelineJob job = getJob();
+            FileAnalysisJobSupport support = (FileAnalysisJobSupport) job;
+
+            processInbreeding(job.getContainer(), job.getUser(), support.getAnalysisDirectoryPath().toFile(), job.getLogger());
+            processKinship(job.getContainer(), job.getUser(), support.getAnalysisDirectoryPath().toFile(), job.getLogger());
 
             if (GeneticCalculationsJob.isKinshipValidation())
                 validateKinship();
@@ -155,24 +160,27 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
         return new RecordedActionSet(actions);
     }
 
-    private void processKinship() throws PipelineJobException
+    public static void standaloneProcessKinshipAndInbreeding(Container c, User u, File pipelineDir, Logger log) throws PipelineJobException
     {
-        PipelineJob job = getJob();
-        FileAnalysisJobSupport support = (FileAnalysisJobSupport) job;
+        processInbreeding(c, u, pipelineDir, log);
+        processKinship(c, u, pipelineDir, log);
+    }
 
-        File output = new File(support.getAnalysisDirectory(), KINSHIP_FILE);
+    private static void processKinship(Container c, User u, File pipelineDir, Logger log) throws PipelineJobException
+    {
+        File output = new File(pipelineDir, KINSHIP_FILE);
         if (!output.exists())
             throw new PipelineJobException("Unable to find file: " + output.getPath());
 
         DbSchema ehrSchema = EHRSchema.getInstance().getSchema();
         TableInfo kinshipTable = ehrSchema.getTable("kinship");
 
-        getJob().getLogger().info("Inspecting file length: " + output.getPath());
+        log.info("Inspecting file length: " + output.getPath());
 
         try
         {
             try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction();
-                 LineNumberReader lnr = new LineNumberReader(new BufferedReader(new FileReader(output))))
+                 LineNumberReader lnr = new LineNumberReader(Readers.getReader(output)))
             {
                 while (lnr.readLine() != null)
                 {
@@ -180,19 +188,19 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                         break;
                 }
                 int lineNumber = lnr.getLineNumber();
-                lnr.close();
-
                 if (lineNumber < 3)
+                {
                     throw new PipelineJobException("Too few lines found in output.  Line count was: " + lineNumber);
+                }
 
                 //delete all previous records
-                getJob().getLogger().info("Deleting existing rows");
-                Table.delete(kinshipTable, new SimpleFilter(FieldKey.fromString("container"), getJob().getContainerId(), CompareType.EQUAL));
+                log.info("Deleting existing rows");
+                Table.delete(kinshipTable, new SimpleFilter(FieldKey.fromString("container"), c.getId(), CompareType.EQUAL));
 
                 //NOTE: this process creates and deletes a ton of rows each day.  the rowId can balloon very quickly, so we reset it here
                 SqlSelector ss = new SqlSelector(kinshipTable.getSchema(), new SQLFragment("SELECT max(rowid) as expt FROM " + kinshipTable.getSelectName()));
                 List<Long> ret = ss.getArrayList(Long.class);
-                Integer maxVal;
+                int maxVal;
                 if (ret.isEmpty())
                 {
                     maxVal = 0;
@@ -230,9 +238,9 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
             }
 
             try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction();
-                 BufferedReader reader = new BufferedReader(new FileReader(output)))
+                 BufferedReader reader = Readers.getReader(output))
             {
-                getJob().getLogger().info("Inserting rows");
+                log.info("Inserting rows");
                 String line = null;
                 int lineNum = 0;
                 while ((line = reader.readLine()) != null)
@@ -246,7 +254,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                     if (fields[0].equalsIgnoreCase(fields[1]))
                         continue; //dont import self-kinship
 
-                    Map row = new HashMap<String, Object>();
+                    Map<String, Object> row = new HashMap<>();
                     assert fields[0].length() < 80 : "Field Id value too long: [" + fields[0] + ']';
                     assert fields[1].length() < 80 : "Field Id2 value too long: [" + fields[1] + "]";
 
@@ -261,19 +269,19 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                         throw new PipelineJobException("Invalid kinship coefficient on line " + (lineNum + 1) + " for IDs " + fields[0] + " and " + fields[1] + ": " + fields[2], e);
                     }
 
-                    row.put("container", job.getContainer().getId());
+                    row.put("container", c.getId());
                     row.put("created", new Date());
-                    row.put("createdby", job.getUser().getUserId());
-                    Table.insert(job.getUser(), kinshipTable, row);
+                    row.put("createdby", u.getUserId());
+                    Table.insert(u, kinshipTable, row);
                     lineNum++;
 
                     if (lineNum % 100000 == 0)
                     {
-                        getJob().getLogger().info("processed " + lineNum + " rows");
+                        log.info("processed " + lineNum + " rows");
                     }
                 }
 
-                job.getLogger().info("Inserted " + lineNum + " rows into ehr.kinship");
+                log.info("Inserted " + lineNum + " rows into ehr.kinship");
                 transaction.commit();
             }
         }
@@ -431,7 +439,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                 if (kinRelation != null)
                 {
                     foundKinships.add(id + "-" + kin);
-                    Double coefficient = rs.getDouble("coefficient");
+                    double coefficient = rs.getDouble("coefficient");
                     if (coefficient < getMinCoefficient(kinRelation.getRelation(), kinRelation.getRelationDetailed()))
                     {
                         PipelineJob job = getJob();
@@ -443,6 +451,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                 }
             }
         });
+
         for (String id : relations.keySet())
         {
             for (String kin : relations.get(id).keySet())
@@ -453,15 +462,12 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                     handleMissingCoefficient(job.getUser(), job.getContainer(), id, kin, relations.get(id).get(kin).getRelation());
                 }
             }
-
         }
-
     }
 
     private boolean validateKinshipType(TableInfo kinshipTable, TableInfo familyTable, List<String> familyMembers)
     {
-        PipelineJob job = getJob();
-        TableSelector familyTs = new TableSelector(familyTable, new LinkedHashSet(familyMembers));
+        TableSelector familyTs = new TableSelector(familyTable, new LinkedHashSet<>(familyMembers));
 
         Map<String, Map<String, Relationship>> relations = new HashMap<>();
         familyTs.forEach(rs -> {
@@ -564,7 +570,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
         return true;
     }
 
-    private TableInfo getRealTable(TableInfo ti)
+    private static TableInfo getRealTable(TableInfo ti)
     {
         Domain domain = ti.getDomain();
         if (domain != null)
@@ -575,48 +581,44 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
         return null;
     }
 
-    private void processInbreeding() throws PipelineJobException
+    private static void processInbreeding(Container c, User u, File pipelineDir, Logger log) throws PipelineJobException
     {
-        PipelineJob job = getJob();
-        FileAnalysisJobSupport support = (FileAnalysisJobSupport) job;
-
-        File output = new File(support.getAnalysisDirectory(), INBREEDING_FILE);
+        File output = new File(pipelineDir, INBREEDING_FILE);
         if (!output.exists())
             throw new PipelineJobException("Unable to find file: " + output.getPath());
 
-        UserSchema us = QueryService.get().getUserSchema(job.getUser(), job.getContainer(), "study");
+        UserSchema us = QueryService.get().getUserSchema(u, c, "study");
         TableInfo ti = us.getTable("Inbreeding Coefficients");
         if (ti == null)
         {
-            getJob().getLogger().warn("Unable to find table study.inbreeding coefficients");
+            log.warn("Unable to find table study.inbreeding coefficients");
             return;
         }
 
         QueryUpdateService qus = ti.getUpdateService();
         qus.setBulkLoad(true);
 
-        LineNumberReader lnr = null;
-        BufferedReader reader = null;
-
-        try
+        try (BufferedReader reader = Readers.getReader(output))
         {
             try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction())
             {
-                getJob().getLogger().info("Inspecting file length: " + output.getPath());
-                lnr = new LineNumberReader(new BufferedReader(new FileReader(output)));
-                while (lnr.readLine() != null)
+                log.info("Inspecting file length: " + output.getPath());
+                try (LineNumberReader lnr = new LineNumberReader(Readers.getReader(output)))
                 {
-                    if (lnr.getLineNumber() > 3)
-                        break;
+                    while (lnr.readLine() != null)
+                    {
+                        if (lnr.getLineNumber() > 3)
+                            break;
+                    }
+                    int lineNumber = lnr.getLineNumber();
+                    if (lineNumber < 3)
+                    {
+                        throw new PipelineJobException("Too few lines found in inbreeding output.  Line count was: " + lineNumber);
+                    }
                 }
-                int lineNumber = lnr.getLineNumber();
-                lnr.close();
-
-                if (lineNumber < 3)
-                    throw new PipelineJobException("Too few lines found in inbreeding output.  Line count was: " + lineNumber);
 
                 //delete all previous records
-                getJob().getLogger().info("Deleting existing rows");
+                log.info("Deleting existing rows");
                 TableInfo realTable = getRealTable(ti);
                 if (realTable == null)
                 {
@@ -628,14 +630,12 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                 transaction.commit();
             }
 
-            reader = new BufferedReader(new FileReader(output));
-
             String line;
             int lineNum = 0;
             List<Map<String, Object>> rows = new ArrayList<>();
             Date date = new Date();
 
-            getJob().getLogger().info("Reading file");
+            log.info("Reading file");
             while ((line = reader.readLine()) != null){
                 String[] fields = line.split("\t");
                 if (fields.length < 2)
@@ -643,11 +643,11 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                 if ("coefficient".equalsIgnoreCase(fields[1]))
                     continue; //skip header
 
-                Map row = new CaseInsensitiveHashMap<Object>();
+                Map<String, Object> row = new CaseInsensitiveHashMap<>();
                 String subjectId = StringUtils.trimToNull(fields[0]);
                 if (subjectId == null)
                 {
-                    getJob().getLogger().error("Missing subjectId on row " + lineNum);
+                    log.error("Missing subjectId on row " + lineNum);
                     continue;
                 }
 
@@ -660,22 +660,22 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                 lineNum++;
             }
 
-            getJob().getLogger().info("Inserting rows");
+            log.info("Inserting rows");
             BatchValidationException errors = new BatchValidationException();
 
             Map<Enum, Object> options = new HashMap<>();
-            options.put(QueryUpdateService.ConfigParameters.Logger, getJob().getLogger());
+            options.put(QueryUpdateService.ConfigParameters.Logger, log);
 
             try (DbScope.Transaction transaction = ExperimentService.get().ensureTransaction())
             {
-                qus.insertRows(getJob().getUser(), getJob().getContainer(), rows, errors, options, new HashMap<String, Object>());
+                qus.insertRows(u, c, rows, errors, options, new HashMap<>());
 
                 if (errors.hasErrors())
                     throw errors;
 
                 transaction.commit();
             }
-            job.getLogger().info("Inserted " + lineNum + " rows into inbreeding coefficients table");
+            log.info("Inserted " + lineNum + " rows into inbreeding coefficients table");
 
         }
         catch (DuplicateKeyException | SQLException | IOException | QueryUpdateServiceException e)
@@ -684,21 +684,13 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
         }
         catch (BatchValidationException e)
         {
-            getJob().getLogger().info("error inserting rows");
+            log.info("error inserting rows");
             for (ValidationException ve : e.getRowErrors())
             {
-                getJob().getLogger().info(ve.getMessage());
+                log.info(ve.getMessage());
             }
 
             throw new PipelineJobException(e);
-        }
-        finally
-        {
-            if (lnr != null)
-                try{lnr.close();}catch (Exception ignored){}
-
-            if (reader != null)
-                try{reader.close();}catch (Exception ignored){}
         }
     }
 }

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
@@ -33,6 +33,7 @@ import org.labkey.api.query.QueryService;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.util.FileType;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.writer.PrintWriters;
 import org.springframework.jdbc.BadSqlGrammarException;
 
 import java.io.File;
@@ -84,7 +85,7 @@ public class GeneticCalculationsInitTask extends PipelineJob.Task<GeneticCalcula
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public PipelineJob.Task<?> createTask(PipelineJob job)
         {
             GeneticCalculationsInitTask task = new GeneticCalculationsInitTask(this, job);
             setJoin(false);
@@ -138,7 +139,7 @@ public class GeneticCalculationsInitTask extends PipelineJob.Task<GeneticCalcula
 
             File outputFile = new File(support.getAnalysisDirectory(), GeneticCalculationsImportTask.PEDIGREE_FILE);
 
-            try (CSVWriter writer = new CSVWriter(new OutputStreamWriter(new FileOutputStream(outputFile)), '\t', CSVWriter.DEFAULT_QUOTE_CHARACTER))
+            try (CSVWriter writer = new CSVWriter(PrintWriters.getPrintWriter(outputFile), '\t', CSVWriter.DEFAULT_QUOTE_CHARACTER))
             {
                 long count = ts.getRowCount();
                 if (count > 0)

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
@@ -122,6 +122,16 @@ public class GeneticCalculationsJob implements Job
             return false;
     }
 
+    public static boolean isMergeSpeciesWithHybrids()
+    {
+        Map<String, String> saved = PropertyManager.getProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN);
+
+        if (saved.containsKey("mergeSpeciesWithHybrids"))
+            return Boolean.parseBoolean(saved.get("mergeSpeciesWithHybrids"));
+        else
+            return false;
+    }
+
     public static boolean isEnabled()
     {
         Map<String, String> saved = PropertyManager.getProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN);
@@ -152,13 +162,14 @@ public class GeneticCalculationsJob implements Job
         return null;
     }
 
-    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay, Boolean isKinshipValidation)
+    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay, Boolean isKinshipValidation, Boolean mergeSpeciesWithHybrids)
     {
         PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN, true);
         props.put("enabled", isEnabled.toString());
         props.put("container", c.getId());
         props.put("hourOfDay", hourOfDay.toString());
         props.put("kinshipValidation", isKinshipValidation.toString());
+        props.put("mergeSpeciesWithHybrids", mergeSpeciesWithHybrids.toString());
         props.save();
 
         //unschedule in case settings have changed

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
@@ -132,6 +132,17 @@ public class GeneticCalculationsJob implements Job
             return false;
     }
 
+
+    public static boolean isAllowImportDuringBusinessHours()
+    {
+        Map<String, String> saved = PropertyManager.getProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN);
+
+        if (saved.containsKey("allowImportDuringBusinessHours"))
+            return Boolean.parseBoolean(saved.get("allowImportDuringBusinessHours"));
+        else
+            return false;
+    }
+
     public static boolean isEnabled()
     {
         Map<String, String> saved = PropertyManager.getProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN);
@@ -162,7 +173,7 @@ public class GeneticCalculationsJob implements Job
         return null;
     }
 
-    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay, Boolean isKinshipValidation, Boolean mergeSpeciesWithHybrids)
+    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay, Boolean isKinshipValidation, Boolean mergeSpeciesWithHybrids, Boolean allowImportDuringBusinessHours)
     {
         PropertyManager.PropertyMap props = PropertyManager.getWritableProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN, true);
         props.put("enabled", isEnabled.toString());
@@ -170,6 +181,7 @@ public class GeneticCalculationsJob implements Job
         props.put("hourOfDay", hourOfDay.toString());
         props.put("kinshipValidation", isKinshipValidation.toString());
         props.put("mergeSpeciesWithHybrids", mergeSpeciesWithHybrids.toString());
+        props.put("allowImportDuringBusinessHours", allowImportDuringBusinessHours.toString());
         props.save();
 
         //unschedule in case settings have changed
@@ -193,7 +205,7 @@ public class GeneticCalculationsJob implements Job
         try
         {
             _log.info("Running Scheduled Genetic Calculations Job");
-            new GeneticCalculationsRunnable().run(c, false);
+            new GeneticCalculationsRunnable().run(c, isAllowImportDuringBusinessHours());
         }
         catch (PipelineJobException e)
         {

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
@@ -82,7 +82,7 @@ public class GeneticCalculationsRTask extends WorkDirectoryTask<GeneticCalculati
         }
 
         @Override
-        public PipelineJob.Task createTask(PipelineJob job)
+        public PipelineJob.Task<?> createTask(PipelineJob job)
         {
             GeneticCalculationsRTask task = new GeneticCalculationsRTask(this, job);
             setJoin(false);

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
@@ -86,6 +86,8 @@ public class GeneticCalculationsRunnable
             String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<bioml>\n" +
                     (allowRunningDuringDay ? "\t<note label=\"allowRunningDuringDay\" type=\"input\">true</note>" : "") +
+                    "\t<note label=\"kinshipValidation\" type=\"input\">" + GeneticCalculationsJob.isKinshipValidation() + "</note>" +
+                    "\t<note label=\"mergeSpeciesWithHybrids\" type=\"input\">" + GeneticCalculationsJob.isMergeSpeciesWithHybrids() + "</note>" +
                 "</bioml>";
 
             AbstractFileAnalysisProtocol<?> protocol = factory.createProtocolInstance(protocolName, "", xml);

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
@@ -31,6 +31,7 @@ import org.labkey.api.pipeline.file.AbstractFileAnalysisProvider;
 import org.labkey.api.pipeline.file.FileAnalysisTaskPipeline;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ConfigurationException;
+import org.labkey.api.util.StringUtilsLabKey;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewBackgroundInfo;
@@ -73,12 +74,12 @@ public class GeneticCalculationsRunnable
         {
             String taskIdString =  FileAnalysisTaskPipeline.class.getName() + ":" + KINSHIP_PIPELINE_NAME;
             TaskId taskId = new TaskId(taskIdString);
-            TaskPipeline taskPipeline = PipelineJobService.get().getTaskPipeline(taskId);
+            TaskPipeline<?> taskPipeline = PipelineJobService.get().getTaskPipeline(taskId);
             if (taskPipeline == null)
                 throw new PipelineJobException("Unable to find kinship pipeline: " + taskId);
 
             AbstractFileAnalysisProvider provider = (AbstractFileAnalysisProvider) PipelineService.get().getPipelineProvider("File Analysis");
-            AbstractFileAnalysisProtocolFactory factory = provider.getProtocolFactory(taskPipeline);
+            AbstractFileAnalysisProtocolFactory<?> factory = provider.getProtocolFactory(taskPipeline);
             ViewBackgroundInfo bg = new ViewBackgroundInfo(c, u, new ActionURL());
             PipeRoot root = PipelineService.get().getPipelineRootSetting(c);
             String protocolName = "EHR Kinship Calculation";
@@ -87,7 +88,7 @@ public class GeneticCalculationsRunnable
                     (allowRunningDuringDay ? "\t<note label=\"allowRunningDuringDay\" type=\"input\">true</note>" : "") +
                 "</bioml>";
 
-            AbstractFileAnalysisProtocol protocol = factory.createProtocolInstance(protocolName, "", xml);
+            AbstractFileAnalysisProtocol<?> protocol = factory.createProtocolInstance(protocolName, "", xml);
             if (protocol == null)
             {
                 return;
@@ -111,7 +112,7 @@ public class GeneticCalculationsRunnable
 
             defaultXml.getParentFile().mkdirs();
             defaultXml.createNewFile();
-            try (FileWriter w = new FileWriter(defaultXml))
+            try (FileWriter w = new FileWriter(defaultXml, StringUtilsLabKey.DEFAULT_CHARSET))
             {
                 w.write(xml);
             }
@@ -135,11 +136,7 @@ public class GeneticCalculationsRunnable
         {
             throw new ConfigurationException("The EHR kinship pipeline has not been configured on this server", e);
         }
-        catch (IOException e)
-        {
-            throw new PipelineJobException(e);
-        }
-        catch (PipelineValidationException e)
+        catch (IOException | PipelineValidationException e)
         {
             throw new PipelineJobException(e);
         }

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
@@ -85,7 +85,7 @@ public class GeneticCalculationsRunnable
             String protocolName = "EHR Kinship Calculation";
             String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<bioml>\n" +
-                    (allowRunningDuringDay ? "\t<note label=\"allowRunningDuringDay\" type=\"input\">true</note>" : "") +
+                    "\t<note label=\"allowRunningDuringDay\" type=\"input\">" + allowRunningDuringDay + "</note>" +
                     "\t<note label=\"kinshipValidation\" type=\"input\">" + GeneticCalculationsJob.isKinshipValidation() + "</note>" +
                     "\t<note label=\"mergeSpeciesWithHybrids\" type=\"input\">" + GeneticCalculationsJob.isMergeSpeciesWithHybrids() + "</note>" +
                 "</bioml>";


### PR DESCRIPTION
This PR contains two main categories of changes. The motivation of these changes was to separate the process of computing the data for EHR genetics (e.g. kinship and inbreeding) from actually importing the data into the EHR. In total, the idea is that PRIMe-seq (which already has a mirrored copy of pedigree data), will execute the default EHR GeneticsCalculation pipeline. It will farm the computation to our cluster, which that server is already configured to do. When complete, this pipeline already saves the results as TSV files. I wrote a separate ETL that will be defined in ONPRC modules, which copies the resulting TSVs to a location visible to PRIMe, and then pings PRIMe via a new server-side action to cause PRIMe to take those TSVs and call EHRService.standaloneProcessKinshipAndInbreeding to actually import them.

The changes within EHR itself are primarily to refactor the portions of the code that import the TSVs be to static, allow it to be called separately, and expose this through EHRService. These changes themselves are basically a refactor without touching much within the code itself.

When I got into the weeds of the R code, I noticed a number of other things that seemed worth cleaning up. These are not directly related to the importing of data, but should be broadly useful:

- I did some general style improvements in the R code, and removed some ancient strange patterns. This resulted in more code being touched, but most changes are minor.
- Since we now depend on dplyr anyway, I used it more, which should reduce the memory footprint b/c we can stream dataframes.
- I think I understand the intent behind "options(error = dump.frames)", but I dont think it was giving the result it should. In my hands, not only was this not writing anything to a file, the script did not die on errors. I'd argue it's a lot more useful if it dies when there's an error (such as not having kinship2 installed), rather than continue onward after errors and accumulate strange downstream errors. I tested this pretty thoroughly locally and I think R's default error handling (i.e. dont specify anything with options()) does as good a job as anything here. Here is an example (which requires a login), showing how the existing 23.7 code ignores R errors: https://prime-seq.ohsu.edu/pipeline-status/Internal/PMR/details.view?rowId=433466. 
- Marty's addition of the java-side validation step seems useful; however, I realized we already have all the information we need to replicate that in-memory within R. Using the input pedigree data, we can generate a table of expected coefficients and just merge that with the kinship data. The advantage is that this is really fast, and we can easily just do that every time. As-is, the pipeline job just logs the result; however, it would not be hard to respect the existing 'kinshipValidation' flag. 
