### PR TITLE
make ehr.notificationrecipients table extensible for other centers to add their own columns

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr-23.001-23.002.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr-23.001-23.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr.notificationrecipients ADD COLUMN LSID LSIDtype;

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-23.001-23.002.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-23.001-23.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr.notificationrecipients ADD Lsid LsidType null;

--- a/ehr/resources/schemas/ehr.xml
+++ b/ehr/resources/schemas/ehr.xml
@@ -759,6 +759,17 @@
                 <nullable>true</nullable>
                 <isHidden>true</isHidden>
             </column>
+            <column columnName="lsid">
+                <datatype>lsidtype</datatype>
+                <isReadOnly>true</isReadOnly>
+                <isHidden>true</isHidden>
+                <isUserEditable>false</isUserEditable>
+                <fk>
+                    <fkColumnName>ObjectUri</fkColumnName>
+                    <fkTable>Object</fkTable>
+                    <fkDbSchema>exp</fkDbSchema>
+                </fk>
+            </column>
         </columns>
     </table>
     <table tableName="form_framework_types" tableDbType="TABLE">

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -133,7 +133,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 23.001;
+        return 23.002;
     }
 
     @Override


### PR DESCRIPTION
 #### Rationale
Making ehr.notificationrecipients extensible to allow other centers to add their columns.

#### Related Pull Requests
* https://github.com/LabKey/johnsHopkinsEHRModules/pull/146

#### Changes
* add lsid column to notificationrecipients table
