### PR TITLE
Adding option to the navMenu to add a target when generating links in…

### DIFF
--- a/ehr/resources/web/ehr/navMenu.js
+++ b/ehr/resources/web/ehr/navMenu.js
@@ -107,11 +107,19 @@ Ext4.define('EHR.NavMenu', {
                     item = this.renderer(tmp.items[j])
                 }
                 else {
-                   //NOTE: this is the default renderer
-                   item = {
-                       //Creates links for the navigation panel
-                        html: '<a href="'+tmp.items[j].url+'">'+tmp.items[j].name+'</a>'
+                    if (tmp.items[j].target){
+                        item = {
+                            //Creates links for the navigation panel to a target
+                            html: '<a target="'+tmp.items[j].target+'" href="'+tmp.items[j].url+'">'+tmp.items[j].name+'</a>'
+                        }
+                    }else{
+                        item = {
+                            //Creates links for the navigation panel
+                            html: '<a href="'+tmp.items[j].url+'">'+tmp.items[j].name+'</a>'
+                        }
                     }
+                   //NOTE: this is the default renderer
+
                 }
                 section.add(item)
             }


### PR DESCRIPTION
#### Rationale
Need to add a target when generating link in navMenu. This will not change any of the links, only if target is added to the html page will add the target to open the window in a new tab.

#### Related Pull Requests
WNPRC-modules PR 784

#### Changes
Added an if statement that looks for target to add it to the html item.
