### PR TITLE
Make EHRCompliance tables extensible starting with RequirementsPerEmployee

### DIFF
--- a/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-25.000-25.001.sql
+++ b/EHR_ComplianceDB/resources/schemas/dbscripts/postgresql/EHR_ComplianceDB-25.000-25.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_compliancedb.requirementsperemployee ADD COLUMN LSID LSIDtype;

--- a/EHR_ComplianceDB/resources/schemas/dbscripts/sqlserver/EHR_ComplianceDB-25.000-25.001.sql
+++ b/EHR_ComplianceDB/resources/schemas/dbscripts/sqlserver/EHR_ComplianceDB-25.000-25.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr_compliancedb.requirementsperemployee ADD Lsid LsidType null;

--- a/EHR_ComplianceDB/resources/schemas/ehr_compliancedb.xml
+++ b/EHR_ComplianceDB/resources/schemas/ehr_compliancedb.xml
@@ -453,6 +453,17 @@
                 <isKeyField>true</isKeyField>
                 <columnTitle>Key</columnTitle>
             </column>
+            <column columnName="lsid">
+                <datatype>lsidtype</datatype>
+                <isReadOnly>true</isReadOnly>
+                <isHidden>true</isHidden>
+                <isUserEditable>false</isUserEditable>
+                <fk>
+                    <fkColumnName>ObjectUri</fkColumnName>
+                    <fkTable>Object</fkTable>
+                    <fkDbSchema>exp</fkDbSchema>
+                </fk>
+            </column>
             <column columnName="employeeid">
                 <columnTitle>Employee Id</columnTitle>
                 <fk>

--- a/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/EHR_ComplianceDBModule.java
+++ b/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/EHR_ComplianceDBModule.java
@@ -19,9 +19,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbSchemaType;
+import org.labkey.api.exp.property.PropertyService;
 import org.labkey.api.ldk.ExtendedSimpleModule;
 import org.labkey.api.ldk.LDKService;
 import org.labkey.api.ldk.notification.NotificationService;
+import org.labkey.ehr_compliancedb.model.EHRComplianceDBDomainKind;
 import org.labkey.ehr_compliancedb.notification.EmployeeComplianceNotification;
 import org.labkey.api.module.ModuleContext;
 import org.labkey.ehr_compliancedb.api.EHR_ComplianceService;
@@ -49,7 +51,7 @@ public class EHR_ComplianceDBModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 12.44;
+        return 25.001;
     }
 
     @Override
@@ -64,6 +66,7 @@ public class EHR_ComplianceDBModule extends ExtendedSimpleModule
         addController(CONTROLLER_NAME, EHR_ComplianceDBController.class);
 
         EHR_ComplianceService.setInstance(new EHR_ComplianceServiceImpl());
+        PropertyService.get().registerDomainKind(new EHRComplianceDBDomainKind());
     }
 
     @Override

--- a/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/EHR_ComplianceDBUserSchema.java
+++ b/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/EHR_ComplianceDBUserSchema.java
@@ -25,8 +25,10 @@ import org.labkey.api.ldk.table.ContainerScopedTable;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.DefaultSchema;
 import org.labkey.api.query.QuerySchema;
+import org.labkey.api.query.SimpleTableDomainKind;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.User;
+import org.labkey.ehr_compliancedb.model.EHRComplianceDBDomainKind;
 
 /**
  * User: bimber
@@ -36,6 +38,7 @@ import org.labkey.api.security.User;
 public class EHR_ComplianceDBUserSchema extends SimpleUserSchema
 {
     public static final String TABLE_REQUIREMENTS = "requirements";
+    private static final String TABLE_REQUIREMENTSPEREMPLOYEE = "requirementsperemployee";
 
     public EHR_ComplianceDBUserSchema(User user, Container container, DbSchema dbschema)
     {
@@ -49,6 +52,23 @@ public class EHR_ComplianceDBUserSchema extends SimpleUserSchema
         {
             SchemaTableInfo table = _dbSchema.getTable(name);
             return new ContainerScopedTable<>(this, table, cf, "requirementname").init();
+        }
+        else if (TABLE_REQUIREMENTSPEREMPLOYEE.equalsIgnoreCase(name))
+        {
+            SchemaTableInfo table = _dbSchema.getTable(name);
+            return new ContainerScopedTable<>(this, table, cf, "rowid")
+            {
+                // There are issues with the '_' in the name of this module and creating template domains. This addresses
+                // the domain URI by normalizing with the domain kind.
+                @Override
+                public String getDomainURI()
+                {
+                    if (_objectUriCol == null)
+                        return null;
+
+                    return SimpleTableDomainKind.getDomainURI(EHRComplianceDBDomainKind.KIND_NAME, getName(), getDomainContainer(), _userSchema.getUser());
+                }
+            }.init();
         }
 
         return super.createTable(name, cf);

--- a/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/EHR_ComplianceDBUserSchema.java
+++ b/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/EHR_ComplianceDBUserSchema.java
@@ -56,7 +56,7 @@ public class EHR_ComplianceDBUserSchema extends SimpleUserSchema
         else if (TABLE_REQUIREMENTSPEREMPLOYEE.equalsIgnoreCase(name))
         {
             SchemaTableInfo table = _dbSchema.getTable(name);
-            return new ContainerScopedTable<>(this, table, cf, "rowid")
+            return new SimpleTable<>(this, table, cf)
             {
                 // There are issues with the '_' in the name of this module and creating template domains. This addresses
                 // the domain URI by normalizing with the domain kind.

--- a/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/model/EHRComplianceDBDomainKind.java
+++ b/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/model/EHRComplianceDBDomainKind.java
@@ -1,0 +1,57 @@
+package org.labkey.ehr_compliancedb.model;
+
+import org.labkey.api.data.Container;
+import org.labkey.api.exp.property.Domain;
+import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
+import org.labkey.api.query.ExtendedTableDomainKind;
+import org.labkey.api.security.User;
+import org.labkey.api.security.permissions.AdminPermission;
+import org.labkey.data.xml.domainTemplate.DomainTemplateType;
+import org.labkey.data.xml.domainTemplate.EHRComplianceDBTemplateType;
+
+
+import java.util.List;
+import java.util.Set;
+
+public class EHRComplianceDBDomainKind extends ExtendedTableDomainKind
+{
+    public static final String KIND_NAME = "EHRComplianceDB";
+
+    @Override
+    public boolean canCreateDefinition(User user, Container container)
+    {
+        return container.hasPermission("EHRComplianceDBDomainKind.canCreateDefinition", user, AdminPermission.class);
+    }
+
+    @Override
+    protected String getSchemaName()
+    {
+        return KIND_NAME.toLowerCase();
+    }
+
+    @Override
+    protected String getNamespacePrefix()
+    {
+        return KIND_NAME.toLowerCase();
+    }
+
+    @Override
+    public String getKindName()
+    {
+        return KIND_NAME;
+    }
+
+    @Override
+    public Set<String> getReservedPropertyNames(Domain domain, User user)
+    {
+        return super.getReservedPropertyNames(domain, user);
+    }
+
+    @Override
+    public boolean matchesTemplateXML(String templateName, DomainTemplateType template, List<GWTPropertyDescriptor> properties)
+    {
+        return template instanceof EHRComplianceDBTemplateType;
+    }
+}
+
+

--- a/ehr/resources/views/ehrTemplates.html
+++ b/ehr/resources/views/ehrTemplates.html
@@ -54,19 +54,52 @@
         });
     }
 
+    createEHRComplianceDomainHandler = function () {
+        var ctx = EHR.Utils.getEHRContext();
+        var container = document.getElementById("ehrcompliance_container").value;
+        if (!container) {
+            LABKEY.Utils.alert("Error", "Must enter the container path of the compliance folder.");
+        }
+        else {
+            LABKEY.Domain.create({
+                module: ctx ? ctx['EHRCustomModule'] : null,
+                domainKind: "EHRComplianceDB",
+                domainGroup: "ehrcompliancedb",
+                importData: false,
+                containerPath: container,
+                success: function () {
+                    LABKEY.Utils.alert("Success", "EHR_ComplianceDB tables updated successfully.");
+                },
+                failure: function (e) {
+                    LABKEY.Utils.alert("Error", e.exception);
+                }
+            });
+        }
+    }
+
     LABKEY.Utils.onReady(function(){
         document.getElementById('createEHRDomainHandler')['onclick'] = function(){ createEHRDomainHandler(); return false; }
         document.getElementById('createEHRLookupsDomainHandler')['onclick'] = function(){ createEHRLookupsDomainHandler(); return false; }
         document.getElementById('createEHRBillingDomainHandler')['onclick'] = function(){ createEHRBillingDomainHandler(); return false; }
+        document.getElementById('createEHRComplianceDomainHandler')['onclick'] = function(){ createEHRComplianceDomainHandler(); return false; }
     });
 </script>
 
 <html>
 <div style="margin: 20px 0;">
     <h5><b>
-        <a style="margin-right: 30px; cursor: pointer;" id='createEHRDomainHandler'>Load EHR table definitions</a>
-        <a style="margin-right: 30px; cursor: pointer;" id='createEHRLookupsDomainHandler'>Load EHR_Lookup table definitions</a>
-        <a style="margin-right: 30px; cursor: pointer;" id='createEHRBillingDomainHandler'>Load EHR_Billing table definitions</a>
+        <a style="cursor: pointer;" id='createEHRDomainHandler'>Load EHR table definitions</a>
+        <br><br>
+        <a style="cursor: pointer;" id='createEHRLookupsDomainHandler'>Load EHR_Lookup table definitions</a>
+        <br><br>
+        <a style="cursor: pointer;" id='createEHRBillingDomainHandler'>Load EHR_Billing table definitions</a>
+        <br><br>
+        <div>
+            <a style="margin-right: 10px; cursor: pointer;" id='createEHRComplianceDomainHandler'>Load EHR_Compliance table definitions</a>
+            <label for="ehrcompliance_container">Container:</label>
+            <input type="text" id="ehrcompliance_container" name="ehrcompliance_container" style="width: 300px;">
+
+        </div>
     </b></h5>
 </div>
 </html>


### PR DESCRIPTION
#### Rationale
As groups continue to use the EHR_ComplianceDB module there is a need to make some tables extensible. The current need is to extend RequirementsPerEmployee, but this will help with other tables should they need to be extended.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6644

#### Changes
* Add and register domain kind
* Add fix for domainURI
* Add LSID to RequirementsPerEmployee
*  Update general EHR page to add this schema including container field
