### PR TITLE
Update query for EHR_SM ETL deleted rows

### DIFF
--- a/ehr/resources/queries/auditLog/DemographicsDeleted.sql
+++ b/ehr/resources/queries/auditLog/DemographicsDeleted.sql
@@ -1,10 +1,15 @@
-SELECT
-    a.Date,
-    substring(a.DataChanges, a.IdStart, CAST(LOCATE('&', a.DataChanges, LOCATE('&Id=', a.DataChanges) + 1) - a.IdStart AS INTEGER)) as Id
-FROM (
-    SELECT Date,
-    DataChanges,
-    LOCATE('&Id=', DataChanges) + LENGTH('&Id=') as IdStart
-    FROM DatasetAuditEvent
-    WHERE DatasetId.Name = 'demographics' AND Comment = 'A dataset record was deleted'
-    ) a
+WITH cte0 AS (
+    SELECT
+        a.Date,
+        substring(a.DataChanges, a.IdStart, CAST(LOCATE('&', a.DataChanges, LOCATE('&Id=', a.DataChanges) + 1) - a.IdStart AS INTEGER)) as Id
+    FROM (
+             SELECT Date,
+                 DataChanges,
+                 LOCATE('&Id=', DataChanges) + LENGTH('&Id=') as IdStart
+             FROM DatasetAuditEvent
+             WHERE DatasetId.Name = 'demographics' AND Comment = 'A dataset record was deleted'
+         ) AS a
+)
+SELECT c.Date, c.Id
+FROM cte0 AS c
+WHERE NOT EXISTS (SELECT 1 FROM study.demographics AS d WHERE c.Id = d.id)


### PR DESCRIPTION
#### Rationale
Update deleted rows source for EHR_SM to account for ids that are deleted then added back to demographics.

Author: @spamhurts 

#### Changes
* Update DemographicsDeleted query
