### PR TITLE
Improvements to the protocol validation for animal assignments

### DIFF
--- a/ehr/resources/queries/ehr/protocolTotalAnimalsBySpecies.sql
+++ b/ehr/resources/queries/ehr/protocolTotalAnimalsBySpecies.sql
@@ -30,6 +30,10 @@ FROM
 
         UNION
 
+        /*
+         * Calculate the macaque totals as well, as the sum of Cynos and Rhesus
+         */
+
         SELECT
             coalesce(p.protocol, pa.protocol) as protocol,
             'Macaque' as species,

--- a/ehr/resources/queries/ehr/protocolTotalAnimalsBySpecies.sql
+++ b/ehr/resources/queries/ehr/protocolTotalAnimalsBySpecies.sql
@@ -5,52 +5,54 @@
  */
 SELECT
 
-p.protocol,
-p.approve,
-p.species,
-pc.allowed,
-p.TotalAnimals,
-CONVERT(pc.allowed - p.TotalAnimals, INTEGER) as TotalRemaining,
-CASE WHEN (pc.allowed IS NULL or pc.allowed = 0) THEN NULL ELSE round(cast(p.TotalAnimals as float) / cast(pc.allowed as float) * 100, 1) END as PercentUsed,
-p.Animals
+    p.protocol,
+    (select approve from ehr.protocol where p.protocol = protocol) as approve,
+    p.species,
+    pc.allowed,
+    p.TotalAnimals,
+    CONVERT(pc.allowed - p.TotalAnimals, INTEGER) as TotalRemaining,
+    CASE WHEN (pc.allowed IS NULL or pc.allowed = 0) THEN NULL ELSE round(cast(p.TotalAnimals as float) / cast(pc.allowed as float) * 100, 1) END as PercentUsed,
+    p.Animals
 
 FROM
-(
-SELECT
-  coalesce(p.protocol, pa.protocol) as protocol,
-  p.approve,
-  pa.species,
-  group_concat(DISTINCT pa.id) as Animals,
-  CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
+    (
+        SELECT
+            coalesce(p.protocol, pa.protocol) as protocol,
+            p.species as species,
+            group_concat(DISTINCT pa.id) as Animals,
+            CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
 
-FROM ehr.protocol p
-LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol)
+        FROM ehr.protocol_counts p
+            LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol and p.species = pa.species)
 
-GROUP BY coalesce(p.protocol, pa.protocol), p.approve, pa.species
+        WHERE p.species != 'Macaque'
+        GROUP BY coalesce(p.protocol, pa.protocol), p.species
 
-/*
- * Calculate the macaque totals as well, as the sum of Cynos and Rhesus
- */
-UNION
-SELECT
-  coalesce(p.protocol, pa.protocol) as protocol,
-  p.approve,
-  'Macaque' as species,
-  group_concat(DISTINCT pa.id) as Animals,
-  CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
+        UNION
 
-FROM ehr.protocol p
-  LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol)
+        SELECT
+            coalesce(p.protocol, pa.protocol) as protocol,
+            'Macaque' as species,
+            group_concat(DISTINCT pa.id) as Animals,
+            CONVERT(Count(pa.id), INTEGER) AS TotalAnimals
 
-  WHERE pa.species = 'Cynomolgus' OR pa.species = 'Rhesus'
+        FROM ehr.protocol_counts p
+            LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol and p.species = pa.species)
 
-GROUP BY coalesce(p.protocol, pa.protocol), p.approve
 
-  /* End   Edit */
+        WHERE pa.species = 'Cynomolgus' OR pa.species = 'Rhesus'
 
-) p
+          AND EXISTS (  -- Check if 'macaque' exists for protocol
+            SELECT 1
+            FROM ehr.protocol_counts pc2
+            WHERE pc2.protocol = p.protocol AND pc2.species = 'Macaque'
+            )
+        GROUP BY coalesce(p.protocol, pa.protocol), p.species
 
-LEFT JOIN ehr.protocol_counts pc ON (p.protocol = pc.protocol AND pc.species = p.species)
+
+    ) p
+
+    LEFT JOIN ehr.protocol_counts pc ON (p.protocol = pc.protocol AND pc.species = p.species)
 
 WHERE p.species IS NOT NULL
 
@@ -59,17 +61,17 @@ UNION ALL
 
 
 SELECT
-  p.protocol,
-  p.approve,
-  'All Species' as species,
-  p.maxAnimals as allowed,
-  CONVERT(Count(pa.id), INTEGER) AS TotalAnimals,
-  p.maxAnimals - Count(pa.id) as TotalRemaining,
-  CASE WHEN (p.maxAnimals IS NULL or p.maxAnimals = 0) THEN NULL ELSE round(cast(Count(pa.id) as float) / cast(p.maxAnimals as float) * 100, 1) END as PercentUsed,
-  group_concat(distinct pa.Id) as animals
+    p.protocol,
+    (select approve from ehr.protocol where p.protocol = protocol) as approve,
+    'All Species' as species,
+    p.maxAnimals as allowed,
+    CONVERT(Count(pa.id), INTEGER) AS TotalAnimals,
+    p.maxAnimals - Count(pa.id) as TotalRemaining,
+    CASE WHEN (p.maxAnimals IS NULL or p.maxAnimals = 0) THEN NULL ELSE round(cast(Count(pa.id) as float) / cast(p.maxAnimals as float) * 100, 1) END as PercentUsed,
+    group_concat(distinct pa.Id) as animals
 
 FROM ehr.protocol p
-LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol)
+    LEFT OUTER JOIN ehr.protocolAnimals pa ON (p.protocol = pa.protocol)
 WHERE p.maxAnimals IS NOT NULL
-GROUP BY p.protocol, p.approve, p.maxAnimals
+GROUP BY p.protocol, p.maxAnimals
 


### PR DESCRIPTION
#### Rationale
Currently the system does not check for a couple cases when assigning animals to a project/protocol. This validation is called from EHR's assignment.js trigger script. One missing case is if the species is not at all listed in the protocol_counts table for the given protocol (in this case it is assumed to be zero animals allowed). And another case is if there's a max number of animals that are Macaques, since that is the genus for Cynomolgus and Rhesus and also can have a cap e.g., if a protocol allows only 10 Macaque meaning it could be 5 Cyno and 5 Rhesus or another mix but no greater than 10 total. Also the protocolTotalAnimalsBySpecies.sql should be checking against the protocol_counts table for the most part, since that's where the species level counts are located, at least for WNPRC, I am assuming this is the case for other centers.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Join with the protocol_counts table
* Add checks for Macaque 
* Add check for when a species is not listed at all on a protocol
