### PR TITLE
Fix a longstanding typo in column label

### DIFF
--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -1210,8 +1210,8 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         ds.addColumn(col8);
 
         var col21 = getWrappedIdCol(us, ds, "MhcStatus", "demographicsMhcStatus");
-        col12.setLabel("MHC Status");
-        col12.setDescription("MHC status");
+        col21.setLabel("MHC Status");
+        col21.setDescription("MHC status");
         ds.addColumn(col21);
 
         var id = ds.getMutableColumn(ID_COL);


### PR DESCRIPTION
@labkey-martyp: this must be a really old typo. You can see this is adding a calculated column with variable named "col21", but it was setting label on "col12" (which is the mostRecentDeparture, i think). 