### PR TITLE
Remove SupportedDatabases property now that default is PostgreSQL-only

### DIFF
--- a/EHR_App/module.properties
+++ b/EHR_App/module.properties
@@ -1,2 +1,1 @@
 ModuleClass: org.labkey.ehr_app.EHR_AppModule
-SupportedDatabases: pgsql

--- a/EHR_Purchasing/module.properties
+++ b/EHR_Purchasing/module.properties
@@ -1,4 +1,3 @@
 ModuleClass: org.labkey.ehr_purchasing.EHR_PurchasingModule
-SupportedDatabases: pgsql
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6067