### PR TITLE
Blood draw interval fix

### DIFF
--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -1118,7 +1118,7 @@ public class TriggerScriptHelper
         intervalStop = DateUtils.truncate(intervalStop, Calendar.DATE);
 
         SimpleFilter filter = new SimpleFilter(FieldKey.fromString("Id"), id);
-        filter.addCondition(FieldKey.fromString("date"), intervalStart, CompareType.DATE_GTE);
+        filter.addCondition(FieldKey.fromString("date"), intervalStart, CompareType.DATE_GT);
         filter.addCondition(FieldKey.fromString("date"), intervalStop, CompareType.DATE_LTE);
         filter.addCondition(FieldKey.fromString("quantity"), null, CompareType.NONBLANK);
         filter.addCondition(FieldKey.fromString("countsAgainstVolume"), true);


### PR DESCRIPTION
#### Rationale
Our SOP states that "in any 30-day period the animal blood collection should not exceed 20% of the animal's estimated blood volume." The current blood calculation that happens during validation when blood draws are requested/performed was adding an additional day in the interval, but, the animal should actually get replenished a day sooner.

Here's an example:
If an animal had blood drawn on 2/12/2025, the 30 day period would bring us through 3/13/2025, and the animal should get replenished on 3/14/2025. The current blood calculation subtracts 30 days (or whatever the interval may be) to the current date (which turns out to be a 31 day period). It should only be 30 days total much like the current blood draw table here https://github.com/LabKey/snprcEHRModules/blob/75291bccef3cdc7055d0461686c9836497d77ba9/snprc_ehr/resources/queries/study/currentBloodDraws.sql#L72.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
