### PR TITLE
Fix incorrect R syntax

### DIFF
--- a/ehr/resources/pipeline/install.r
+++ b/ehr/resources/pipeline/install.r
@@ -5,4 +5,4 @@
 ##
 
 #installs required packages for populateKinship.r
-install.packages("kinship2", "Rlabkey", "getopt", "Matrix", "pedigree", dependencies=TRUE);
+install.packages(c("kinship2", "Rlabkey", "getopt", "Matrix", "pedigree"), dependencies=TRUE);

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -306,13 +306,13 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
 
                     if (lineNum % 250000 == 0)
                     {
-                        log.info("imported " + lineNum + " rows");
+                        log.info("imported " + String.format("%,d", lineNum) + " rows");
                     }
                 }
 
                 stmt.executeBatch();
                 transaction.commit();
-                log.info("Inserted " + lineNum + " rows into ehr.kinship");
+                log.info("Inserted " + String.format("%,d", lineNum) + " rows into ehr.kinship");
             }
         }
         catch (RuntimeSQLException | SQLException | IOException e)
@@ -705,7 +705,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
 
                 transaction.commit();
             }
-            log.info("Inserted " + lineNum + " rows into inbreeding coefficients table");
+            log.info("Inserted " + String.format("%,d", lineNum) + " rows into inbreeding coefficients table");
 
         }
         catch (DuplicateKeyException | SQLException | IOException | QueryUpdateServiceException e)


### PR DESCRIPTION
This includes two minor improvements:

1) I noticed the R script in the EHR (which is supposed to document what dependencies are needed), doesnt have valid R code. This is never directly executed, but it might as well be correct.

2) This adds decimal formatting to the output of the kinship job. Not exactly mission-critical, but a minor improvement that makes it a little easier to see progress. 