### PR TITLE
Track blood draw warning limits in the species table

### DIFF
--- a/ehr/resources/data/species.tsv
+++ b/ehr/resources/data/species.tsv
@@ -1,10 +1,10 @@
-common	scientific_name	id_prefix	mhc_prefix	blood_per_kg	max_draw_pct	blood_draw_interval
-Baboon				60.0	0.2	30.0
-Cotton-top Tamarin	Saguinus oedipus	so	Saoe	60.0	0.2	30.0
-Cynomolgus	Macaca fascicularis	cy	Mafa	60.0	0.2	30.0
-Pigtail	Macaca Nemestrina		Mane	60.0	0.2	30.0
-Rhesus	Macaca mulatta	r|rh	Mamu	60.0	0.2	30.0
-Sooty Mangabey	Cercocebus atys		Ceat	60.0	0.2	30.0
-Stump Tailed	Macaca Arctoides		Maar	60.0	0.2	30.0
-Vervet	Chlorocebus sabaeus	ag	Chsa	60.0	0.2	30.0
-Marmoset	Callithrix jacchus	cj	Caja	60.0	0.15	30.0
+common	scientific_name	id_prefix	mhc_prefix	blood_per_kg	max_draw_pct	blood_draw_interval	blood_threshold_warning
+Baboon				60	0.2	30	6
+Cotton-top Tamarin	Saguinus oedipus	so	Saoe	60	0.2	30	6
+Cynomolgus	Macaca fascicularis	cy	Mafa	60	0.2	30	6
+Pigtail	Macaca Nemestrina		Mane	60	0.2	30	6
+Rhesus	Macaca mulatta	r|rh	Mamu	60	0.2	30	6
+Sooty Mangabey	Cercocebus atys		Ceat	60	0.2	30	6
+Stump Tailed	Macaca Arctoides		Maar	60	0.2	30	6
+Vervet	Chlorocebus sabaeus	ag	Chsa	60	0.2	30	6
+Marmoset	Callithrix jacchus	cj	Caja	60	0.15	30	0.5

--- a/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-24.003-24.004.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr_lookups-24.003-24.004.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_lookups.species ADD blood_threshold_warning double precision;

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-24.003-24.004.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr_lookups-24.003-24.004.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_lookups.species ADD blood_threshold_warning double precision;

--- a/ehr/resources/schemas/ehr_lookups.xml
+++ b/ehr/resources/schemas/ehr_lookups.xml
@@ -900,6 +900,10 @@
             <column columnName="isNHP">
                 <columnTitle>Is NHP?</columnTitle>
             </column>
+            <column columnName="blood_threshold_warning">
+                <columnTitle>Blood Threshold Warning</columnTitle>
+                <description>The threshold of blood in ml for when to start warning users they are approaching the amount of blood available</description>
+            </column>
             <column columnName="container">
                 <isUserEditable>false</isUserEditable>
                 <isHidden>true</isHidden>

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -133,7 +133,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 24.003;
+        return 24.004;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1244,7 +1244,13 @@ public class TriggerScriptHelper
     {
         AnimalRecord ar = EHRDemographicsServiceImpl.get().getAnimal(getContainer(), id);
         Map<String, Object> bloodBySpecies = getBloodForSpecies(ar.getSpecies());
-        return (Double)bloodBySpecies.get("blood_threshold_warning");
+        Double theWarningThresh = (Double)bloodBySpecies.get("blood_threshold_warning");
+        if (theWarningThresh == null)
+        {
+            throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold no value found for the blood warning threshold. Please set one in ehr_lookup.species blood_threshold_warning column.");
+        }
+
+        return theWarningThresh;
 
     }
 

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1143,6 +1143,7 @@ public class TriggerScriptHelper
         // Iterate over all of the blood records
         TreeSet<Double> overages = new TreeSet<>();
         TreeSet<Double> closeToThreshold = new TreeSet<>();
+        double bloodThreshold = 0;
         for (BloodInfo blood1 : allBloods)
         {
             double bloodNextInterval = 0;
@@ -1174,7 +1175,8 @@ public class TriggerScriptHelper
                 //because allBloods contains everything and we want to distinguish them
                 if (blood1.getInTransaction())
                 {
-                    double maxAllowableThreshold = maxAllowable - getBloodNearingOveragesThreshold();
+                    bloodThreshold =  getBloodNearingOveragesThreshold(id);
+                    double maxAllowableThreshold = maxAllowable - bloodThreshold;
                     if (bloodNextInterval > maxAllowableThreshold)
                     {
                         closeToThreshold.add(bloodNextInterval);
@@ -1212,7 +1214,7 @@ public class TriggerScriptHelper
                                .append(" over ")
                                .append(interval)
                                .append(" days) is within ")
-                               .append(getBloodNearingOveragesThreshold())
+                               .append(bloodThreshold)
                                .append(" mL of the max allowable limit of ")
                                .append(maxAllowable)
                                .append(" mL (weight: ")
@@ -1229,40 +1231,21 @@ public class TriggerScriptHelper
     }
 
     /**
-     * Gets the center specific threshold from _centerCustomProps.bloodNearOverageThreshold to warn when blood vols are close to the max blood allowed,
-     * only used if the doWarnForBloodNearOverages() is true
+     * Gets the center specific threshold from ehr_lookups.species table
      * e.g., if the max allowable blood drawn vol is 60.0, a threshold of 4.0 will warn users if blood vol is greater than 56.0 ml
-     * this should be set in a JS trigger script via     helper.setCenterCustomProps(), for example:
+     * this should be turned on in a JS trigger script via helper.setCenterCustomProps(), for example:
      * helper.setCenterCustomProps({
      *  doWarnForBloodNearOverages: true,
-     *  bloodNearOverageThreshold: 5.0
      * })
-     * It uses default value "_bloodNearingOveragesThresholdDefaultValue" if none is supplied or incorrect data type is supplied
      *
      * @return      the threshold value of the limit
      */
-    public double getBloodNearingOveragesThreshold()
+    public double getBloodNearingOveragesThreshold(String id)
     {
-        Object theVal = _centerCustomProps.get("bloodNearOverageThreshold");
-        if (null != theVal)
-        {
-            if (theVal instanceof Integer theValInt)
-            {
-                return theValInt.doubleValue();
-            }
-            else if (theVal instanceof Double theValDouble)
-            {
-                return theValDouble;
-            }
-            else
-            {
-                throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold invalid value found for _centerCustomProps.bloodNearOverageThreshold. Required type is a double.");
-            }
-        }
-        else
-        {
-            throw new RuntimeException("TriggerScriptHelper.getBloodNearingOveragesThreshold no value found for _centerCustomProps.bloodNearOverageThreshold. If doWarnForBloodNearOverages is set to true, then bloodNearOverageThreshold must also be set.");
-        }
+        AnimalRecord ar = EHRDemographicsServiceImpl.get().getAnimal(getContainer(), id);
+        Map<String, Object> bloodBySpecies = getBloodForSpecies(ar.getSpecies());
+        return (Double)bloodBySpecies.get("blood_threshold_warning");
+
     }
 
 
@@ -1272,7 +1255,6 @@ public class TriggerScriptHelper
      * this should be set in a JS trigger script via helper.setCenterCustomProps(), for example:
      * helper.setCenterCustomProps({
      *  doWarnForBloodNearOverages: true,
-     *  bloodNearOverageThreshold: 5.0
      * })
      *
      * @return      whether to warn for bloods nearing overages


### PR DESCRIPTION
#### Rationale
Right now the EHR trigger script will warn the user if they are approaching the blood limit for an animal but it's set globally for all animals in a trigger script. This PR will move this into the database so that the warning threshold can be set per species.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* Add blood threshold warning column to ehr_lookups.species
* Select from above column for the warning
