### PR TITLE
Populate EHR Lookups Select

### DIFF
--- a/ehr/resources/views/populateLookupData.html
+++ b/ehr/resources/views/populateLookupData.html
@@ -36,9 +36,16 @@
             result = confirm("Deleting lookups will delete all values populated from file or manually added. Delete lookups?");
         }
         else {
-            result = confirm("Populating lookups from file will delete any manual edits to lookups. Populate lookups from file?");
+            result = confirm("Populating lookups from file will delete any manual edits to the lookups. Populate lookups from file?");
         }
         if (result) {
+            let lookup;
+            if (isDelete) {
+                lookup = document.getElementById("deleteOptions").value;
+            }
+            else {
+                lookup = document.getElementById("populateOptions").value;
+            }
 
             document.getElementById("populateLookupResults").value = isDelete ? "Deleting..." : "Loading...";
             LABKEY.Ajax.request({
@@ -46,7 +53,8 @@
                 method: 'POST',
                 jsonData: {
                     delete: isDelete,
-                    manifest: manifest || null
+                    manifest: manifest || null,
+                    lookup: lookup
                 },
                 timeout: 100000,
                 success: LABKEY.Utils.getCallbackWrapper((response) => {
@@ -59,6 +67,40 @@
         }
     }
 
+    (function getLookups() {
+        const manifest = LABKEY.ActionURL.getParameter('manifest');
+
+        const container = "<%=containerPath%>";
+
+        LABKEY.Ajax.request({
+            url: LABKEY.ActionURL.buildURL("ehr", "getLookups", container),
+            jsonData: {
+                manifest: manifest || null
+            },
+            timeout: 100000,
+            success: LABKEY.Utils.getCallbackWrapper((response) => {
+                if (response?.lookups?.length > 0) {
+                    let populateDropdown = document.getElementById("populateOptions");
+                    let deleteDropdown = document.getElementById("deleteOptions");
+
+                    populateDropdown.innerHTML = "";
+                    deleteDropdown.innerHTML = "";
+
+                    response.lookups.forEach((lookup) => {
+                        let option = document.createElement("option");
+                        option.value = lookup;
+                        option.text = lookup;
+                        populateDropdown.appendChild(option);
+                        deleteDropdown.appendChild(option.cloneNode(true));
+                    });
+                }
+            }),
+            failure: LABKEY.Utils.getCallbackWrapper((response) => {
+                document.getElementById("populateLookupResults").value = "Failed: " + response.exception
+            })
+        });
+    })();
+
 </script>
 
 <html>
@@ -66,8 +108,14 @@
         <h5><b>
             <a style="margin-right: 30px; cursor: pointer;" onclick='populateReports(false); return false;'>Populate Reports</a>
             <a style="margin-right: 30px; cursor: pointer;" onclick='populateReports(true); return false;'>Delete Reports</a>
-            <a style="margin-right: 30px; cursor: pointer;" onclick='populateLookups(false); return false;'>Populate Lookups</a>
-            <a style="margin-right: 30px; cursor: pointer;" onclick='populateLookups(true); return false;'>Delete Lookups</a>
+            <a style="margin-right: 10px; cursor: pointer;" onclick='populateLookups(false); return false;'>Populate Lookups</a>
+            <select style="margin-right: 30px;" id="populateOptions" name="populateOptions">
+                <option value="all">All</option>
+            </select>
+            <a style="margin-right: 10px; cursor: pointer;" onclick='populateLookups(true); return false;'>Delete Lookups</a>
+            <select style="margin-right: 30px;" id="deleteOptions" name="populateOptions">
+                <option value="all">All</option>
+            </select>
         </b></h5>
     </div>
     <div>


### PR DESCRIPTION
#### Rationale
A new populate lookups UI was previously created which populates from file or deletes all lookups defined in the lookupsManifest file. This PR adds the ability to select single lookup tables from the lookupsManifest to delete or populate from file. 

This should now be a complete replacement for the previous EHR lookups UI. Once the individual centers are converted to this UI, we can delete the old UI.

#### Changes
* Add select options to populate and delete lookups.
* Add action to populate select option from lookupsManifest
* Add lookup to populateLookups action
