### PR TITLE
Add a 24.00x db script to create a new ehr_billing table if it doesn't exist 

### DIFF
--- a/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-24.000-24.001.sql
+++ b/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-24.000-24.001.sql
@@ -1,0 +1,20 @@
+-- this table should consists of the rows with schema name, query name where the resulting rows of that query are associated with a chargeId, chargeId, and description of the query
+CREATE TABLE IF NOT EXISTS ehr_billing.procedureQueryChargeIdAssoc (
+
+                                                                       rowId SERIAL NOT NULL,
+                                                                       schemaName varchar(200) NOT NULL,
+    queryName varchar(500) NOT NULL,
+    description varchar(2000) NOT NULL,
+    chargeId int NOT NULL,
+
+    container ENTITYID NOT NULL,
+    createdBy USERID,
+    created timestamp,
+    modifiedBy USERID,
+    modified timestamp,
+
+    CONSTRAINT PK_procedureQueryChargeIdAssociations PRIMARY KEY (rowId),
+    CONSTRAINT FK_EHR_BILLING_PROCEDURE_QUERY_CHARGEID_ASSOC_CONTAINER FOREIGN KEY (container) REFERENCES core.Containers (EntityId)
+    );
+
+CREATE INDEX IF NOT EXISTS IDX_EHR_BILLING_PROCEDURE_QUERY_CHARGEID_ASSOC_CONTAINER ON ehr_billing.procedureQueryChargeIdAssoc (container);

--- a/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-24.000-24.001.sql
+++ b/ehr_billing/resources/schemas/dbscripts/postgresql/ehr_billing-24.000-24.001.sql
@@ -1,8 +1,8 @@
 -- this table should consists of the rows with schema name, query name where the resulting rows of that query are associated with a chargeId, chargeId, and description of the query
 CREATE TABLE IF NOT EXISTS ehr_billing.procedureQueryChargeIdAssoc (
 
-                                                                       rowId SERIAL NOT NULL,
-                                                                       schemaName varchar(200) NOT NULL,
+    rowId SERIAL NOT NULL,
+    schemaName varchar(200) NOT NULL,
     queryName varchar(500) NOT NULL,
     description varchar(2000) NOT NULL,
     chargeId int NOT NULL,

--- a/ehr_billing/resources/schemas/dbscripts/sqlserver/ehr_billing-24.000-24.001.sql
+++ b/ehr_billing/resources/schemas/dbscripts/sqlserver/ehr_billing-24.000-24.001.sql
@@ -1,0 +1,26 @@
+IF OBJECT_ID(N'ehr_billing.procedureQueryChargeIdAssoc', N'U') IS NULL
+    BEGIN
+        CREATE TABLE ehr_billing.procedureQueryChargeIdAssoc (
+         rowId INT IDENTITY(1,1) NOT NULL,
+         schemaName nvarchar(200) NOT NULL,
+         queryName nvarchar(500) NOT NULL,
+         description nvarchar(2000) NOT NULL,
+         chargeId int NOT NULL,
+
+         container ENTITYID NOT NULL,
+         createdBy USERID,
+         created DATETIME,
+         modifiedBy USERID,
+         modified DATETIME,
+
+         CONSTRAINT PK_procedureQueryChargeIdAssociations PRIMARY KEY (rowId),
+         CONSTRAINT FK_EHR_BILLING_PROCEDURE_QUERY_CHARGEID_ASSOC_CONTAINER FOREIGN KEY (Container) REFERENCES core.Containers (EntityId)
+        );
+    END;
+GO
+
+IF NOT EXISTS(SELECT * FROM sys.indexes WHERE name = 'IDX_EHR_BILLING_PROCEDURE_QUERY_CHARGEID_ASSOC_CONTAINER' AND object_id = OBJECT_ID('ehr_billing.procedureQueryChargeIdAssoc'))
+BEGIN
+CREATE INDEX IDX_EHR_BILLING_PROCEDURE_QUERY_CHARGEID_ASSOC_CONTAINER ON ehr_billing.procedureQueryChargeIdAssoc (container);
+END;
+GO

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingModule.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingModule.java
@@ -63,7 +63,7 @@ public class EHR_BillingModule extends SpringModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 24.000;
+        return 24.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Erring on the side caution, adding a 24.00x db script to create a new table (ehr_billing.procedureQueryChargeIdAssoc) if it doesn't already exist since the module version here is already bumped to 24.00x, and the new table was created in 23.11 branch with a 23.00x script.

#### Changes
* Upgrade scripts to create new ehr_billing.procedureQueryChargeIdAssoc table if it doesn't exist for 24.3 servers