### PR TITLE
Misc code cleanup; add vet to users and groups in tests

### DIFF
--- a/ehr/src/org/labkey/ehr/query/EHRLookupsUserSchema.java
+++ b/ehr/src/org/labkey/ehr/query/EHRLookupsUserSchema.java
@@ -36,9 +36,7 @@ import org.labkey.api.ldk.table.ContainerScopedTable;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.FilteredTable;
 import org.labkey.api.query.QueryForeignKey;
-import org.labkey.api.query.QueryService;
 import org.labkey.api.query.SimpleUserSchema;
-import org.labkey.api.query.UserSchema;
 import org.labkey.api.security.Group;
 import org.labkey.api.security.MemberType;
 import org.labkey.api.security.RoleAssignment;
@@ -68,15 +66,12 @@ import java.util.Set;
 public class EHRLookupsUserSchema extends SimpleUserSchema
 {
     public static final String TABLE_AREAS = "areas";
-    public static final String TABLE_BUILDINGS = "buildings";
     public static final String TABLE_CAGE = "cage";
     public static final String TABLE_CAGE_POSITIONS = "cage_positions";
     public static final String TABLE_CAGE_TYPE = "cage_type";
-    public static final String TABLE_GEOGRAPHIC_ORIGINS = "geographic_origins";
     public static final String TABLE_ROOMS = "rooms";
     public static final String TABLE_SNOMED = "snomed";
     public static final String TABLE_SNOMED_SUBSET_CODES = "snomed_subset_codes";
-    public static final String TABLE_TREATMENT_CODES = "treatment_codes";
     public static final String TABLE_VETERINARIANS = "veterinarians";
 
     public EHRLookupsUserSchema(User user, Container container, DbSchema dbschema)
@@ -218,7 +213,7 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
             // By default, any hard tables in the ehr_lookups schema not accounted for above will fall into one of the
             // two categories below. Both of these will add a check that makes sure the user has EHRDataAdminPermission
             // in order to insert/update/delete on the table. The ContainerScopedTable case is for those tables that
-            // have a true DB PK or rowid but a User psedoPK that should be accounted for at the container level.
+            // have a true DB PK or rowid but a User pseudoPK that should be accounted for at the container level.
             String pkColName = getPkColName(ti);
             if (pkColName != null && !"rowid".equalsIgnoreCase(pkColName) && ti.getColumn("container") != null)
                 return getContainerScopedTable(name, cf, pkColName, EHRDataAdminPermission.class);
@@ -252,7 +247,7 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
 
     private TableInfo createVeterinariansTable(String name, ContainerFilter cf)
     {
-        FilteredTable ti = new FilteredTable<>(CoreSchema.getInstance().getTableInfoUsersData(), this, cf);
+        FilteredTable<EHRLookupsUserSchema> ti = new FilteredTable<>(CoreSchema.getInstance().getTableInfoUsersData(), this, cf);
         ti.setPublicSchemaName(EHRSchema.EHR_LOOKUPS);
 
         Set<Integer> userIds = new HashSet<>();
@@ -271,9 +266,9 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
                 else
                 {
                     Group assignedGroup = SecurityManager.getGroup(r.getUserId());
-                    if (assignedGroup != null && !assignedGroup.isProjectGroup())
+                    if (assignedGroup != null)
                     {
-                        // Add all site groups
+                        // Add all groups, both site and project-scoped
                         groupsToExpand.add(assignedGroup);
                     }
                 }
@@ -293,7 +288,7 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
 
         ti.addWrapColumn(ti.getRealTable().getColumn("UserId"));
         ti.addWrapColumn(ti.getRealTable().getColumn("DisplayName"));
-        ti.getMutableColumn("UserId").setFk(new QueryForeignKey(QueryService.get().getUserSchema(getUser(), getContainer(), "core"), null, "Users", "UserId", "DisplayName"));
+        ti.getMutableColumnOrThrow("UserId").setFk(new QueryForeignKey.Builder(this, getDefaultContainerFilter()).schema(CoreSchema.getInstance().getSchemaName()).table("Users"));
         ti.setName(name);
         ti.setTitle("Veterinarians");
 
@@ -302,7 +297,7 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
 
     private TableInfo getContainerScopedTable(String name, ContainerFilter cf, String psuedoPk, @Nullable Class<? extends Permission> perm)
     {
-        EHR_LookupsContainerScopedTable ret = new EHR_LookupsContainerScopedTable<>(this, this.createSourceTable(name), cf, psuedoPk);
+        EHR_LookupsContainerScopedTable<?> ret = new EHR_LookupsContainerScopedTable<>(this, this.createSourceTable(name), cf, psuedoPk);
         if (perm != null)
         {
             ret.addPermissionMapping(InsertPermission.class, perm);
@@ -314,14 +309,14 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
 
     private TableInfo getCustomPermissionTable(TableInfo schemaTable, ContainerFilter cf, Class<? extends Permission> perm)
     {
-        EHR_LookupsCustomPermissionsTable ret = new EHR_LookupsCustomPermissionsTable<>(this, schemaTable, cf);
+        EHR_LookupsCustomPermissionsTable<?> ret = new EHR_LookupsCustomPermissionsTable<>(this, schemaTable, cf);
         ret.addPermissionMapping(InsertPermission.class, perm);
         ret.addPermissionMapping(UpdatePermission.class, perm);
         ret.addPermissionMapping(DeletePermission.class, perm);
         return ret.init();
     }
 
-    private LookupSetTable createForPropertySet(UserSchema us, ContainerFilter cf, String setName, Map<String, Object> map)
+    private LookupSetTable createForPropertySet(EHRLookupsUserSchema us, ContainerFilter cf, String setName, Map<String, Object> map)
     {
         SchemaTableInfo table = _dbSchema.getTable(EHRSchema.TABLE_LOOKUPS);
         LookupSetTable ret = new LookupSetTable(us, table, cf, setName, map);
@@ -331,7 +326,7 @@ public class EHRLookupsUserSchema extends SimpleUserSchema
         return ret.init();
     }
 
-    private LabworkTypeTable createForLabwork(UserSchema us, ContainerFilter cf, String tableName, String typeName)
+    private LabworkTypeTable createForLabwork(EHRLookupsUserSchema us, ContainerFilter cf, String tableName, String typeName)
     {
         SchemaTableInfo table = _dbSchema.getTable(EHRSchema.TABLE_LAB_TESTS);
         return new LabworkTypeTable(us, table, cf, tableName, typeName).init();

--- a/ehr/src/org/labkey/ehr/query/LabworkTypeTable.java
+++ b/ehr/src/org/labkey/ehr/query/LabworkTypeTable.java
@@ -35,7 +35,6 @@ import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.QueryUpdateServiceException;
 import org.labkey.api.query.SimpleTableDomainKind;
 import org.labkey.api.query.SimpleUserSchema;
-import org.labkey.api.query.UserSchema;
 import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
@@ -45,21 +44,21 @@ import org.labkey.ehr.EHRSchema;
 
 import java.sql.SQLException;
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
 /**
  * User: bimber
  * Date: 3/27/13
  * Time: 6:20 PM
  */
-public class LabworkTypeTable extends AbstractDataDefinedTable
+public class LabworkTypeTable extends AbstractDataDefinedTable<EHRLookupsUserSchema>
 {
     public static final String CACHE_KEY = LabworkTypeTable.class.getName() + "||types";
 
     private static final String FILTER_FIELD = "testid";
     private static final String TYPE_FIELD = "type";
 
-    public LabworkTypeTable(UserSchema schema, SchemaTableInfo table, ContainerFilter cf, String tableName, String filterValue)
+    public LabworkTypeTable(EHRLookupsUserSchema schema, SchemaTableInfo table, ContainerFilter cf, String tableName, String filterValue)
     {
         super(schema, table, cf, TYPE_FIELD, FILTER_FIELD, tableName, filterValue);
         addPermissionMapping(InsertPermission.class, EHRDataAdminPermission.class);
@@ -117,7 +116,7 @@ public class LabworkTypeTable extends AbstractDataDefinedTable
 
     private class LabWorkTableUpdateService extends UpdateService
     {
-        public LabWorkTableUpdateService(SimpleUserSchema.SimpleTable ti)
+        public LabWorkTableUpdateService(SimpleUserSchema.SimpleTable<EHRLookupsUserSchema> ti)
         {
             super(ti);
         }
@@ -188,19 +187,14 @@ public class LabworkTypeTable extends AbstractDataDefinedTable
                 //append a column that will normalize whitespace in aliases
                 ColumnInfo aliasColInfo = getRealTable().getColumn(aliasColName);
                 final int inputIdx = aliasInputIdx;
-                it.addColumn(aliasColInfo, new Callable()
-                {
-                    @Override
-                    public Object call()
+                it.addColumn(aliasColInfo, (Supplier<Object>) () -> {
+                    Object val = it.getInputColumnValue(inputIdx);
+                    if (val instanceof String s)
                     {
-                        Object val = it.getInputColumnValue(inputIdx);
-                        if (val != null && val instanceof String)
-                        {
-                            val = normalizeAliasString((String)val);
-                        }
-
-                        return val;
+                        val = normalizeAliasString(s);
                     }
+
+                    return val;
                 });
             }
         }

--- a/ehr/src/org/labkey/ehr/query/LookupSetTable.java
+++ b/ehr/src/org/labkey/ehr/query/LookupSetTable.java
@@ -23,7 +23,6 @@ import org.labkey.api.ldk.LDKService;
 import org.labkey.api.ldk.table.AbstractDataDefinedTable;
 import org.labkey.api.query.QueryUpdateService;
 import org.labkey.api.query.SimpleUserSchema;
-import org.labkey.api.query.UserSchema;
 
 import java.util.Map;
 
@@ -32,7 +31,7 @@ import java.util.Map;
  * Date: 1/31/13
  * Time: 4:33 PM
  */
-public class LookupSetTable extends AbstractDataDefinedTable
+public class LookupSetTable extends AbstractDataDefinedTable<EHRLookupsUserSchema>
 {
     private static final String CACHE_KEY = LookupSetTable.class.getName() + "||values";
 
@@ -46,7 +45,7 @@ public class LookupSetTable extends AbstractDataDefinedTable
         return CACHE_KEY + "||" + c.getId();
     }
 
-    public LookupSetTable(UserSchema schema, SchemaTableInfo table, ContainerFilter cf, String setName, Map<String, Object> map)
+    public LookupSetTable(EHRLookupsUserSchema schema, SchemaTableInfo table, ContainerFilter cf, String setName, Map<String, Object> map)
     {
         super(schema, table, cf, FILTER_COL, VALUE_COL, setName, setName);
 
@@ -78,13 +77,13 @@ public class LookupSetTable extends AbstractDataDefinedTable
             if (keyCol != null)
             {
                 keyCol.setKeyField(true);
-                getMutableColumn("rowid").setKeyField(false);
+                getMutableColumnOrThrow("rowid").setKeyField(false);
             }
         }
         else
         {
-            getMutableColumn(VALUE_COL).setKeyField(false);
-            getMutableColumn("rowid").setKeyField(true);
+            getMutableColumnOrThrow(VALUE_COL).setKeyField(false);
+            getMutableColumnOrThrow("rowid").setKeyField(true);
         }
 
         if (_titleColumn != null)
@@ -107,7 +106,7 @@ public class LookupSetTable extends AbstractDataDefinedTable
 
     protected class EHRLookupsUpdateService extends UpdateService
     {
-        public EHRLookupsUpdateService(SimpleUserSchema.SimpleTable ti)
+        public EHRLookupsUpdateService(SimpleUserSchema.SimpleTable<EHRLookupsUserSchema> ti)
         {
             super(ti);
         }

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -114,6 +114,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
     protected static EHRUser NON_PATHOLOGY_REPORT = new EHRUser("non_pathology_report_user@ehrstudy.test","EHR Non Pathology", EHRRole.FULL_UPDATER);
     protected static EHRUser INVESTIGATOR = new EHRUser("investigator@ehrstudy.test", "EHR Lab", EHRRole.REQUESTER);
     protected static EHRUser INVESTIGATOR_PRINCIPAL = new EHRUser("investigator_principal@ehrstudy.test", "EHR Lab", EHRRole.DATA_ADMIN);
+    protected static EHRUser VET = new EHRUser("vet@ehrstudy.test", "EHR Vet", EHRRole.VETERINARIAN);
 
     protected static String REQUESTER_USER = "requester@ehrstudy.test";
     protected static String REQUEST_ADMIN_USER ="request_admin@ehrstudy.test";
@@ -667,6 +668,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         _userHelper.createUser(NON_PATHOLOGY_REPORT.getEmail(), true, true);
         _userHelper.createUser(INVESTIGATOR.getEmail(), true, true);
         _userHelper.createUser(INVESTIGATOR_PRINCIPAL.getEmail(), true, true);
+        _userHelper.createUser(VET.getEmail(), true, true);
         goToEHRFolder();
 
         _permissionsHelper.createPermissionsGroup(DATA_ADMIN.getGroup(), DATA_ADMIN.getEmail());
@@ -679,6 +681,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         _permissionsHelper.createPermissionsGroup(NON_PATHOLOGY_REPORT.getGroup(), NON_PATHOLOGY_REPORT.getEmail());
         _permissionsHelper.createPermissionsGroup(INVESTIGATOR.getGroup(), INVESTIGATOR.getEmail());
         _permissionsHelper.createPermissionsGroup(INVESTIGATOR_PRINCIPAL.getGroup(), INVESTIGATOR_PRINCIPAL.getEmail());
+        _permissionsHelper.createPermissionsGroup(VET.getGroup(), VET.getEmail());
 
         if (!getContainerPath().equals(getProjectName()))
             _permissionsHelper.uncheckInheritedPermissions();
@@ -690,6 +693,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         _permissionsHelper.setPermissions(FULL_SUBMITTER.getGroup(), "EHR Data Entry");
         _permissionsHelper.setPermissions(FULL_UPDATER.getGroup(), "EHR Data Entry");
         _permissionsHelper.setPermissions(REQUEST_ADMIN.getGroup(), "EHR Data Entry");
+        _permissionsHelper.setPermissions(VET.getGroup(), "EHR Veterinarian");
 
         _permissionsHelper.setPermissions(REQUESTER.getGroup(), "EHR Requestor");
         _permissionsHelper.setPermissions(REQUEST_ADMIN.getGroup(), "EHR Request Admin");
@@ -1015,7 +1019,8 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         BASIC_SUBMITTER ("EHR Basic Submitter"),
         FULL_SUBMITTER ("EHR Full Submitter"),
         FULL_UPDATER ("EHR Full Updater"),
-        REQUEST_ADMIN ("EHR Request Admin");
+        REQUEST_ADMIN ("EHR Request Admin"),
+        VETERINARIAN("EHR Veterinarian");
 
         private final String name;
 


### PR DESCRIPTION
#### Rationale
Add a new vet user and group as part of automated test setup. Clear many IntelliJ warnings.

#### Changes
* Clean up generics
* Misc other code cleanup
* Add vet user and group
* Include both site and project groups when populating the `ehr_lookups.veterinarian` table
