### PR TITLE
Convert assignment trigger back to non-registered trigger

### DIFF
--- a/ehr/resources/queries/study/assignment.js
+++ b/ehr/resources/queries/study/assignment.js
@@ -6,7 +6,7 @@
 
 require("ehr/triggers").initScript(this);
 
-EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.INIT, 'study', 'assignment', function(event, helper){
+function onInit(event, helper){
     helper.setScriptOptions({
         allowFutureDates: true,
         removeTimeFromDate: true,
@@ -49,7 +49,7 @@ EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Even
 
         helper.setProperty('assignmentsInTransaction', assignmentsInTransaction);
     });
-});
+}
 
 EHR.Server.TriggerManager.registerHandlerForQuery(EHR.Server.TriggerManager.Events.BEFORE_UPSERT, 'study', 'assignment', function(helper, scriptErrors, row, oldRow){
     if (!helper.isETL()){


### PR DESCRIPTION
#### Rationale
This INIT trigger was recently converted to a registered trigger. Upon further testing, it is clear that EHR module init triggers should always remain the traditional non-registered type. This is due to the order of execution of triggers up the dependency tree and with traditional ehr triggers firing before registered triggers. A registered ehr INIT trigger would always execute last and not be overridable. 

#### Changes
* Convert assignment INIT trigger back to traditional ehr trigger.
