### PR TITLE
Cases update and override

### DIFF
--- a/ehr/resources/web/ehr/form/field/AnimalField.js
+++ b/ehr/resources/web/ehr/form/field/AnimalField.js
@@ -21,7 +21,7 @@ Ext4.define('EHR.form.field.AnimalField.js', {
 
         // Verify one more time when the field loses focus as change handler can be a little flaky
         this.on('blur', function(field){
-            this.fireEvent('animalchange', field.lastValue || field.value);
+            this.fireEvent('animalchange', field.getValue());
         }, this);
     },
 

--- a/ehr/resources/web/ehr/form/field/AnimalField.js
+++ b/ehr/resources/web/ehr/form/field/AnimalField.js
@@ -21,7 +21,7 @@ Ext4.define('EHR.form.field.AnimalField.js', {
 
         // Verify one more time when the field loses focus as change handler can be a little flaky
         this.on('blur', function(field){
-            this.fireEvent('animalchange', field.value);
+            this.fireEvent('animalchange', field.lastValue || field.value);
         }, this);
     },
 

--- a/ehr/resources/web/ehr/window/SedationWindow.js
+++ b/ehr/resources/web/ehr/window/SedationWindow.js
@@ -126,6 +126,47 @@ Ext4.define('EHR.window.SedationWindow', {
         }]
     },
 
+    getCodeField: function(key){
+        return {
+            xtype: 'combo',
+            key: key,
+            fieldName: 'code',
+            valueField: 'code',
+            displayField: 'displayField',
+            value: 'E-70590',
+            store: {
+                type: 'store',
+                fields: ['code', 'displayField', 'dosage'],
+                data: [
+                    {code: 'E-70590', displayField: 'Ketamine', dosage: 10},
+                    {code: 'E-YY992', displayField: 'Telazol', dosage: 3},
+                    {code: 'none', displayField: 'None', dosage: null}
+                ]
+            },
+            listeners: {
+                select: function(field, recs){
+                    if (!recs || recs.length != 1)
+                        return;
+
+                    var round = field.up('ehr-sedationwindow').down('#roundField').getValue();
+                    var dose = recs[0].get('dosage');
+                    var weightField = field.up('panel').down("field[key='" + field.key + "][fieldName='weight']");
+                    var dosageField = field.up('panel').down("numberfield[key='" + field.key + "][fieldName='dosage']");
+                    var amountField = field.up('panel').down("numberfield[key='" + field.key + "][fieldName='amount']");
+                    LDK.Assert.assertNotEmpty('Unable to find target field in SedationWindow', dosageField);
+
+                    var amount = weightField.getValue() ? Ext4.util.Format.round(weightField.getValue() * dose, 1) : null;
+
+                    dosageField.setValue(dose);
+
+                    amountField.suspendEvents();
+                    amountField.setValue(EHR.Utils.roundToNearest(amount, round));
+                    amountField.resumeEvents();
+                }
+            }
+        };
+    },
+
     getFinalItems: function(){
         var numCols = 7;
         var items = [{
@@ -211,44 +252,7 @@ Ext4.define('EHR.window.SedationWindow', {
                 value: minDate
             });
 
-            items.push({
-                xtype: 'combo',
-                key: key,
-                fieldName: 'code',
-                valueField: 'code',
-                displayField: 'displayField',
-                value: 'E-70590',
-                store: {
-                    type: 'store',
-                    fields: ['code', 'displayField', 'dosage'],
-                    data: [
-                        {code: 'E-70590', displayField: 'Ketamine', dosage: 10},
-                        {code: 'E-YY992', displayField: 'Telazol', dosage: 3},
-                        {code: 'none', displayField: 'None', dosage: null}
-                    ]
-                },
-                listeners: {
-                    select: function(field, recs){
-                        if (!recs || recs.length != 1)
-                            return;
-
-                        var round = field.up('ehr-sedationwindow').down('#roundField').getValue();
-                        var dose = recs[0].get('dosage');
-                        var weightField = field.up('panel').down("field[key='" + field.key + "][fieldName='weight']");
-                        var dosageField = field.up('panel').down("numberfield[key='" + field.key + "][fieldName='dosage']");
-                        var amountField = field.up('panel').down("numberfield[key='" + field.key + "][fieldName='amount']");
-                        LDK.Assert.assertNotEmpty('Unable to find target field in SedationWindow', dosageField);
-
-                        var amount = weightField.getValue() ? Ext4.util.Format.round(weightField.getValue() * dose, 1) : null;
-
-                        dosageField.setValue(dose);
-
-                        amountField.suspendEvents();
-                        amountField.setValue(EHR.Utils.roundToNearest(amount, round));
-                        amountField.resumeEvents();
-                    }
-                }
-            });
+            items.push(this.getCodeField(key));
 
             items.push({
                 xtype: 'ldk-numberfield',


### PR DESCRIPTION
#### Rationale
Couple updates to facilitate cases implementation. 
- AnimalField fix to account for auto-upper casing of Ids in forms - ensure the animal lookup is using getValue instead of accessing value directly (gets the upper cased values in this case). 
- Make code field in sedation window overridable to facilitate different snomed codes

#### Related Pull Requests
* https://github.com/LabKey/johnsHopkinsEHRModules/pull/112

#### Changes
* Use getValue instead of value on AnimalField blur
* Move code field into separate function in sedation window
