### PR TITLE
Optional async demographic provider updates

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/demographics/DemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/DemographicsProvider.java
@@ -39,6 +39,16 @@ public interface DemographicsProvider
 
     boolean isAvailable(Container c, User u);
 
+    /**
+     * Allow a provider to run the demographics cache update (triggered from announceIdsModified) in another thread.
+     * This can ensure triggers don't time out if the cache update takes a long time, such as when there are a large amount
+     * of related Ids to process. Note: if switching this to true, the saved data will likely be in a different state than
+     * when the sync update is completed within a trigger, so the provider will likely need to be updated to account.
+     */
+    default boolean isAsync() {
+        return false;
+    }
+
     Map<String, Map<String, Object>> getProperties(DefaultSchema defaultSchema, Collection<String> ids);
 
     /**

--- a/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
@@ -25,6 +25,7 @@ import org.labkey.api.cache.CacheManager;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -72,7 +73,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 
 /**
  * User: bimber
@@ -343,21 +343,31 @@ public class EHRDemographicsServiceImpl extends EHRDemographicsService
                 // If not already in an async thread, and the provider is async, defer just this provider update to an async thread
                 if (!async && p.isAsync())
                 {
-                    JobRunner.getDefault().execute(TimeUnit.SECONDS.toMillis(30), () -> {
-                        try
+                    try (DbScope.Transaction transaction = StudyService.get().getDatasetSchema().getScope().ensureTransaction())
+                    {
+                        // Add post commit task to run provider update in another thread once this transaction is complete.
+                        transaction.addCommitTask(() ->
                         {
-                            // Set up environment so auditing in compliance code works
-                            QueryService.get().setEnvironment(QueryService.Environment.USER, EHRService.get().getEHRUser(c));
-                            QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, c);
+                            JobRunner.getDefault().execute(() ->
+                            {
+                                try
+                                {
+                                    // Set up environment so auditing in compliance code works
+                                    QueryService.get().setEnvironment(QueryService.Environment.USER, EHRService.get().getEHRUser(c));
+                                    QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, c);
 
-                            // Update provider in another thread
-                            updateForProvider(defaultSchema, p, ids, true, true);
-                        }
-                        finally
-                        {
-                            QueryService.get().clearEnvironment();
-                        }
-                    });
+                                    // Update provider in another thread
+                                    updateForProvider(defaultSchema, p, ids, true, true);
+                                }
+                                finally
+                                {
+                                    QueryService.get().clearEnvironment();
+                                }
+                            });
+                        }, DbScope.CommitTaskOption.POSTCOMMIT);
+
+                        transaction.commit();
+                    }
                 }
                 else {
                     updateForProvider(defaultSchema, p, ids, true, async);

--- a/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
@@ -344,7 +344,19 @@ public class EHRDemographicsServiceImpl extends EHRDemographicsService
                 if (!async && p.isAsync())
                 {
                     JobRunner.getDefault().execute(TimeUnit.SECONDS.toMillis(30), () -> {
-                        updateForProvider(defaultSchema, p, ids, true, true);
+                        try
+                        {
+                            // Set up environment so auditing in compliance code works
+                            QueryService.get().setEnvironment(QueryService.Environment.USER, EHRService.get().getEHRUser(c));
+                            QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, c);
+
+                            // Update provider in another thread
+                            updateForProvider(defaultSchema, p, ids, true, true);
+                        }
+                        finally
+                        {
+                            QueryService.get().clearEnvironment();
+                        }
                     });
                 }
                 else {


### PR DESCRIPTION
#### Rationale
Provide a way for individual demographic providers to be run asynchronously in another thread. Doing this shortens data insertion times and avoids trigger timeout limits in extreme cases.

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/996

#### Changes
* Add isAsync option to DemographicProvider
* If isAsync is true, split provider cache update to a separate postcommit task job