### PR TITLE
Augment kinship calculation to check modification date and only run as needed

### DIFF
--- a/ehr/resources/queries/study/demographicsParents.sql
+++ b/ehr/resources/queries/study/demographicsParents.sql
@@ -23,7 +23,8 @@ SELECT
         WHEN d.dam IS NOT NULL AND d.sire IS NOT NULL THEN 2
         WHEN d.dam IS NOT NULL OR d.sire IS NOT NULL THEN 1
         ELSE 0
-        END as numParents
+        END as numParents,
+    d.modified
 FROM study.demographics d
 
 UNION ALL
@@ -38,6 +39,7 @@ SELECT
         WHEN s.dam IS NOT NULL AND s.sire IS NOT NULL THEN 2
         WHEN s.dam IS NOT NULL OR s.sire IS NOT NULL THEN 1
         ELSE 0
-        END as numParents
+        END as numParents,
+    s.modified
 FROM ehr.supplemental_pedigree s
 

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -1274,7 +1274,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class DeletedRecordsRunnerAction extends ConfirmAction<Object>
+    public static class DeletedRecordsRunnerAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -160,6 +160,13 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
             }
         }
 
+        String jobCreateTime = StringUtils.trimToNull(getJob().getParameters().get("jobCreateTime"));
+        if (jobCreateTime != null)
+        {
+            Long time = Long.parseLong(jobCreateTime);
+            GeneticCalculationsJob.setLastRun(getJob().getContainer(), time);
+        }
+
         return new RecordedActionSet(actions);
     }
 

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
@@ -37,9 +37,7 @@ import org.labkey.api.writer.PrintWriters;
 import org.springframework.jdbc.BadSqlGrammarException;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
@@ -272,7 +272,7 @@ public class GeneticCalculationsJob implements Job
             return true;
         }
 
-        SqlSelector ss = new SqlSelector(DbScope.getLabKeyScope(), new SQLFragment("Select max(t.modified) FROM (").append(ti.getFromSQL("t")));
+        SqlSelector ss = new SqlSelector(DbScope.getLabKeyScope(), new SQLFragment("Select max(t.modified) FROM ").append(ti.getFromSQL("t")));
         Date lastModified = ss.getObject(Date.class);
         if (lastModified == null || lastModified.getTime() > lastRun)
         {

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRunnable.java
@@ -86,6 +86,7 @@ public class GeneticCalculationsRunnable
             String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<bioml>\n" +
                     "\t<note label=\"allowRunningDuringDay\" type=\"input\">" + allowRunningDuringDay + "</note>" +
+                    "\t<note label=\"jobCreateTime\" type=\"input\">" + new Date().getTime() + "</note>" +
                 "</bioml>";
 
             AbstractFileAnalysisProtocol<?> protocol = factory.createProtocolInstance(protocolName, "", xml);


### PR DESCRIPTION
The EHR has a longstanding pipeline job that calculates and stores kinship and inbreeding. For a large colony, the compute time for this R job is pretty big, and it requires a long time to import the results. This job historically runs once/day as a scheduled pipeline job. 

The underlying data does not necessarily change every day, and therefore it's not actually necessarily to run it daily. This PR as opt-in behavior such that:

1) If the study.pedigree query (which is typically defined in the center-specific module) contains as column named modified, the new behavior starts. If the source query does not have modified, nothing changes.

2) If study.pedigree contains modified, then the scheduler will first query the max(modified). It compares this against the last run time of the job. If this value is less than the job's last run time, the scheduler aborts and doesnt submit that unnecessary job. 

Again, unless the center chooses to add 'modified' to their study.pedigree query, nothing changes. 