### PR TITLE
Form animal id flakiness

### DIFF
--- a/ehr/resources/web/ehr/form/field/AnimalField.js
+++ b/ehr/resources/web/ehr/form/field/AnimalField.js
@@ -19,8 +19,8 @@ Ext4.define('EHR.form.field.AnimalField.js', {
             this.fireEvent('animalchange', val);
         }, this, {buffer: 200});
 
-        this.on('blur', function(field, val, oldVal){
-            this.fireEvent('animalchange', val);
+        this.on('blur', function(field){
+            this.fireEvent('animalchange', field.value);
         }, this);
     },
 

--- a/ehr/resources/web/ehr/form/field/AnimalField.js
+++ b/ehr/resources/web/ehr/form/field/AnimalField.js
@@ -19,6 +19,7 @@ Ext4.define('EHR.form.field.AnimalField.js', {
             this.fireEvent('animalchange', val);
         }, this, {buffer: 200});
 
+        // Verify one more time when the field loses focus as change handler can be a little flaky
         this.on('blur', function(field){
             this.fireEvent('animalchange', field.value);
         }, this);

--- a/ehr/resources/web/ehr/form/field/AnimalField.js
+++ b/ehr/resources/web/ehr/form/field/AnimalField.js
@@ -18,6 +18,10 @@ Ext4.define('EHR.form.field.AnimalField.js', {
         this.on('change', function(field, val, oldVal){
             this.fireEvent('animalchange', val);
         }, this, {buffer: 200});
+
+        this.on('blur', function(field, val, oldVal){
+            this.fireEvent('animalchange', val);
+        }, this);
     },
 
     //NOTE: modules can override this method to enfore alternate rules


### PR DESCRIPTION
#### Rationale
The animal id form input looks up animal id as the user types. On occasion depending on how fast the id is typed and network variability affecting the response, this can be validating an id that is different than the actual input by a character. This just does one more check on blur.

#### Changes
* Add blur handler
