### PR TITLE
EHR Action Updates

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/demographics/HousingDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/HousingDemographicsProvider.java
@@ -47,8 +47,6 @@ public class HousingDemographicsProvider extends AbstractListDemographicsProvide
         keys.add(FieldKey.fromString("date"));
         keys.add(FieldKey.fromString("cond"));
         keys.add(FieldKey.fromString("reason"));
-
-        //cnprc
         keys.add(FieldKey.fromString("location"));
 
         return keys;

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -383,7 +383,7 @@ public class EHRController extends SpringActionController
 
             ActionURL url = getViewContext().getActionURL().clone();
 
-            if (keyField != null)
+            if (keyField != null && ti.getUpdateService() != null)
             {
                 String detailsStr;
                 String importStr;
@@ -1427,7 +1427,14 @@ public class EHRController extends SpringActionController
                 return null;
 
             List<String> lookups = new ArrayList<>();
-            lookups.add("All");
+
+            // This is too dangerous to leave in production so only include it if a manifest is provided as a URL parameter
+            // such as in automated testing
+            if (form.getManifest() != null)
+            {
+                lookups.add("All");
+            }
+
             lookups.add("lookup_sets");
 
             BufferedReader reader = Readers.getReader(_lookupsManifest.getInputStream());

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -1216,7 +1216,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         ds.addColumn(col20);
 
         var col8 = getWrappedIdCol(us, ds, "CageClass", "demographicsCageClass");
-        col8.setLabel("Required Case Size");
+        col8.setLabel("Required Cage Size");
         col8.setDescription("Calculates the cage size necessary for this animal, based on weight using The Guide requirements");
         ds.addColumn(col8);
 


### PR DESCRIPTION
#### Rationale
- Query datasets, recently added, are not editable so don't provide edit options if a QUS is not available.
- Remove option to reload 'All' lookups from normal operations. This could cause big problems for existing data.

#### Changes
* Check if TableInfo has a QUS in UpdateQueryAction before providing links to update.
* Only allow option to reload 'All' if a manifest is defined in a URL parameter
* Some cleanup
