### PR TITLE
Resolve LabworkTypes in module dependency order to remove need for registerLabworkOverrides

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -329,14 +329,6 @@ abstract public class EHRService
     abstract public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges);
 
     /**
-     * Note: there is probably no need to use this method. Modules can simply register LabworkTypes using registerLabworkType().
-     * LabworkTypes are resolved in module dependency order, meaning if a center-specific module registers a type with the same name as a built-in
-     * type, the LabworkType from the center-specific module will be preferentially used instead of the built-in one.
-     */
-    @Deprecated
-    abstract public void registerLabWorkOverrides(Module module, String fromType, LabworkType toType);
-
-    /**
      * The EHR has a built-in GeneticsCalculations pipeline job that computes inbreeding and kinship based on the pedigree.
      * These are normally calculated in R, saved as TSVs, and imported using java code. This method is a separate entrypoint
      * that allows other code perform the calculations, save the results as TSVs, and then trigger import here.

--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -328,6 +328,12 @@ abstract public class EHRService
     /** The EHR expects certain QC states to exist. This will inspect the current study and create any missing QC states. **/
     abstract public List<String> ensureStudyQCStates(Container c, final User u, final boolean commitChanges);
 
+    /**
+     * Note: there is probably no need to use this method. Modules can simply register LabworkTypes using registerLabworkType().
+     * LabworkTypes are resolved in module dependency order, meaning if a center-specific module registers a type with the same name as a built-in
+     * type, the LabworkType from the center-specific module will be preferentially used instead of the built-in one.
+     */
+    @Deprecated
     abstract public void registerLabWorkOverrides(Module module, String fromType, LabworkType toType);
 
     /**

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultLabworkType.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultLabworkType.java
@@ -79,7 +79,7 @@ public class DefaultLabworkType implements LabworkType
     @NotNull
     private final Module _declaringModule;
 
-        public DefaultLabworkType(String name, String schemaName, String queryName, Module declaringModule)
+        public DefaultLabworkType(String name, String schemaName, String queryName, @NotNull Module declaringModule)
     {
         _name = name;
         _schemaName = schemaName;
@@ -116,6 +116,11 @@ public class DefaultLabworkType implements LabworkType
     public boolean isEnabled(Container c)
     {
         return c.getActiveModules().contains(_declaringModule);
+    }
+
+    public Module getDeclaringModule()
+    {
+        return _declaringModule;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -113,7 +113,6 @@ public class EHRServiceImpl extends EHRService
     private final List<DemographicsProvider> _demographicsProviders = new ArrayList<>();
     private final Map<REPORT_LINK_TYPE, List<ReportLink>> _reportLinks = new HashMap<>();
     private final MultiValuedMap<String, Pair<Module, Path>> _actionOverrides = new ArrayListValuedHashMap<>();
-    private final Map<String, Pair<Module, LabworkType>> _labWorkOverrides = new HashMap<>();
     private final List<Pair<Module, Resource>> _extraTriggerScripts = new ArrayList<>();
     private final Map<Module, List<Supplier<ClientDependency>>> _clientDependencies = new HashMap<>();
     private final Map<String, Map<String, List<Pair<Module, Class<? extends TableCustomizer>>>>> _tableCustomizers = new CaseInsensitiveHashMap<>();
@@ -1053,29 +1052,6 @@ public class EHRServiceImpl extends EHRService
             simpleRawCol.setDisplayWidth("250");
             ti.addColumn(simpleRawCol);
         }
-    }
-
-    @Override
-    @Deprecated
-    public void registerLabWorkOverrides(Module module, String fromType, LabworkType toType)
-    {
-        // If this is true, we can just use the normal registration pathway:
-        if (toType instanceof DefaultLabworkType dlt)
-        {
-            if (module.equals(dlt.getDeclaringModule()) && toType.getName().equals(fromType))
-            {
-                registerLabworkType(toType);
-                return;
-            }
-        }
-
-        _labWorkOverrides.put(fromType, Pair.of(module, toType));
-    }
-
-    @Deprecated
-    public Map<String, Pair<Module, LabworkType>> getLabWorkOverrides()
-    {
-        return _labWorkOverrides;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/EHRServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/EHRServiceImpl.java
@@ -1055,11 +1055,24 @@ public class EHRServiceImpl extends EHRService
         }
     }
 
+    @Override
+    @Deprecated
     public void registerLabWorkOverrides(Module module, String fromType, LabworkType toType)
     {
+        // If this is true, we can just use the normal registration pathway:
+        if (toType instanceof DefaultLabworkType dlt)
+        {
+            if (module.equals(dlt.getDeclaringModule()) && toType.getName().equals(fromType))
+            {
+                registerLabworkType(toType);
+                return;
+            }
+        }
+
         _labWorkOverrides.put(fromType, Pair.of(module, toType));
     }
 
+    @Deprecated
     public Map<String, Pair<Module, LabworkType>> getLabWorkOverrides()
     {
         return _labWorkOverrides;

--- a/ehr/src/org/labkey/ehr/history/LabworkManager.java
+++ b/ehr/src/org/labkey/ehr/history/LabworkManager.java
@@ -58,21 +58,9 @@ public class LabworkManager
 
     public Collection<LabworkType> getTypes(Container c)
     {
-        Map<String, Pair<Module, LabworkType>> labworkTypeOverrides = EHRServiceImpl.get().getLabWorkOverrides();
-
         Map<String, LabworkType> map = new LinkedHashMap<>();
         for (LabworkType type : _types)
         {
-            // NOTE: this override mechanism should not actually be needed, and would be great to phase out.
-            // This code is retained to allow legacy code to continue working. Performing a checking on whether the module is part of the
-            // container's active modules and checking LabworkType.isEnabled() is probably redundant,
-            // but the code does allow the user to provide them separately, so we should respect that.
-            if (labworkTypeOverrides.containsKey(type.getName()) && c.getActiveModules().contains(labworkTypeOverrides.get(type.getName()).first) && labworkTypeOverrides.get(type.getName()).second.isEnabled(c))
-            {
-                map.put(type.getName(), labworkTypeOverrides.get(type.getName()).second);
-                continue;
-            }
-
             // NOTE: Because modules initialize in dependency order, they will be registered in order and the code below should allow
             // center modules to override default EHR labwork types.
             // Also, if it ever becomes necessary for a center module to simply eliminate a built-in labwork type we could consider making a


### PR DESCRIPTION
@labkey-jeckels and @ankurjuneja: I had EHR open for a different PR and thought I would add this. In #687, there is code for a new mechanism to registerLabworkOverrides(). As I commented there, is that mechanism really needed? Other similar EHR resources are resolved in module dependency order, meaning that rather than needing to maintain separate lists for 'normal' and 'overrides', we might be able to just have one list. If a center module registers a resource with the same name as a built-in module, it would be preferentially used in favor of the built-in one. While LabworkTypes does not currently work this way, it is a simple fix to make it do that.

It is possible there is some complex use case I dont understand that requires a separate method. However, since a LabworkType already stores the owning module and implements isEnabled(), it seems unnecessary for registerLabworkOverride() to require a separate Module argument. If there is some reason that a caller would need a different owning module for the LabworkType and when registerLabworkOverride(), then that caller might be able to override isEnabled() on the LabworkType. If the use-case involved trying to disable a built-in LabworkType with a non-functional one (i.e. just remove the built-in), then I think one could register a LabworkType of the same name and override getResults() to return nothing. This NoOpLabworkType would replace the built-in and never report anything.

This PR leaves the existing registerLabworkOverrides, but deprecates it, so it's backwards compatible. However, if the LabworkType being registered uses the same Module and owningModule, then the code just registers that LabworkType with the regular entrypoint, since using an override is probably not needed.

I'm making assumptions about the motivations behind registerLabworkOverrides(), but if those assumption are valid then this PR should simplify things and make LabworkTypes more consistent with other EHR resources. 

Also, this is targeting 23.11, but I am not especially concerned about the target branch. Develop is also fine. 