### PR TITLE
QCState option for location filter

### DIFF
--- a/ehr/resources/web/ehr/panel/LocationFilterType.js
+++ b/ehr/resources/web/ehr/panel/LocationFilterType.js
@@ -115,6 +115,11 @@ Ext4.define('EHR.panel.LocationFilterType', {
             removable: [],
             nonRemovable: []
         };
+
+        if (this.reportQCStates?.length) {
+            filterArray.nonRemovable.push(LABKEY.Filter.create('qcstate/label', this.reportQCStates, LABKEY.Filter.Types.EQUALS_ONE_OF));
+        }
+
         var area, room, cage;
 
         var areaFieldName = tab.report.areaFieldName;


### PR DESCRIPTION
#### Rationale
Use the reportQCStates option defined in the related PR to add a non-removable filter to location filter, when reportQCStates is defined.

#### Related Pull Requests
* https://github.com/LabKey/LabDevKitModules/pull/176

#### Changes
* If defined add filter on reportQCStates
