### PR TITLE
User dropdowns should only show active users

### DIFF
--- a/ehr/resources/queries/core/PrincipalsWithoutAdmin.sql
+++ b/ehr/resources/queries/core/PrincipalsWithoutAdmin.sql
@@ -19,7 +19,8 @@ SELECT
   u.DisplayName,
   'u' as Type,
   u.FirstName,
-  u.LastName
+  u.LastName,
+  u.active
 
 FROM core.Users u
 WHERE u.userid > 0
@@ -31,6 +32,7 @@ SELECT
   g.Name as DisplayName,
   'g' as Type,
   null as FirstName,
-  null as LastName
+  null as LastName,
+  true AS active
 FROM core.groups g
 WHERE g.userid > 0

--- a/ehr/resources/web/ehr/form/field/UsersAndGroupsCombo.js
+++ b/ehr/resources/web/ehr/form/field/UsersAndGroupsCombo.js
@@ -20,6 +20,7 @@ Ext4.define('EHR.form.field.UsersAndGroupsCombo', {
                 queryName: 'PrincipalsWithoutAdmin',
                 columns: 'UserId,DisplayName,FirstName,LastName',
                 sort: 'Type,DisplayName',
+                filterArray: [LABKEY.Filter.create('active', true, LABKEY.Filter.Types.EQUAL)],
                 autoLoad: true
             },
             anyMatch: true,


### PR DESCRIPTION
#### Rationale
All assignment dropdowns are showing inactive users along with active users. I'm not aware of any cases that a review, task, request, etc would be assigned to an inactive user.

This does not affect historical data.

#### Changes
* Add user active status to PrincipalsWithoutAdmin
* Update UsersAndGroupsCombo filter
