### PR TITLE
Fix for creating templates from selected records

### DIFF
--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -252,7 +252,8 @@ EHR.Server.Triggers.beforeUpdate = function(row, oldRow, errors){
     helper.logDebugMsg(row);
 
     if (EHR.Server.Security.verifyPermissions('update', row, oldRow) === false){
-        errors._form = 'Insufficient permissions to update: ' + helper.getQueryName() + ' to status: ' + row.QCStateLabel + ', from: ' + (oldRow ? oldRow.QCStateLabel : '<none>');
+        console.log((EHR.Server.Security.verifyPermissions('update', row, oldRow)));
+        errors._form = 'Insufficient permissions to updateee: ' + helper.getQueryName() + ' to status: ' + row.QCStateLabel + ', from: ' + (oldRow ? oldRow.QCStateLabel : '<none>');
         return;
     }
 

--- a/ehr/resources/scripts/ehr/triggers.js
+++ b/ehr/resources/scripts/ehr/triggers.js
@@ -252,8 +252,7 @@ EHR.Server.Triggers.beforeUpdate = function(row, oldRow, errors){
     helper.logDebugMsg(row);
 
     if (EHR.Server.Security.verifyPermissions('update', row, oldRow) === false){
-        console.log((EHR.Server.Security.verifyPermissions('update', row, oldRow)));
-        errors._form = 'Insufficient permissions to updateee: ' + helper.getQueryName() + ' to status: ' + row.QCStateLabel + ', from: ' + (oldRow ? oldRow.QCStateLabel : '<none>');
+        errors._form = 'Insufficient permissions to update: ' + helper.getQueryName() + ' to status: ' + row.QCStateLabel + ', from: ' + (oldRow ? oldRow.QCStateLabel : '<none>');
         return;
     }
 

--- a/ehr/resources/web/ehr/window/SaveTemplateWindow.js
+++ b/ehr/resources/web/ehr/window/SaveTemplateWindow.js
@@ -204,7 +204,8 @@ Ext4.define('EHR.window.SaveTemplateWindow', {
         var rows = [];
 
         this.down('#theForm').items.each(function(tab){
-            var selections = tab.down('#recordSelector').getValue().inputValue;
+            var radioGroup = tab.down('#recordSelector');
+            var selections = radioGroup.getValue()[radioGroup.down('[name]').name];
             var fields = tab.down('#fieldSelector').getValue().fields;
 
             if (!fields.length)
@@ -220,7 +221,7 @@ Ext4.define('EHR.window.SaveTemplateWindow', {
 
             var records = [];
             if (selections == 'selected'){
-                records = this.grid.getSelectionModel().getSelections();
+                records = this.targetGrid.getSelectionModel().getSelection();
 
                 if (!records.length){
                     Ext4.Msg.hide();


### PR DESCRIPTION
#### Rationale
When you try to create a template in the ext4 grid and try to save it by selecting the radio option from the "selected records" in a grid, that it does not work, it uses all the records as the templates rather than just the ones selected. This is a fix for that.

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* <!-- list of descriptions of changes that are worth noting (replace this comment) -->
