### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/EHR_App/resources/views/populateData.view.xml
+++ b/EHR_App/resources/views/populateData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Populate Initial Data">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/ehr/resources/views/ehrAdmin.view.xml
+++ b/ehr/resources/views/ehrAdmin.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Administration" frame="none" >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/ehr/resources/views/ehrLookupsWebpart.view.xml
+++ b/ehr/resources/views/ehrLookupsWebpart.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Lookups">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="gen/EHRLookupsWebpart"/>
     </dependencies>

--- a/ehr/resources/views/ehrTemplates.view.xml
+++ b/ehr/resources/views/ehrTemplates.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Extensible Templates" frame="none" >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/ehr/resources/views/enterData.view.xml
+++ b/ehr/resources/views/enterData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Enter Data" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
         <dependency path="ehr/panel/EnterDataPanel.js"/>

--- a/ehr/resources/views/populateLookupData.view.xml
+++ b/ehr/resources/views/populateLookupData.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Populate EHR Reports and Lookups From File" frame="none" >
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="ehr.context" />
     </dependencies>

--- a/ehr/resources/views/referenceStudyComparison.view.xml
+++ b/ehr/resources/views/referenceStudyComparison.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="EHR Reference Study Comparison" frame="none">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4"/>
         <dependency path="codemirror"/>


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.