### PR TITLE
Change EHR assignment triggers to registered triggers

### DIFF
--- a/ehr/resources/queries/study/assignment.js
+++ b/ehr/resources/queries/study/assignment.js
@@ -6,7 +6,7 @@
 
 require("ehr/triggers").initScript(this);
 
-function onInit(event, helper){
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'study', 'assignment', function(event, helper){
     helper.setScriptOptions({
         allowFutureDates: true,
         removeTimeFromDate: true,
@@ -49,9 +49,9 @@ function onInit(event, helper){
 
         helper.setProperty('assignmentsInTransaction', assignmentsInTransaction);
     });
-}
+});
 
-function onUpsert(helper, scriptErrors, row, oldRow){
+EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'assignment', function(helper, scriptErrors, row, oldRow){
     if (!helper.isETL()){
         //note: the the date field is handled above by removeTimeFromDate
         EHR.Server.Utils.removeTimeFromDate(row, scriptErrors, 'enddate');
@@ -80,4 +80,4 @@ function onUpsert(helper, scriptErrors, row, oldRow){
             }
         }
     }
-}
+});

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -19,7 +19,6 @@ import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.remoteapi.CommandResponse;
-import org.labkey.remoteapi.PostCommand;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.Locator;
 import org.labkey.test.pages.ehr.AnimalHistoryPage;
@@ -119,7 +118,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
     @Test
     public void testWeightValidation()
     {
-        //initialize wieght of subject 0
+        //initialize weight of subject 3
         String[] fields;
         Object[][] data;
         SimplePostCommand insertCommand;


### PR DESCRIPTION
#### Rationale
Change EHR assignment triggers to the newer registered type to allow centers to unregister them.

#### Changes
* Change trigger type of assignments INIT and BEFORE_UPSERT
