### PR TITLE
Add optional check for blood draws nearing the max vol

### DIFF
--- a/ehr/resources/data/labwork_services.tsv
+++ b/ehr/resources/data/labwork_services.tsv
@@ -1,32 +1,32 @@
-servicename	dataset
-CBC	Hematology
-Chlamydia trachomatis Detection by NAA	Bacteriology
-Chol/HDL Ratio	Chemistry
-Culture, Bacterial/Smear	Bacteriology
-Culture, Enteric	Bacteriology
-Culture, Fungus, Dermal/Smear	Bacteriology
-Culture, Other	Bacteriology
-Culture, Sterile Fluid/Tissue/Smear	Bacteriology
-Culture, Urine	Bacteriology
-Culture, Wound/Smear	Bacteriology
-Direct Smear for Protozoa	Parasitology
-ELISA - HBV	Virology
-ELISA - Measles	Virology
-ELISA - SIV	Virology
-ELISA - SRV	Virology
-ELISA - STLV-1	Virology
-GIFN for TB detection	Bacteriology
-Glycosylated Hemoglobin	Hematology
-Isolation - HBV	Virology
-Lipid Panel	Chemistry
-Mycobacteria Smear and Culture	Bacteriology
-Occult Blood	Parasitology
-Osmolarity	Chemistry
-Ova and Parasite Antigen Panel (EIA)	Parasitology
-Ova and Parasite Concentration (Fecal Float)	Parasitology
-Ova and Parasite Wet Prep	Parasitology
-PCR - Individual Bacterium	Bacteriology
-PCR - SRV 1,2,3,4,5	Virology
-PCR - STLV-1	Virology
-Prothrombin Time (PT) and Activated Partial Thromboplastin Time (APTT)	Chemistry
-Vet-19 Chem Panel	Chemistry
+servicename	dataset	alertOnComplete
+CBC	Hematology 	FALSE
+Chlamydia trachomatis Detection by NAA	Bacteriology	FALSE
+Chol/HDL Ratio	Chemistry	FALSE
+"Culture, Bacterial/Smear"	Bacteriology	FALSE
+"Culture, Enteric"	Bacteriology	FALSE
+"Culture, Fungus, Dermal/Smear"	Bacteriology	FALSE
+"Culture, Other"	Bacteriology	FALSE
+"Culture, Sterile Fluid/Tissue/Smear"	Bacteriology	FALSE
+"Culture, Urine"	Bacteriology	FALSE
+"Culture, Wound/Smear"	Bacteriology	FALSE
+Direct Smear for Protozoa	Parasitology	FALSE
+ELISA - HBV	Virology	FALSE
+ELISA - Measles	Virology	FALSE
+ELISA - SIV	Virology	FALSE
+ELISA - SRV	Virology	FALSE
+ELISA - STLV-1	Virology	FALSE
+GIFN for TB detection	Bacteriology	FALSE
+Glycosylated Hemoglobin	Hematology	FALSE
+Isolation - HBV	Virology	FALSE
+Lipid Panel	Chemistry	FALSE
+Mycobacteria Smear and Culture	Bacteriology	FALSE
+Occult Blood	Parasitology	FALSE
+Osmolarity	Chemistry	FALSE
+Ova and Parasite Antigen Panel (EIA)	Parasitology	FALSE
+Ova and Parasite Concentration (Fecal Float)	Parasitology	FALSE
+Ova and Parasite Wet Prep	Parasitology	FALSE
+PCR - Individual Bacterium	Bacteriology	FALSE
+"PCR - SRV 1,2,3,4,5"	Virology	FALSE
+PCR - STLV-1	Virology	FALSE
+Prothrombin Time (PT) and Activated Partial Thromboplastin Time (APTT)	Chemistry	FALSE
+Vet-19 Chem Panel	Chemistry	FALSE

--- a/ehr/resources/data/species.tsv
+++ b/ehr/resources/data/species.tsv
@@ -1,10 +1,10 @@
-common	scientific_name	id_prefix	mhc_prefix
-Baboon			
-Cotton-top Tamarin	Saguinus oedipus	so	Saoe
-Cynomolgus	Macaca fascicularis	cy	Mafa
-Pigtail	Macaca Nemestrina		Mane
-Rhesus	Macaca mulatta	r|rh	Mamu
-Sooty Mangabey	Cercocebus atys		Ceat
-Stump Tailed	Macaca Arctoides		Maar
-Vervet	Chlorocebus sabaeus	ag	Chsa
-Marmoset	Callithrix jacchus	cj	Caja
+common	scientific_name	id_prefix	mhc_prefix	blood_per_kg	max_draw_pct	blood_draw_interval
+Baboon				60.0	0.2	30.0
+Cotton-top Tamarin	Saguinus oedipus	so	Saoe	60.0	0.2	30.0
+Cynomolgus	Macaca fascicularis	cy	Mafa	60.0	0.2	30.0
+Pigtail	Macaca Nemestrina		Mane	60.0	0.2	30.0
+Rhesus	Macaca mulatta	r|rh	Mamu	60.0	0.2	30.0
+Sooty Mangabey	Cercocebus atys		Ceat	60.0	0.2	30.0
+Stump Tailed	Macaca Arctoides		Maar	60.0	0.2	30.0
+Vervet	Chlorocebus sabaeus	ag	Chsa	60.0	0.2	30.0
+Marmoset	Callithrix jacchus	cj	Caja	60.0	0.15	30.0

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1258,13 +1258,12 @@ public class TriggerScriptHelper
                                .append(" kg).\n");
             }
 
-            //report all the ones that are close to limit
-            for (double closeValue : closeToThreshold.descendingSet())
+            if (!closeToThreshold.isEmpty())
             {
                 errorMsgBuilder.append("Limit notice! Blood volume of ")
                                .append(rowQuantity)
                                .append(" (")
-                               .append(closeValue)
+                               .append(closeToThreshold.descendingSet().iterator().next())
                                .append(" over ")
                                .append(interval)
                                .append(" days) is within ")
@@ -1285,10 +1284,15 @@ public class TriggerScriptHelper
     }
 
     /**
-     * Gets the center specific threshold to warn when blood vols are close to the max blood allowed,
+     * Gets the center specific threshold from _centerCustomProps.bloodNearOverageThreshold to warn when blood vols are close to the max blood allowed,
      * only used if the doWarnForBloodNearOverages() is true
      * e.g., if the max allowable blood drawn vol is 60.0, a threshold of 4.0 will warn users if blood vol is greater than 56.0 ml
-     * this should be set on the JS side with helper.setCenterCustomProps()
+     * this should be set in a JS trigger script via     helper.setCenterCustomProps(), for example:
+     * helper.setCenterCustomProps({
+     *  doWarnForBloodNearOverages: true,
+     *  bloodNearOverageThreshold: 5.0
+     * })
+     * It uses default value "_bloodNearingOveragesThresholdDefaultValue" if none is supplied or incorrect data type is supplied
      *
      * @return      the threshold value of the limit
      */
@@ -1306,6 +1310,10 @@ public class TriggerScriptHelper
             {
                 return (Double) theVal;
             }
+            else
+            {
+                _log.warn("TriggerScriptHelper.getBloodNearingOveragesThreshold incorrect datatype supplied for _centerCustomProps.bloodNearOverageThreshold, using default value.");
+            }
         }
         else
         {
@@ -1317,8 +1325,12 @@ public class TriggerScriptHelper
 
 
     /**
-     * For use with _bloodLimitThreshold, checks to see whether we should warn about bloods draws nearing their limit,
-     * this should be set on the JS side with helper.setCenterCustomProps()
+     * For use with getBloodNearingOveragesThreshold(), checks to see whether we should warn about bloods draws nearing their limit,
+     * this should be set in a JS trigger script via helper.setCenterCustomProps(), for example:
+     * helper.setCenterCustomProps({
+     *  doWarnForBloodNearOverages: true,
+     *  bloodNearOverageThreshold: 5.0
+     * })
      *
      * @return      whether to warn for bloods nearing overages
      */

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1307,6 +1307,10 @@ public class TriggerScriptHelper
                 return (Double) theVal;
             }
         }
+        else
+        {
+            _log.warn("TriggerScriptHelper.getBloodNearingOveragesThreshold no value found for _centerCustomProps.bloodNearOverageThreshold, using default value.");
+        }
         return _bloodNearingOveragesThresholdDefaultValue;
     }
 

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1860,7 +1860,7 @@ public class TriggerScriptHelper
                 }
                 else if (hasCustomDepartureStatus)
                 {
-                    status = _centerCustomProps.get("departureStatus").toString();
+                    status = String.valueOf(_centerCustomProps.get("departureStatus"));
                 }
                 else
                 {

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1310,7 +1310,7 @@ public class TriggerScriptHelper
             }
             else
             {
-                throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold invalid value found for _centerCustomProps.bloodNearOverageThreshold.");
+                throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold invalid value found for _centerCustomProps.bloodNearOverageThreshold. Required type is a double.");
             }
         }
         else

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1299,14 +1299,13 @@ public class TriggerScriptHelper
         Object theVal = _centerCustomProps.get("bloodNearOverageThreshold");
         if (null != theVal)
         {
-            if (theVal instanceof Integer)
+            if (theVal instanceof Integer theValInt)
             {
-                Integer theValInt = (Integer) theVal;
                 return theValInt.doubleValue();
             }
-            else if (theVal instanceof Double)
+            else if (theVal instanceof Double theValDouble)
             {
-                return (Double) theVal;
+                return theValDouble;
             }
             else
             {

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1315,7 +1315,7 @@ public class TriggerScriptHelper
         }
         else
         {
-            throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold no value found for _centerCustomProps.bloodNearOverageThreshold, please supply a value.");
+            throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold no value found for _centerCustomProps.bloodNearOverageThreshold. If doWarnForBloodNearOverages is set to true, then bloodNearOverageThreshold must also be set.");
         }
     }
 

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -138,8 +138,6 @@ public class TriggerScriptHelper
 
     private static final Logger _log = LogHelper.getLogger(TriggerScriptHelper.class, "Server-side validation of EHR data insert/update/deletes");
 
-    private static double _bloodNearingOveragesThresholdDefaultValue = 4.0; //in mL
-
     private TriggerScriptHelper(int userId, String containerId)
     {
         User user = UserManager.getUser(userId);

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1312,14 +1312,13 @@ public class TriggerScriptHelper
             }
             else
             {
-                _log.warn("TriggerScriptHelper.getBloodNearingOveragesThreshold incorrect datatype supplied for _centerCustomProps.bloodNearOverageThreshold, using default value.");
+                throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold invalid value found for _centerCustomProps.bloodNearOverageThreshold.");
             }
         }
         else
         {
-            _log.warn("TriggerScriptHelper.getBloodNearingOveragesThreshold no value found for _centerCustomProps.bloodNearOverageThreshold, using default value.");
+            throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold no value found for _centerCustomProps.bloodNearOverageThreshold, please supply a value.");
         }
-        return _bloodNearingOveragesThresholdDefaultValue;
     }
 
 


### PR DESCRIPTION
#### Rationale
WNPRC wants to warn users when filling out a blood draw in EHR, if an animal is getting close to an its max allowable blood draw limit. Currently EHR does this through a TriggerScriptHelper that has a lot of logic to check for blood remaining, but only warns if an animal goes over the limit. In order to take advantage of that work that is already done in the TriggerScriptHelper, it seemed most reliable to tap into this by adding in an optional limit check that can be turned on in a trigger script. This change is backwards compatible with other areas, and requires no intervention for other centers.

#### Related Pull Requests


#### Changes
* TriggerScriptHelper.java - added on an error msg to check additional limits, made it opt-in behavior. Added member to BloodInfo to track report only records in the current transaction.

* species.tsv - needed to test validation for blood volumes

* labwork_services.tsv - does not really apply here, but wanted to get started on this. blood.js in EHR creates a clinpath request after a request becomes public, there is no EHR test for this. This puts in the minimum required data if WNPRC wants to test it later.
