### PR TITLE
Restore event no-arg constructors for reflection

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
@@ -54,6 +54,8 @@ public class EHRSecurityEscalatorAuditProvider extends SecurityEscalationAuditPr
 
     public static class EHRSecurityEscalationEvent extends SecurityEscalationEvent
     {
+        /** Important for reflection-based instantiation */
+        @SuppressWarnings("unused")
         public EHRSecurityEscalationEvent() {}
 
         public EHRSecurityEscalationEvent(Container container, String comment)

--- a/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
@@ -54,6 +54,8 @@ public class EHRSecurityEscalatorAuditProvider extends SecurityEscalationAuditPr
 
     public static class EHRSecurityEscalationEvent extends SecurityEscalationEvent
     {
+        public EHRSecurityEscalationEvent() {}
+
         public EHRSecurityEscalationEvent(Container container, String comment)
         {
             super(EVENT_TYPE, container, comment);


### PR DESCRIPTION
#### Rationale
Test failures reveal that we need no-arg constructors for all AuditEventType classes.

https://teamcity.labkey.org/buildConfiguration/LabKey_Trunk_Premium_Ehr_BvtEhrPostgres/3437940

```
ERROR Registry                 2025-03-25T18:43:28,580            JobThread-2.1 : getFactory: failed to create bean factory
java.lang.RuntimeException: java.lang.NoSuchMethodException: org.labkey.api.ehr.security.EHRSecurityEscalatorAuditProvider$EHRSecurityEscalationEvent.<init>()
	at org.labkey.api.data.BeanObjectFactory.<init>(BeanObjectFactory.java:74) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.api.data.ObjectFactory$Registry.getFactory(ObjectFactory.java:73) ~[api-25.4-SNAPSHOT.jar:?]
	at org.labkey.audit.model.LogManager.validateFields(LogManager.java:243) ~[audit-25.4-SNAPSHOT.jar:?]
	at org.labkey.audit.model.LogManager.insertEvent(LogManager.java:100) ~[audit-25.4-SNAPSHOT.jar:?]
	at org.labkey.audit.AuditLogImpl._addEvents(AuditLogImpl.java:205) ~[audit-25.4-SNAPSHOT.jar:?]
	at org.labkey.audit.AuditLogImpl.addEvent(AuditLogImpl.java:134) ~[audit-25.4-SNAPSHOT.jar:?]
```

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6491

#### Changes
* Restore no-arg constructor, add comment