### PR TITLE
Add ManageVersion property to all module.properties files

### DIFF
--- a/EHR_App/module.properties
+++ b/EHR_App/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.ehr_app.EHR_AppModule
+ManageVersion: true

--- a/EHR_Purchasing/module.properties
+++ b/EHR_Purchasing/module.properties
@@ -1,3 +1,4 @@
 ModuleClass: org.labkey.ehr_purchasing.EHR_PurchasingModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
+ManageVersion: true

--- a/EHR_SM/module.properties
+++ b/EHR_SM/module.properties
@@ -4,3 +4,4 @@ Description: Adds additional EHR related data to Sample Manager. Provides ETL fo
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/ehr/module.properties
+++ b/ehr/module.properties
@@ -2,3 +2,4 @@ ModuleClass: org.labkey.ehr.EHRModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true

--- a/ehr_billing/module.properties
+++ b/ehr_billing/module.properties
@@ -2,3 +2,4 @@ ModuleClass: org.labkey.ehr_billing.EHR_BillingModule
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql
+ManageVersion: true


### PR DESCRIPTION
#### Rationale
We want every LabKey-managed module to specify the `ManageVersion` property. https://www.labkey.org/home/Developer/issues/Secure/issues-details.view?issueId=47369
