### PR TITLE
Sample and Animal Import Fixes

### DIFF
--- a/EHR_SM/resources/etls/animal_template.xml
+++ b/EHR_SM/resources/etls/animal_template.xml
@@ -8,7 +8,7 @@
             <description>Copy Animal Data to Animal Source</description>
             <!-- For source, update folderPath to the folder path of your EHR folder using dot notation. queryName can be
             demographics or another query if you want to copy in a subset of animals -->
-            <source schemaName="Site.folderPath.study" queryName="demographics">
+            <source sourceContainerPath="myEHRFolderPath" schemaName="study" queryName="demographics">
                 <sourceColumns>
                     <column>Id</column>
                 </sourceColumns>
@@ -19,7 +19,7 @@
     <incrementalFilter className="ModifiedSinceFilterStrategy" timestampColumnName="modified">
         <!-- For deletedRowsSource, update folderPath to the folder path of your EHR folder using dot notation.
          DemographicsDeleted is a query in the EHR to indicate when an animal record has been deleted using audit logs -->
-        <deletedRowsSource schemaName="Site.folderPath.auditLog" queryName="DemographicsDeleted" timestampColumnName="Date" deletedSourceKeyColumnName="Id" targetKeyColumnName="Id"/>
+        <deletedRowsSource sourceContainerPath="myEHRFolderPath" schemaName="auditLog" queryName="DemographicsDeleted" timestampColumnName="Date" deletedSourceKeyColumnName="Id" targetKeyColumnName="Id"/>
     </incrementalFilter>
     <schedule>
         <poll interval="1d"/>

--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMCustomizer.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMCustomizer.java
@@ -90,14 +90,16 @@ public class EHR_SMCustomizer extends AbstractTableCustomizer
             // Add to default columns
             List<FieldKey> defaultCols = new ArrayList<>(ti.getDefaultVisibleColumns());
 
-            FieldKey animalRecordFk = FieldKey.fromParts("AnimalRecord");
+            FieldKey animalRecordFk = FieldKey.fromParts("Id");
             var aliasCol = new AliasedColumn(idCol.getParentTable(), animalRecordFk, idCol, false);
             aliasCol.setShownInInsertView(false);
             aliasCol.setShownInUpdateView(false);
+            aliasCol.setRequired(false);
+            aliasCol.setLabel("Animal Record");
 
             defaultCols.add(animalRecordFk);
-            defaultCols.add(FieldKey.fromParts("AnimalRecord", "Demographics", "Species"));
-            defaultCols.add(FieldKey.fromParts("AnimalRecord", "Demographics", "Gender"));
+            defaultCols.add(FieldKey.fromParts("Id", "Demographics", "Species"));
+            defaultCols.add(FieldKey.fromParts("Id", "Demographics", "Gender"));
             ti.setDefaultVisibleColumns(defaultCols);
             ti.addColumn(aliasCol);
 


### PR DESCRIPTION
#### Rationale
A few updates and fixes to support sample and animal imports.

#### Changes
- Update ETL to use the sourceContainerPath instead of dot notation schema
- Make the Animal Record column not required
- Don't change the name of Id alias column, just give it a label
