### PR TITLE
Remove redundant task dependency

### DIFF
--- a/EHR_App/build.gradle
+++ b/EHR_App/build.gradle
@@ -11,5 +11,3 @@ dependencies
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:ehrModules:ehr", depProjectConfig: "published", depExtension: "module")
             BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "published", depExtension: "module")
         }
-
-tasks.named('module').configure { dependsOn(project(":server:modules:LabDevKitModules:LDK").tasks.module) }


### PR DESCRIPTION
#### Rationale
Since there is a dependency declared between this module and the LDK module via the `modules` configuration, there is no need to declare a separate task dependency. Adding this declaration causes problems when trying to use `-PbuildFromSource=false`

#### Changes
* Remove task dependency
