### PR TITLE
Update Max Merge Rows on SND EventsTable so that ETL handles mergeRows under a certain count

### DIFF
--- a/snd/src/org/labkey/snd/query/EventsTable.java
+++ b/snd/src/org/labkey/snd/query/EventsTable.java
@@ -146,10 +146,12 @@ public class EventsTable extends AbstractSNDTableInfo
             Set<Integer> eventIds = handleNarrativeCache(rows, configParameters, errors);
 
             int result = 0;
+            int maxMergeRows = SNDManager.MAX_MERGE_ROWS * 10;
+
             // Large merge triggers importRows path
-            if (eventIds.size() > SNDManager.MAX_MERGE_ROWS)
+            if (eventIds.size() > maxMergeRows)
             {
-                log.info("More than " + SNDManager.MAX_MERGE_ROWS + " rows. using importRows method.");
+                log.info("More than " + maxMergeRows + " rows. using importRows method.");
                 result = super.importRows(user, container, rows, errors, configParameters, extraScriptContext);
             }
             else


### PR DESCRIPTION
* Added maxMergeRows to EventsTable similar to in EventDataTable that is MAX_MERGE_ROWS * 10 so that mergeRows will be executed on larger updates that are not complete database reloads (20000 or more rows) instead of importRows