### PR TITLE
Caseid on tasks

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr-25.000-25.001.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr-25.000-25.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr.tasks ADD caseid ENTITYID null;

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-25.000-25.001.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-25.000-25.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr.tasks ADD caseid ENTITYID null;

--- a/ehr/resources/schemas/ehr.xml
+++ b/ehr/resources/schemas/ehr.xml
@@ -212,6 +212,9 @@
             <column columnName="description">
                 <nullable>true</nullable>
             </column>
+            <column columnName="caseid">
+                <nullable>true</nullable>
+            </column>
         </columns>
     </table>
     <table tableName="requests" tableDbType="TABLE" useColumnOrder="true">

--- a/ehr/resources/web/ehr/DataEntryUtils.js
+++ b/ehr/resources/web/ehr/DataEntryUtils.js
@@ -885,7 +885,7 @@ EHR.DataEntryUtils = new function(){
             var vol;
             if (!fixedAmount){
                 if (valMap.concentration && valMap.dosage && valMap.weight){
-                    if (valMap.dosage_units === 'ml/kg') {
+                    if (valMap.dosage_units?.toLowerCase() === 'ml/kg') {
                         // Some drugs are in ml/kg instead of mg/kg. In those cases, concentration is irrelevant.
                         vol = valMap.dosage * valMap.weight;
 

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -133,7 +133,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 25.000;
+        return 25.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Add caseid field to ehr.tasks table. This allows easier tracking when multiple tasks are part of a case. Nullable so should not cause issues for implementations not using it.

#### Related Pull Requests
* https://github.com/LabKey/nircEHRModules/pull/477

#### Changes
* Upgrade scripts and schema xml update to add caseid to ehr.tasks
* Fix for units check in lab results
