### PR TITLE
Collapsible Data Entry

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/dataentry/NonStoreFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/NonStoreFormSection.java
@@ -57,9 +57,9 @@ public class NonStoreFormSection extends AbstractFormSection
     @Override
     public JSONObject toJSON(DataEntryFormContext ctx, boolean includeFormElements)
     {
-        JSONObject json = super.toJSON(ctx, includeFormElements);
-        json.put("supportsTemplates", false);
+        JSONObject ret = super.toJSON(ctx, includeFormElements);
+        ret.put("supportsTemplates", false);
 
-        return json;
+        return ret;
     }
 }

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/NonStoreFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/NonStoreFormSection.java
@@ -57,9 +57,13 @@ public class NonStoreFormSection extends AbstractFormSection
     @Override
     public JSONObject toJSON(DataEntryFormContext ctx, boolean includeFormElements)
     {
-        JSONObject ret = super.toJSON(ctx, includeFormElements);
-        ret.put("supportsTemplates", false);
+        JSONObject json = super.toJSON(ctx, includeFormElements);
+        json.put("collapsible", true);
+        json.put("initCollapsed", true);
+        json.put("dataDependentCollapseHeader", false);
 
-        return ret;
+        json.put("supportsTemplates", false);
+
+        return json;
     }
 }

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/NonStoreFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/NonStoreFormSection.java
@@ -58,10 +58,6 @@ public class NonStoreFormSection extends AbstractFormSection
     public JSONObject toJSON(DataEntryFormContext ctx, boolean includeFormElements)
     {
         JSONObject json = super.toJSON(ctx, includeFormElements);
-        json.put("collapsible", true);
-        json.put("initCollapsed", true);
-        json.put("dataDependentCollapseHeader", false);
-
         json.put("supportsTemplates", false);
 
         return json;

--- a/ehr/resources/web/ehr/ehr_ext4_dataEntry.lib.xml
+++ b/ehr/resources/web/ehr/ehr_ext4_dataEntry.lib.xml
@@ -20,6 +20,7 @@
         <script path="ehr/plugin/DataBind.js"/>
         <script path="ehr/plugin/ResizableTextArea.js"/>
         <script path="ehr/plugin/RowEditor.js"/>
+        <script path="ehr/plugin/CollapsibleDataEntryPanel.js"/>
 
         <!--fields-->
         <script path="ehr/form/field/AnimalField.js"/>

--- a/ehr/resources/web/ehr/form/Panel.js
+++ b/ehr/resources/web/ehr/form/Panel.js
@@ -30,6 +30,10 @@ Ext4.define('EHR.form.Panel', {
             buttonAlign: 'left'
         });
 
+        if (this.formConfig.collapsible){
+            this.plugins = ['ehr-collapsibleDataEntryPanel'];
+        }
+
         this.bindConfig = this.bindConfig || {};
         LABKEY.Utils.mergeIf(this.bindConfig, {
             autoCreateRecordOnChange: true,

--- a/ehr/resources/web/ehr/grid/Panel.js
+++ b/ehr/resources/web/ehr/grid/Panel.js
@@ -17,6 +17,10 @@ Ext4.define('EHR.grid.Panel', {
             return;
         }
 
+        if (this.formConfig.collapsible){
+            this.plugins = ['ehr-collapsibleDataEntryPanel'];
+        }
+
         this.configureColumns();
         this.sortColumns();
 

--- a/ehr/resources/web/ehr/plugin/CollapsibleDataEntryPanel.js
+++ b/ehr/resources/web/ehr/plugin/CollapsibleDataEntryPanel.js
@@ -1,0 +1,44 @@
+
+/**
+ * A plugin for Ext.form.TextArea that will allow the box to be resized by the user.
+ */
+Ext4.define('EHR.plugin.CollapsibleDataEntryPanel', {
+    extend: 'Ext.AbstractPlugin',
+    alias: 'plugin.ehr-collapsibleDataEntryPanel',
+
+    init: function(panel){
+
+        panel.collapsible = true;
+
+        if ((!panel.store || panel.store.getCount() === 0) && panel.formConfig?.initCollapsed) {
+            panel.collapsed = true;
+        }
+
+        panel.on('collapse', function() {
+            if (!panel.formConfig.dataDependentCollapseHeader || (!panel.store || panel.store.getCount() === 0)) {
+                panel.header?.addCls('collapsed-dataentry-panel');
+            }
+        }, panel);
+
+        panel.on('expand', function() {
+            panel.header?.removeCls('collapsed-dataentry-panel');
+        }, panel);
+
+        panel.on('afterrender', function() {
+            if (panel.header) {
+                if ((!panel.formConfig.dataDependentCollapseHeader || panel.store?.getCount() === 0) && panel.formConfig.initCollapsed) {
+                    panel.header.addCls('collapsed-dataentry-panel');
+                }
+
+                panel.header.on('click', function () {
+                    if (panel.collapsed) {
+                        panel.expand();
+                    }
+                    else {
+                        panel.collapse();
+                    }
+                }, panel);
+            }
+        }, panel);
+    }
+});

--- a/ehr/resources/web/ehr/plugin/CollapsibleDataEntryPanel.js
+++ b/ehr/resources/web/ehr/plugin/CollapsibleDataEntryPanel.js
@@ -15,7 +15,7 @@ Ext4.define('EHR.plugin.CollapsibleDataEntryPanel', {
         }
 
         panel.on('collapse', function() {
-            if (!panel.formConfig.dataDependentCollapseHeader || (!panel.store || panel.store.getCount() === 0)) {
+            if (!panel.formConfig.dataDependentCollapseHeader || !panel.store || panel.store.getCount() === 0) {
                 panel.header?.addCls('collapsed-dataentry-panel');
             }
         }, panel);

--- a/ehr/resources/web/ehr/stylesheet.css
+++ b/ehr/resources/web/ehr/stylesheet.css
@@ -216,3 +216,7 @@ a:hover .ehr-tool-icon-lg {
 .clinical-history-print .x4-panel-body{
     overflow: visible !important;
 }
+
+.collapsed-dataentry-panel {
+    opacity: 0.5;
+}

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -155,7 +155,10 @@ public class EHRTestHelper
         Ext4CmpRef.waitForComponent(_test, query);
         Ext4GridRef grid = _test._ext4Helper.queryOne(query, Ext4GridRef.class);
         if (grid != null)
+        {
+            grid.expand();
             grid.setClicksToEdit(1);
+        }
 
         return grid;
     }


### PR DESCRIPTION
#### Rationale
EHR data entry forms can be very noisy, out of sequence with workflows and unclear for new users where to start entering data. This PR provides an optional way to collapse sections of the data entry forms to minimize the visible options when first navigating to the form. Headers of collapsed sections are visible with lower opacity and can be clicked to expand. Any sections with data entered will maintain full opacity of the header even when collapsed to ensure users do not forget they entered data in that section. Loading existing tasks with data will automatically expand any sections with data. 

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/1808

#### Changes
* Add CollapsibleDataEntryPanel plugin
* Update form and grid panels to add plugin if "collapsible" field is defined/true in the formConfig
* Opacity css update
* Test update
