### PR TITLE
Add inheritDefaultDateFromParent to encounter forms

### DIFF
--- a/ehr/resources/web/ehr/data/EncounterStoreCollection.js
+++ b/ehr/resources/web/ehr/data/EncounterStoreCollection.js
@@ -60,19 +60,19 @@ Ext4.define('EHR.data.EncounterStoreCollection', {
             var parentRec = this.getEncountersRecord(model.get('parentid'));
             if (parentRec){
                 model.beginEdit();
-                if (parentRec.get('Id') !== model.get('Id') && model.fields.get('Id')?.inheritFromParent){
+                if (parentRec.get('Id') !== model.get('Id')){
                     model.set('Id', parentRec.get('Id'));
                 }
 
-                if (model.fields.get('date')?.inheritDateFromParent && !model.get('date') && parentRec.get('date')){
+                if (model.fields.get('date')?.inheritDefaultDateFromParent && !model.get('date') && parentRec.get('date')){
                     model.set('date', parentRec.get('date'));
                 }
 
-                if (model.fields.get('project')?.inheritFromParent && !model.get('project') && parentRec.get('project')){
+                if (model.fields.get('project') && !model.get('project') && parentRec.get('project')){
                     model.set('project', parentRec.get('project'));
                 }
 
-                if (model.fields.get('chargetype')?.inheritFromParent && !model.get('chargetype') && parentRec.get('chargetype')){
+                if (model.fields.get('chargetype') && !model.get('chargetype') && parentRec.get('chargetype')){
                     model.set('chargetype', parentRec.get('chargetype'));
                 }
 

--- a/ehr/resources/web/ehr/data/EncounterStoreCollection.js
+++ b/ehr/resources/web/ehr/data/EncounterStoreCollection.js
@@ -60,19 +60,19 @@ Ext4.define('EHR.data.EncounterStoreCollection', {
             var parentRec = this.getEncountersRecord(model.get('parentid'));
             if (parentRec){
                 model.beginEdit();
-                if (parentRec.get('Id') !== model.get('Id')){
+                if (parentRec.get('Id') !== model.get('Id') && model.fields.get('Id')?.inheritFromParent){
                     model.set('Id', parentRec.get('Id'));
                 }
 
-                if (model.fields.get('date') && !model.get('date') && parentRec.get('date')){
+                if (model.fields.get('date')?.inheritDateFromParent && !model.get('date') && parentRec.get('date')){
                     model.set('date', parentRec.get('date'));
                 }
 
-                if (model.fields.get('project') && !model.get('project') && parentRec.get('project')){
+                if (model.fields.get('project')?.inheritFromParent && !model.get('project') && parentRec.get('project')){
                     model.set('project', parentRec.get('project'));
                 }
 
-                if (model.fields.get('chargetype') && !model.get('chargetype') && parentRec.get('chargetype')){
+                if (model.fields.get('chargetype')?.inheritFromParent && !model.get('chargetype') && parentRec.get('chargetype')){
                     model.set('chargetype', parentRec.get('chargetype'));
                 }
 

--- a/ehr/resources/web/ehr/model/sources/EncounterChild.js
+++ b/ehr/resources/web/ehr/model/sources/EncounterChild.js
@@ -12,7 +12,8 @@ EHR.model.DataModelManager.registerMetadata('EncounterChild', {
             }
         },
         date: {
-            inheritDateFromParent: true
+            inheritDateFromParent: true,
+            inheritDefaultDateFromParent: true
         },
         project: {
             inheritFromParent: true

--- a/ehr/resources/web/ehr/window/EncounterAddRecordWindow.js
+++ b/ehr/resources/web/ehr/window/EncounterAddRecordWindow.js
@@ -96,8 +96,14 @@ Ext4.define('EHR.window.EncounterAddRecordWindow', {
             var model = this.targetGrid.store.createModel({});
             var obj = {};
             Ext4.Array.forEach(['Id', 'date', 'parentid', 'project'], function(field){
-                if (this.targetGrid.store.getFields().get(field)){
-                    obj[field] = rec.get(field);
+                const fieldConfig = this.targetGrid.store.getFields().get(field);
+                if (fieldConfig){
+                    if (field === 'date' && fieldConfig.inheritDateFromParent) {
+                        obj[field] = rec.get(field);
+                    }
+                    else if (fieldConfig.inheritFromParent) {
+                        obj[field] = rec.get(field);
+                    }
                 }
             }, this);
 

--- a/ehr/resources/web/ehr/window/EncounterAddRecordWindow.js
+++ b/ehr/resources/web/ehr/window/EncounterAddRecordWindow.js
@@ -98,10 +98,12 @@ Ext4.define('EHR.window.EncounterAddRecordWindow', {
             Ext4.Array.forEach(['Id', 'date', 'parentid', 'project'], function(field){
                 const fieldConfig = this.targetGrid.store.getFields().get(field);
                 if (fieldConfig){
-                    if (field === 'date' && fieldConfig.inheritDateFromParent) {
-                        obj[field] = rec.get(field);
+                    if (field === 'date') {
+                        if (fieldConfig.inheritDefaultDateFromParent) {
+                            obj[field] = rec.get(field);
+                        }
                     }
-                    else if (fieldConfig.inheritFromParent) {
+                    else {
                         obj[field] = rec.get(field);
                     }
                 }


### PR DESCRIPTION
#### Rationale
Currently encounter forms use parent-child relationship to initialize the date from encounters to the new records in the sections below. There are cases where this behavior is not desired. This PR adds the inheritDefaultDateFromParent to skip this initialization.

#### Related Pull Requests
* https://github.com/LabKey/onprcEHRModules/pull/1372

#### Changes
* Add inheritDefaultDateFromParent and conditionalize date default in encounters
