### PR TITLE
Use PreparedStatement instead of looping Table.insert

### DIFF
--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -68,4 +68,5 @@ for (species in unique(allPed$Species)){
 
 # write TSV to disk
 print(paste0('Total kinship records: ', nrow(newRecords)))
+newRecords <- dplyr::arrange(newRecords, Id, Id2)
 write.table(newRecords, file = "kinship.txt", append = FALSE, row.names = FALSE, quote = FALSE, sep = '\t')

--- a/ehr/resources/pipeline/kinship/populateKinship.r
+++ b/ehr/resources/pipeline/kinship/populateKinship.r
@@ -67,4 +67,5 @@ for (species in unique(allPed$Species)){
 }
 
 # write TSV to disk
+print(paste0('Total kinship records: ', nrow(newRecords)))
 write.table(newRecords, file = "kinship.txt", append = FALSE, row.names = FALSE, quote = FALSE, sep = '\t')

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -286,9 +286,14 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
 
                     lineNum++;
 
+                    if (lineNum % 100000 == 0)
+                    {
+                        stmt.executeBatch();
+                    }
+
                     if (lineNum % 250000 == 0)
                     {
-                        log.info("prepared " + lineNum + " rows");
+                        log.info("imported " + lineNum + " rows");
                     }
                 }
 

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -187,11 +187,6 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
             {
                 while (lnr.readLine() != null)
                 {
-                    if (job != null && job.isCancelled())
-                    {
-                        throw new CancelledException();
-                    }
-
                     if (lnr.getLineNumber() > 3)
                         break;
                 }
@@ -257,9 +252,9 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                 int lineNum = 0;
                 while ((line = reader.readLine()) != null)
                 {
-                    if (this.is)
+                    if (job != null && job.isCancelled())
                     {
-
+                        throw new CancelledException();
                     }
 
                     String[] fields = line.split("\t");


### PR DESCRIPTION
@labkey-martyp, this is tangential to #730. Now that the kinship process is actually working, I forgot how long the insert takes. Matt keyed me in to using PreparedStatement instead of looping over Table.insert(). This should be a minor change that improves insert perf.