### PR TITLE
Set caseid on all sections in surgery form

### DIFF
--- a/ehr/resources/web/ehr/window/OpenSurgeryCasesWindow.js
+++ b/ehr/resources/web/ehr/window/OpenSurgeryCasesWindow.js
@@ -268,6 +268,16 @@ Ext4.define('EHR.window.OpenSurgeryCasesWindow', {
                                     console.log('updating procedure with caseid');
                                     rec.set('caseid', row.objectid);
                                 }, this);
+
+                                this.caseUpdateStores.forEach(function(store){
+                                    if (store.getFields().get('caseid') && store.getFields().get('Id')){
+                                        store.each((rec) => {
+                                            if (rec.get('Id') == row.Id){
+                                                rec.set('caseid', row.objectid);
+                                            }
+                                        }, this);
+                                    }
+                                }, this);
                             }
                         }, this);
                     }
@@ -292,6 +302,16 @@ Ext4.define('EHR.window.OpenSurgeryCasesWindow', {
                                 Ext4.Array.forEach(records, function(rec){
                                     console.log('updating procedure with caseid')
                                     rec.set('caseid', row.objectid);
+                                }, this);
+
+                                this.caseUpdateStores.forEach(function(store){
+                                    if (store.getFields().get('caseid') && store.getFields().get('Id')){
+                                        store.each((rec) => {
+                                            if (rec.get('Id') == row.Id){
+                                                rec.set('caseid', row.objectid);
+                                            }
+                                        }, this);
+                                    }
                                 }, this);
                             }
                         }, this);
@@ -336,7 +356,8 @@ EHR.DataEntryUtils.registerDataEntryFormButton('OPENSURGERYCASES', {
         }
 
         Ext4.create('EHR.window.OpenSurgeryCasesWindow', {
-            sourceStore: clientStore
+            sourceStore: clientStore,
+            caseUpdateStores: panel.storeCollection.clientStores.items,
         }).show();
     }
 });


### PR DESCRIPTION
#### Rationale
If a section in the surgery form contains a caseid column, set that column value when selecting/creating a case. Assumes forms have one case per id. Can override caseUpdateStores if a different set of stores to be updated.

#### Related Pull Requests
* TBD

#### Changes
* Loop through stores and find records for the animal in the case, updating caseid on the records if the column exists.
