### PR TITLE
Add initCollapsedWithData to collapsible panels

### DIFF
--- a/ehr/resources/web/ehr/plugin/CollapsibleDataEntryPanel.js
+++ b/ehr/resources/web/ehr/plugin/CollapsibleDataEntryPanel.js
@@ -15,7 +15,11 @@ Ext4.define('EHR.plugin.CollapsibleDataEntryPanel', {
 
         panel.collapsible = true;
 
-        if ((!panel.store || panel.store.getCount() === 0) && panel.formConfig?.initCollapsed) {
+        // - initCollapsed: initialize the panel as collapsed if it has no data
+        // - initCollapsedWithData: initialize the panel as collapsed regardless of data. dataDependentCollapseHeader will
+        // still be respected this is just the initial state of collapsed.
+        if ((panel.formConfig?.initCollapsed && (!panel.store || panel.store.getCount() === 0))
+            || panel.formConfig?.initCollapsedWithData) {
             panel.collapsed = true;
         }
 


### PR DESCRIPTION
#### Rationale
This PR adds the option to have a panel initially collapsed even if it has data in it. The provides a different option than initCollapsed which only collapses the panel if it has no data.

#### Changes
* Add case to collapse if initCollapsedWithData is defined/true
