### PR TITLE
Additional EHR test helpers

### DIFF
--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -298,6 +298,8 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         insertCommand = getApiHelper().prepareInsertCommand("study", "Assignment", "lsid", fields, data);
         getApiHelper().deleteAllRecords("study", "Assignment", new Filter("Id", StringUtils.join(SUBJECTS, ";"), Filter.Operator.IN));
         getApiHelper().doSaveRows(DATA_ADMIN.getEmail(), insertCommand, getExtraContext());
+
+        primeCaches();
     }
 
     @Override
@@ -754,6 +756,12 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         setInitialPassword(FULL_SUBMITTER.getEmail());
         setInitialPassword(FULL_UPDATER.getEmail());
         setInitialPassword(REQUEST_ADMIN.getEmail());
+    }
+
+    protected void validateDemographicsCache()
+    {
+        beginAt(WebTestHelper.buildURL("ehr", getContainerPath(), "cacheLivingAnimals", Map.of("validateOnly", "true")));
+        waitAndClick(WAIT_FOR_JAVASCRIPT, Locator.lkButton("OK"), WAIT_FOR_PAGE * 4);
     }
 
     protected static final ArrayList<Permission> allowedActions = new ArrayList<>()

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
+import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.ehr.ParticipantViewPage;
 import org.labkey.test.tests.ehr.AbstractEHRTest;
 import org.labkey.test.util.Ext4Helper;
@@ -244,6 +245,26 @@ public class EHRTestHelper
         _test.waitAndClickAndWait(Ext4Helper.Locators.windowButton("Discard Form", "Yes"));
 
         _test.waitForElement(Locator.tagWithText("a", "Enter New Data"));
+    }
+
+    public void submitFinalTaskForm()
+    {
+        Locator submitFinalBtn = Locator.linkWithText("Submit Final");
+        _test.shortWait().until(ExpectedConditions.elementToBeClickable(submitFinalBtn));
+        Window<?> msgWindow;
+        try
+        {
+            submitFinalBtn.findElement(_test.getDriver()).click();
+            msgWindow = new Window.WindowFinder(_test.getDriver()).withTitleContaining("Finalize").waitFor();
+        }
+        catch (NoSuchElementException e)
+        {
+            //retry
+            _test.sleep(500);
+            submitFinalBtn.findElement(_test.getDriver()).click();
+            msgWindow = new Window.WindowFinder(_test.getDriver()).withTitleContaining("Finalize").waitFor();
+        }
+        msgWindow.clickButton("Yes");
     }
 
     public void verifyAllReportTabs(ParticipantViewPage participantView)


### PR DESCRIPTION
#### Rationale
Add additional test helpers. Create/migrate some additional test helpers used in ONPRC.

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/991

#### Changes
* validate demographics cache just reruns demographics cache and any mismatches will be caught in error log checks
* submit final task form
