### PR TITLE
Animal History flaky test fix

### DIFF
--- a/ehr/test/src/org/labkey/test/pages/ehr/AnimalHistoryPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/AnimalHistoryPage.java
@@ -46,6 +46,7 @@ public class AnimalHistoryPage<A extends AnimalHistoryPage> extends ParticipantV
     public AnimalHistoryPage(WebDriver driver)
     {
         super(driver);
+        ensureWaitForReports();  // Wait for reports section to load even if empty
     }
 
     public static AnimalHistoryPage beginAt(WebDriverWrapper test)


### PR DESCRIPTION
#### Rationale
AnimalHistoryPage can not fully load before changing filters in some tests causing an issue when the active report has not been set yet. This ensures the reports section is loaded before doing any other operations in animal history.

#### Changes
* Ensure reports loaded in constructor
