### PR TITLE
Move demographic recache to post commit task

### DIFF
--- a/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/EHRDemographicsServiceImpl.java
@@ -472,7 +472,7 @@ public class EHRDemographicsServiceImpl extends EHRDemographicsService
             {
                 _log.error("EHRDemographicsServiceImpl encountered a deadlock", e);
             }
-        }, 5000);
+        });
     }
 
     /**

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -877,22 +877,8 @@ public class TriggerScriptHelper
             // Add post commit task to run provider update in another thread once this transaction is complete.
             transaction.addCommitTask(() ->
             {
-                JobRunner.getDefault().execute(() ->
-                {
-                    try
-                    {
-                        // Set up environment so auditing in compliance code works
-                        QueryService.get().setEnvironment(QueryService.Environment.USER, EHRService.get().getEHRUser(getContainer()));
-                        QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, getContainer());
-
-                        // Update provider in another thread
-                        EHRDemographicsServiceImpl.get().recacheRecords(getContainer(), Collections.singletonList(id));
-                    }
-                    finally
-                    {
-                        QueryService.get().clearEnvironment();
-                    }
-                });
+                // Update provider in another thread
+                EHRDemographicsServiceImpl.get().recacheRecords(getContainer(), Collections.singletonList(id));
             }, DbScope.CommitTaskOption.POSTCOMMIT);
 
             transaction.commit();

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -31,6 +31,7 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
 import org.labkey.api.data.ConvertHelper;
 import org.labkey.api.data.DbSchema;
+import org.labkey.api.data.DbScope;
 import org.labkey.api.data.Results;
 import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.RuntimeSQLException;
@@ -871,7 +872,31 @@ public class TriggerScriptHelper
         // inserted a row into study.participant, which means that calculated lookup values like the animal's current
         // age won't resolve until AFTER the call to insertRows() has completed. Thus, refresh the cache for this new
         // animal an extra time. See ticket 44283.
-        EHRDemographicsServiceImpl.get().recacheRecords(getContainer(), Collections.singletonList(id));
+        try (DbScope.Transaction transaction = StudyService.get().getDatasetSchema().getScope().ensureTransaction())
+        {
+            // Add post commit task to run provider update in another thread once this transaction is complete.
+            transaction.addCommitTask(() ->
+            {
+                JobRunner.getDefault().execute(() ->
+                {
+                    try
+                    {
+                        // Set up environment so auditing in compliance code works
+                        QueryService.get().setEnvironment(QueryService.Environment.USER, EHRService.get().getEHRUser(getContainer()));
+                        QueryService.get().setEnvironment(QueryService.Environment.CONTAINER, getContainer());
+
+                        // Update provider in another thread
+                        EHRDemographicsServiceImpl.get().recacheRecords(getContainer(), Collections.singletonList(id));
+                    }
+                    finally
+                    {
+                        QueryService.get().clearEnvironment();
+                    }
+                });
+            }, DbScope.CommitTaskOption.POSTCOMMIT);
+
+            transaction.commit();
+        }
     }
 
     public void updateDemographicsRecord(List<Map<String, Object>> updatedRows) throws QueryUpdateServiceException, SQLException, BatchValidationException, InvalidKeyException

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -298,6 +298,8 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         insertCommand = getApiHelper().prepareInsertCommand("study", "Assignment", "lsid", fields, data);
         getApiHelper().deleteAllRecords("study", "Assignment", new Filter("Id", StringUtils.join(SUBJECTS, ";"), Filter.Operator.IN));
         getApiHelper().doSaveRows(DATA_ADMIN.getEmail(), insertCommand, getExtraContext());
+
+        primeCaches();
     }
 
     @Override
@@ -754,6 +756,12 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         setInitialPassword(FULL_SUBMITTER.getEmail());
         setInitialPassword(FULL_UPDATER.getEmail());
         setInitialPassword(REQUEST_ADMIN.getEmail());
+    }
+
+    protected void validateDemographicsCache()
+    {
+        beginAt(WebTestHelper.buildURL("ehr", getContainerPath(), "cacheLivingAnimals", Map.of("validateOnly", "true")));
+        waitAndClick(WAIT_FOR_JAVASCRIPT, Locator.lkButton("OK"), WAIT_FOR_PAGE * 4);
     }
 
     protected static final ArrayList<Permission> allowedActions = new ArrayList<>()

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.test.BaseWebDriverTest;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
+import org.labkey.test.components.ext4.Window;
 import org.labkey.test.pages.ehr.ParticipantViewPage;
 import org.labkey.test.tests.ehr.AbstractEHRTest;
 import org.labkey.test.util.Ext4Helper;
@@ -244,6 +245,26 @@ public class EHRTestHelper
         _test.waitAndClickAndWait(Ext4Helper.Locators.windowButton("Discard Form", "Yes"));
 
         _test.waitForElement(Locator.tagWithText("a", "Enter New Data"));
+    }
+
+    public void submitFinalTaskForm()
+    {
+        Locator submitFinalBtn = Locator.linkWithText("Submit Final");
+        _test.shortWait().until(ExpectedConditions.elementToBeClickable(submitFinalBtn));
+        Window<?> msgWindow;
+        try
+        {
+            submitFinalBtn.findElement(_test.getDriver()).click();
+            msgWindow = new Window.WindowFinder(_test.getDriver()).withTitleContaining("Finalize").waitFor();
+        }
+        catch (NoSuchElementException e)
+        {
+            //retry
+            _test.sleep(500);
+            submitFinalBtn.findElement(_test.getDriver()).click();
+            msgWindow = new Window.WindowFinder(_test.getDriver()).withTitleContaining("Finalize").waitFor();
+        }
+        msgWindow.clickButton("Yes");
     }
 
     public void verifyAllReportTabs(ParticipantViewPage participantView)


### PR DESCRIPTION
#### Rationale
The current demographic provider recache after creating a new demographic record can get into race condition with long running trigger scripts. Update this recache to be a post commit task.

Move some test helpers to EHR.

#### Changes
* Make demographic recache a post commit task
* Remove delay from job as recache is now running after the transaction commits
* Add some test helpers
