### PR TITLE
Viral Load Assay JSON date

### DIFF
--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/AbstractWNPRCImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/AbstractWNPRCImportMethod.java
@@ -370,7 +370,7 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
             }
 
             //validate the row's date
-            if (row.get(DATE_FIELD) != null) {
+            if (!row.isNull(DATE_FIELD)) {
                 try {
                     Date date = ConvertHelper.convert(row.get(DATE_FIELD), Date.class);
                     _dateFormat.format(date);


### PR DESCRIPTION
#### Rationale
VL assay JSON parsing error

#### Changes
* use isNull to catch null or is not in JSON
