### PR TITLE
DatabaseIdentifier

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
@@ -116,16 +116,10 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
             public void exec(ResultSet object) throws SQLException
             {
                 Results rs = new ResultsImpl(object, cols);
+                String id = ti.getColumn("Id").getStringValue(rs);
 
-                String id = rs.getString(FieldKey.fromString(ti.getColumn("Id").getAlias()));
-
-                Map<String, Object> map = ret.get(id);
-                if (map == null)
-                    map = new TreeMap<>();
-
+                Map<String, Object> map = ret.computeIfAbsent(id, (x)->new TreeMap<>());
                 processRow(rs, cols, map);
-
-                ret.put(id, map);
             }
         });
         if (debugEnabled)

--- a/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
@@ -85,8 +85,7 @@ public class WeightsDemographicsProvider extends AbstractListDemographicsProvide
                 public void exec(ResultSet object) throws SQLException
                 {
                     Results rs = new ResultsImpl(object, cols);
-
-                    String id = rs.getString(FieldKey.fromString(ti.getColumn("Id").getAlias()));
+                    String id = ti.getColumn("Id").getStringValue(rs);
 
                     Map<String, Object> map = ret.get(id);
                     if (map == null)

--- a/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
@@ -87,13 +87,8 @@ public class WeightsDemographicsProvider extends AbstractListDemographicsProvide
                     Results rs = new ResultsImpl(object, cols);
                     String id = ti.getColumn("Id").getStringValue(rs);
 
-                    Map<String, Object> map = ret.get(id);
-                    if (map == null)
-                        map = new HashMap<>();
-
+                    Map<String, Object> map = ret.computeIfAbsent(id, (x)->new HashMap<>());
                     processRow(rs, cols, map);
-
-                    ret.put(id, map);
                 }
             });
         }


### PR DESCRIPTION
#### Rationale
Generating correct sql is very dependent on everyone writing identifier consistently.  This is often handled by using append(SqlDialect.makeLegalIdentifier(col.getAlias())) or luck append(col.getName()) or append(col.getAlias()).

The idea is to pass around database identifiers such as table names, column names, both generated and from db metadata, using a class DatabaseIdentifier.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
- <!-- list of descriptions of changes that are worth noting (replace this comment) -->
