### PR TITLE
use default DisplayColumnFactory (not inherited OORDisplayColumnFactory)

### DIFF
--- a/Viral_Load_Assay/resources/assay/Viral_Loads/queries/Data.query.xml
+++ b/Viral_Load_Assay/resources/assay/Viral_Loads/queries/Data.query.xml
@@ -100,6 +100,7 @@
                         <shownInInsertView>false</shownInInsertView>
                     </column>
                     <column columnName="viralLoadScientific" wrappedColumnName="viralLoad">
+                        <displayColumnFactory><className>DEFAULT</className></displayColumnFactory>
                         <columnTitle>Viral Load</columnTitle>
                         <conceptURI>http://cpas.labkey.com/laboratory#assayResult</conceptURI>
                         <description>This column shows the viral load, formatted in scientific notation</description>


### PR DESCRIPTION
#### Rationale
fixes ViralLoadAssayTest

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
