### PR TITLE
Mark modules that support both databases

### DIFF
--- a/EHR_ComplianceDB/module.properties
+++ b/EHR_ComplianceDB/module.properties
@@ -2,3 +2,4 @@ ModuleClass: org.labkey.ehr_compliancedb.EHR_ComplianceDBModule
 ManageVersion: false
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/EHR_SM/module.properties
+++ b/EHR_SM/module.properties
@@ -3,3 +3,4 @@ Label: EHR customization of Sample Manager
 Description: Adds additional EHR related data to Sample Manager. Provides ETL for Animal sources.
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/Viral_Load_Assay/module.properties
+++ b/Viral_Load_Assay/module.properties
@@ -1,2 +1,3 @@
 ModuleClass: org.labkey.viral_load_assay.Viral_Load_AssayModule
 ManageVersion: false
+SupportedDatabases: mssql, pgsql

--- a/ehr/module.properties
+++ b/ehr/module.properties
@@ -1,3 +1,4 @@
 ModuleClass: org.labkey.ehr.EHRModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql

--- a/ehr_billing/module.properties
+++ b/ehr_billing/module.properties
@@ -1,3 +1,4 @@
 ModuleClass: org.labkey.ehr_billing.EHR_BillingModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only