### PR TITLE
Migrate inline javascript event handlers

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/table/VetReviewDisplayColumn.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/VetReviewDisplayColumn.java
@@ -44,9 +44,10 @@ public class VetReviewDisplayColumn extends DataColumn
                     text = text.replaceAll("\\*\\*", "<span style=\"background-color: yellow;\">\\*\\*</span>");
                 }
 
-                out.write("<a style=\"max-width: 500px;\" onclick=\"EHR.panel.ClinicalManagementPanel.replaceSoap({objectid: " + PageFlowUtil.jsString(StringUtils.trimToNull(tokens[2])) + ", scope: this, callback: function(){EHR.panel.ClinicalManagementPanel.updateVetColumn(this, arguments[0], arguments[1]);}});\">");
-                out.write(text);
-                out.write("</a>");
+                Link.LinkBuilder link = new Link.LinkBuilder(text)
+                        .style("max-width: 500px;")
+                        .onClick("EHR.panel.ClinicalManagementPanel.replaceSoap({objectid: " + PageFlowUtil.jsString(StringUtils.trimToNull(tokens[2])) + ", scope: this, callback: function(){EHR.panel.ClinicalManagementPanel.updateVetColumn(this, arguments[0], arguments[1]);}});");
+                link.appendTo(out);
             }
         }
     }

--- a/ehr/api-src/org/labkey/api/ehr/table/VetReviewDisplayColumn.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/VetReviewDisplayColumn.java
@@ -6,6 +6,7 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.DataColumn;
 import org.labkey.api.data.RenderContext;
 import org.labkey.api.util.PageFlowUtil;
+import org.labkey.api.view.HttpView;
 import org.labkey.api.view.template.ClientDependency;
 
 import java.io.IOException;
@@ -15,6 +16,8 @@ import java.util.Set;
 
 public class VetReviewDisplayColumn extends DataColumn
 {
+    private boolean _clickHandlerRegistered = false;
+
     public VetReviewDisplayColumn(ColumnInfo col)
     {
         super(col);
@@ -44,10 +47,15 @@ public class VetReviewDisplayColumn extends DataColumn
                     text = text.replaceAll("\\*\\*", "<span style=\"background-color: yellow;\">\\*\\*</span>");
                 }
 
-                Link.LinkBuilder link = new Link.LinkBuilder(text)
-                        .style("max-width: 500px;")
-                        .onClick("EHR.panel.ClinicalManagementPanel.replaceSoap({objectid: " + PageFlowUtil.jsString(StringUtils.trimToNull(tokens[2])) + ", scope: this, callback: function(){EHR.panel.ClinicalManagementPanel.updateVetColumn(this, arguments[0], arguments[1]);}});");
-                link.appendTo(out);
+                out.write("<a style=\"max-width: 500px;\" class=\"labkey-text-link vrdc-row\" data-objectid=" + PageFlowUtil.jsString(StringUtils.trimToNull(tokens[2])) + ">");
+
+                if (!_clickHandlerRegistered)
+                {
+                    HttpView.currentPageConfig().addHandlerForQuerySelector("a.vrdc-row", "click", "EHR.panel.ClinicalManagementPanel.replaceSoap({objectid: this.attributes.getNamedItem('data-objectid').value, scope: this, callback: function(){EHR.panel.ClinicalManagementPanel.updateVetColumn(this, arguments[0], arguments[1]);}});" );
+                    _clickHandlerRegistered = true;
+                }
+                out.write(text);
+                out.write("</a>");
             }
         }
     }

--- a/ehr/api-src/org/labkey/api/ehr/table/VetReviewDisplayColumn.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/VetReviewDisplayColumn.java
@@ -47,7 +47,7 @@ public class VetReviewDisplayColumn extends DataColumn
                     text = text.replaceAll("\\*\\*", "<span style=\"background-color: yellow;\">\\*\\*</span>");
                 }
 
-                out.write("<a style=\"max-width: 500px;\" class=\"labkey-text-link vrdc-row\" data-objectid=" + PageFlowUtil.jsString(StringUtils.trimToNull(tokens[2])) + ">");
+                out.write("<a style=\"max-width: 500px;\" class=\"labkey-text-link vrdc-row\" data-objectid=\"" + PageFlowUtil.filter(StringUtils.trimToNull(tokens[2])) + "\">");
 
                 if (!_clickHandlerRegistered)
                 {

--- a/ehr/resources/web/ehr/panel/SnapshotPanel.js
+++ b/ehr/resources/web/ehr/panel/SnapshotPanel.js
@@ -140,7 +140,8 @@ Ext4.define('EHR.panel.SnapshotPanel', {
                     items: [{
                         xtype: 'displayfield',
                         fieldLabel: 'Flags',
-                        name: 'flags'
+                        name: 'flags',
+                        itemId: 'flags'
                     },{
                         xtype: 'displayfield',
                         fieldLabel: 'Last TB Date',

--- a/ehr/resources/web/ehr/panel/SnapshotPanel.js
+++ b/ehr/resources/web/ehr/panel/SnapshotPanel.js
@@ -41,7 +41,7 @@ Ext4.define('EHR.panel.SnapshotPanel', {
         this.on('afterrender', function() {
 
             var displayField = this.down('#flags');
-            if (displayField.getEl()) {
+            if (displayField && displayField.getEl()) {
 
                 var anchor = displayField.getEl('flagsLink');
 

--- a/ehr/resources/web/ehr/panel/SnapshotPanel.js
+++ b/ehr/resources/web/ehr/panel/SnapshotPanel.js
@@ -31,8 +31,10 @@ Ext4.define('EHR.panel.SnapshotPanel', {
         });
 
         this.callParent();
+        let anmId;
 
         if (this.subjectId){
+            anmId = this.subjectId;
             this.isLoading = true;
             this.setLoading(true);
             this.loadData();
@@ -48,7 +50,9 @@ Ext4.define('EHR.panel.SnapshotPanel', {
                 if (anchor) {
                     Ext4.get(anchor).on('click', function(e) {
                         e.preventDefault();
-                        EHR.Utils.showFlagPopup(this.subjectId, this);
+                        if (anmId) {
+                            EHR.Utils.showFlagPopup(anmId, this);
+                        }
                     });
                 }
             }

--- a/ehr/resources/web/ehr/panel/SnapshotPanel.js
+++ b/ehr/resources/web/ehr/panel/SnapshotPanel.js
@@ -37,6 +37,22 @@ Ext4.define('EHR.panel.SnapshotPanel', {
             this.setLoading(true);
             this.loadData();
         }
+
+        this.on('afterrender', function() {
+
+            var displayField = this.down('#flags');
+            if (displayField.getEl()) {
+
+                var anchor = displayField.getEl('flagsLink');
+
+                if (anchor) {
+                    Ext4.get(anchor).on('click', function(e) {
+                        e.preventDefault();
+                        EHR.Utils.showFlagPopup(this.subjectId, this);
+                    });
+                }
+            }
+        }, this);
     },
 
     getBaseItems: function(){
@@ -702,7 +718,7 @@ Ext4.define('EHR.panel.SnapshotPanel', {
             }
         }
 
-        toSet['flags'] = values.length ? '<a onclick="EHR.Utils.showFlagPopup(\'' + LABKEY.Utils.encodeHtml(this.subjectId) + '\', this);">' + values.join('<br>') + '</div>' : null;
+        toSet['flags'] = values.length ? '<a id="flagsLink">' + values.join('<br>') + '</div>' : null;
     },
 
     getFlagDisplayValue: function(row) {

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -827,10 +827,10 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
                         Date date = (Date) ctx.get("date");
                         Object id = ctx.get(ID_COL);
 
-                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\">[Show Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\" data-objectid=" + objectid + " data-id=" + id + " data-date=" + date.toString() + ">[Show Hx]</a></span>");
                         if (!_clickHandlerAdded)
                         {
-                            HttpView.currentPageConfig().addHandlerForQuerySelector("a.anm-history", "click", "EHR.window.ClinicalHistoryWindow.showClinicalHistory('" + objectid + "', '" + id + "', '" + date + "', this);");
+                            HttpView.currentPageConfig().addHandlerForQuerySelector("a.anm-history", "click", "EHR.window.ClinicalHistoryWindow.showClinicalHistory(this.attributes.getNamedItem('data-objectid').value , this.attributes.getNamedItem('data-id').value, this.attributes.getNamedItem('data-date').value, this);");
                             _clickHandlerAdded = true;
                         }
                     }

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -827,7 +827,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
                         Date date = (Date) ctx.get("date");
                         Object id = ctx.get(ID_COL);
 
-                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\" data-objectid=" + PageFlowUtil.filter(objectid) + " data-id=" + PageFlowUtil.filter(id) + " data-date=" + PageFlowUtil.filter(date) + ">[Show Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\" data-objectid=\"" + PageFlowUtil.filter(objectid) + "\" data-id=\"" + PageFlowUtil.filter(id) + "\" data-date=\"" + PageFlowUtil.filter(date) + "\">[Show Hx]</a></span>");
                         if (!_clickHandlerAdded)
                         {
                             HttpView.currentPageConfig().addHandlerForQuerySelector("a.anm-history", "click", "EHR.window.ClinicalHistoryWindow.showClinicalHistory(this.attributes.getNamedItem('data-objectid').value , this.attributes.getNamedItem('data-id').value, this.attributes.getNamedItem('data-date').value, this);");

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -827,7 +827,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
                         Date date = (Date) ctx.get("date");
                         Object id = ctx.get(ID_COL);
 
-                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\" data-objectid=" + objectid + " data-id=" + id + " data-date=" + date.toString() + ">[Show Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\" data-objectid=" + PageFlowUtil.filter(objectid) + " data-id=" + PageFlowUtil.filter(id) + " data-date=" + PageFlowUtil.filter(date) + ">[Show Hx]</a></span>");
                         if (!_clickHandlerAdded)
                         {
                             HttpView.currentPageConfig().addHandlerForQuerySelector("a.anm-history", "click", "EHR.window.ClinicalHistoryWindow.showClinicalHistory(this.attributes.getNamedItem('data-objectid').value , this.attributes.getNamedItem('data-id').value, this.attributes.getNamedItem('data-date').value, this);");

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -824,7 +824,8 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
                         Date date = (Date) ctx.get("date");
                         Object id = ctx.get(ID_COL);
 
-                        out.write("<span style=\"white-space:nowrap\"><a href=\"javascript:void(0);\" onclick=\"EHR.window.ClinicalHistoryWindow.showClinicalHistory('" + objectid + "', '" + id + "', '" + date + "', this);\">[Show Hx]</a></span>");
+                        Link.LinkBuilder link = new Link.LinkBuilder("[Show Hx]").onClick("EHR.window.ClinicalHistoryWindow.showClinicalHistory('" + objectid + "', '" + id + "', '" + date + "', this);");
+                        DOM.createHtmlFragment(SPAN(at(style, "white-space:nowrap"), link, null)).appendTo(out);
                     }
 
                     @Override

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -828,10 +828,10 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
                         Date date = (Date) ctx.get("date");
                         Object id = ctx.get(ID_COL);
 
-                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\" data-objectid=\"" + PageFlowUtil.filter(objectid) + "\" data-id=\"" + PageFlowUtil.filter(id) + "\" data-date=\"" + PageFlowUtil.filter(date) + "\">[Show Hx]</a></span>");
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\" data-id=\"" + PageFlowUtil.filter(id) + "\">[Show Hx]</a></span>");
                         if (!_clickHandlerAdded)
                         {
-                            HttpView.currentPageConfig().addHandlerForQuerySelector("a.anm-history", "click", "EHR.window.ClinicalHistoryWindow.showClinicalHistory(this.attributes.getNamedItem('data-objectid').value , this.attributes.getNamedItem('data-id').value, this.attributes.getNamedItem('data-date').value, this);");
+                            HttpView.currentPageConfig().addHandlerForQuerySelector("a.anm-history", "click", "EHR.window.ClinicalHistoryWindow.showClinicalHistory(null , this.attributes.getNamedItem('data-id').value, null, this);");
                             _clickHandlerAdded = true;
                         }
                     }

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -65,6 +65,7 @@ import org.labkey.api.study.DatasetTable;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
 import org.labkey.api.util.logging.LogHelper;
+import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.template.ClientDependency;
 import org.labkey.ehr.EHRModule;
@@ -97,6 +98,8 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
     private static final Logger _log = LogHelper.getLogger(DefaultEHRCustomizer.class, "Setup and configuration of EHR data tables, including calculated columns and special lookups");
     private boolean _addLinkDisablers = true;
     private static final String MORE_ACTIONS = "More Actions";
+
+    private boolean _clickHandlerAdded = false;
 
     public DefaultEHRCustomizer()
     {
@@ -824,8 +827,12 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
                         Date date = (Date) ctx.get("date");
                         Object id = ctx.get(ID_COL);
 
-                        Link.LinkBuilder link = new Link.LinkBuilder("[Show Hx]").onClick("EHR.window.ClinicalHistoryWindow.showClinicalHistory('" + objectid + "', '" + id + "', '" + date + "', this);");
-                        DOM.createHtmlFragment(SPAN(at(style, "white-space:nowrap"), link, null)).appendTo(out);
+                        out.write("<span style=\"white-space:nowrap\"><a class=\"labkey-text-link anm-history\">[Show Hx]</a></span>");
+                        if (!_clickHandlerAdded)
+                        {
+                            HttpView.currentPageConfig().addHandlerForQuerySelector("a.anm-history", "click", "EHR.window.ClinicalHistoryWindow.showClinicalHistory('" + objectid + "', '" + id + "', '" + date + "', this);");
+                            _clickHandlerAdded = true;
+                        }
                     }
 
                     @Override

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -64,6 +64,7 @@ import org.labkey.api.study.Dataset;
 import org.labkey.api.study.DatasetTable;
 import org.labkey.api.study.Study;
 import org.labkey.api.study.StudyService;
+import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.logging.LogHelper;
 import org.labkey.api.view.HttpView;
 import org.labkey.api.view.NavTree;


### PR DESCRIPTION
#### Rationale
A strict (no 'unsafe-inline' directive) CSP forbids all inline events. Instead, events must be attached via JavaScript inside a properly nonced script tag

#### Changes
* snapshotPanel.js
* DefaultEHRCustomizer
* VetReviewDisplayColumn
