### PR TITLE
Fix NullPointerException on saveEvent when a parent EventData object has empty unrequired subpackages

### DIFF
--- a/snd/src/org/labkey/snd/SNDManager.java
+++ b/snd/src/org/labkey/snd/SNDManager.java
@@ -2744,12 +2744,14 @@ public class SNDManager
         for (SuperPackage superPackage : pkg.getSubpackages())
         {
             found = false;
-            for (EventData data : eventData.getSubPackages())
-            {
-                if (data.getSuperPkgId() == superPackage.getSuperPkgId())
+            if (eventData.getSubPackages() != null) {
+                for (EventData data : eventData.getSubPackages())
                 {
-                    found = true;
-                    ensureValidPackage(event, data, superPackage.getPkg());
+                    if (data.getSuperPkgId() == superPackage.getSuperPkgId())
+                    {
+                        found = true;
+                        ensureValidPackage(event, data, superPackage.getPkg());
+                    }
                 }
             }
 


### PR DESCRIPTION
* Related Pull Request: https://txbiomed.atlassian.net/browse/MDP-220?atlOrigin=eyJpIjoiNDZjYjYzMWE1YjI3NGZmY2E0YWI3MWNlMTJjNWM2MzQiLCJwIjoiaiJ9