### PR TITLE
PropertyDescriptor: stop holding Container objects

### DIFF
--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -533,7 +533,6 @@ public class EHRManager
                 for (PropertyDescriptor sharedPD : pdsToReparentInShared)
                 {
                     sharedPD.setContainer(ContainerManager.getSharedContainer());
-                    sharedPD.setProject(ContainerManager.getSharedContainer());
                     OntologyManager.updatePropertyDescriptor(sharedPD);
                 }
             }


### PR DESCRIPTION
#### Rationale
No need to set project on a property descriptor... it's implied by container

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6658