### PR TITLE
Remove unnecessary QueryWebPart renders

### DIFF
--- a/ehr/resources/web/ehr/panel/DataEntryFormDetailsPanel.js
+++ b/ehr/resources/web/ehr/panel/DataEntryFormDetailsPanel.js
@@ -127,7 +127,6 @@ Ext4.define('EHR.panel.DataEntryFormDetailsPanel', {
                 success: this.onDataRegionLoad,
                 scope: this
             });
-            qwp.render();
         }, this);
 
         this.showEditBtn('Completed', results.form.permissions);


### PR DESCRIPTION
#### Rationale
If `renderTo` is defined in a QueryWebPart config, it is automatically rendered. Calling `render()` explicitly will request the data again and re-render the grid. This is inefficient at best but I suspect this re-render is behind some intermittent failures we've been seeing on TeamCity.
I'm cleaning up all that I could find.

#### Related Pull Requests
* N/A

#### Changes
* Remove unnecessary QueryWebPart renders