### PR TITLE
Expose EHRDemographicsService.recalculateForAllIdsInCache()

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRDemographicsService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRDemographicsService.java
@@ -50,4 +50,9 @@ abstract public class EHRDemographicsService
     abstract public AnimalRecord getAnimal(Container c, String id);
 
     abstract public List<AnimalRecord> getAnimals(Container c, Collection<String> ids);
+
+    /**
+     *
+     */
+    abstract public void recalculateForAllIdsInCache(final Container c, final String schema, final String query, final boolean async);
 }

--- a/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
@@ -235,6 +235,13 @@ public class EHRDemographicsServiceImpl extends EHRDemographicsService
         reportDataChange(c, Collections.singletonList(Pair.of(schema, query)), ids, false);
     }
 
+    @Override
+    public void recalculateForAllIdsInCache(final Container c, final String schema, final String query, final boolean async)
+    {
+        List<String> cachedIds = _cache.getKeys().stream().map(x -> x.replace(getCacheKeyPrefix(c), "")).toList();
+        reportDataChange(c, Collections.singletonList(Pair.of(schema, query)), cachedIds, async);
+    }
+
     public void reportDataChange(final Container c, final List<Pair<String, String>> changed, final List<String> ids, boolean async)
     {
         final User u = EHRService.get().getEHRUser(c);


### PR DESCRIPTION
#### Rationale
Center-specific modules want a little more control over cache behavior