### PR TITLE
Extensible lab_tests table

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-24.001-24.002.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-24.001-24.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_lookups.lab_tests ADD COLUMN LSID LSIDtype;

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-24.001-24.002.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-24.001-24.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_lookups.lab_tests ADD Lsid LsidType null;

--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -1652,6 +1652,17 @@
                     <fkColumnName>entityid</fkColumnName>
                 </fk>
             </column>
+            <column columnName="lsid">
+                <datatype>lsidtype</datatype>
+                <isReadOnly>true</isReadOnly>
+                <isHidden>true</isHidden>
+                <isUserEditable>false</isUserEditable>
+                <fk>
+                    <fkColumnName>ObjectUri</fkColumnName>
+                    <fkTable>Object</fkTable>
+                    <fkDbSchema>exp</fkDbSchema>
+                </fk>
+            </column>
         </columns>
     </table>
     <table tableName="death_remarks" tableDbType="TABLE" useColumnOrder="true">

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -133,7 +133,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 24.001;
+        return 24.002;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/query/LabworkTypeTable.java
+++ b/ehr/src/org/labkey/ehr/query/LabworkTypeTable.java
@@ -32,6 +32,7 @@ import org.labkey.api.query.DuplicateKeyException;
 import org.labkey.api.query.InvalidKeyException;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
+import org.labkey.api.query.SimpleTableDomainKind;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
@@ -39,6 +40,7 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.ehr.EHRSchema;
 
 import java.sql.SQLException;
 import java.util.Map;
@@ -63,6 +65,15 @@ public class LabworkTypeTable extends AbstractDataDefinedTable
         addPermissionMapping(UpdatePermission.class, EHRDataAdminPermission.class);
         addPermissionMapping(DeletePermission.class, EHRDataAdminPermission.class);
         setTitleColumn("testid");
+    }
+
+    @Override
+    public String getDomainURI()
+    {
+        if (_objectUriCol == null)
+            return null;
+
+        return SimpleTableDomainKind.getDomainURI(_userSchema.getName(), EHRSchema.TABLE_LAB_TESTS, getDomainContainer(), _userSchema.getUser());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Make lab_tests and the virtual tables evolved from this table (chemistry_tests, hematology_tests, etc.) extensible.

#### Changes
* Add LSID column and LSID fk
* Override getDomainURI to get correct domain for virtual tables
