### PR TITLE
Update dependencies for repository consolidation

### DIFF
--- a/EHR_SM/build.gradle
+++ b/EHR_SM/build.gradle
@@ -5,6 +5,6 @@ plugins {
 }
 
 dependencies {
-    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:dataintegration", depProjectConfig: "published", depExtension: "module")
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: ":server:modules:premiumModules:dataintegration", depProjectConfig: "published", depExtension: "module")
     BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath: ":server:modules:LabDevKitModules:LDK", depProjectConfig: "apiJarFile")
 }


### PR DESCRIPTION
#### Rationale
Several modules are being moved into the `premiumModules` repository.

#### Related Pull Requests
* https://github.com/LabKey/premiumModules/pull/77

#### Changes
* Update dependencies on consolidated repositories