### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/EHR_App/test/src/org/labkey/test/tests/EHRAppTestSetupHelper.java
+++ b/EHR_App/test/src/org/labkey/test/tests/EHRAppTestSetupHelper.java
@@ -13,7 +13,6 @@ import org.labkey.test.tests.ehr.AbstractEHRTest;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/EHR_App/test/src/org/labkey/test/tests/EHR_AppTest.java
+++ b/EHR_App/test/src/org/labkey/test/tests/EHR_AppTest.java
@@ -74,7 +74,7 @@ public class EHR_AppTest extends AbstractGenericEHRTest implements PostgresOnlyT
     @BeforeClass
     public static void setupProject() throws Exception
     {
-        EHR_AppTest init = (EHR_AppTest) getCurrentTest();
+        EHR_AppTest init = getCurrentTest();
         init.doSetup();
     }
 

--- a/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/notification/EmployeeComplianceNotification.java
+++ b/EHR_ComplianceDB/src/org/labkey/ehr_compliancedb/notification/EmployeeComplianceNotification.java
@@ -15,15 +15,10 @@
  */
 package org.labkey.ehr_compliancedb.notification;
 
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.apache.commons.lang3.time.DateUtils;
-import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.module.Module;
 import org.labkey.api.data.CompareType;
-import org.labkey.api.data.Results;
 import org.labkey.api.data.ColumnInfo;
-import org.labkey.api.data.ResultsImpl;
 import org.labkey.api.data.Selector;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Sort;
@@ -36,20 +31,15 @@ import org.labkey.api.security.User;
 import org.labkey.api.query.UserSchema;
 import org.labkey.api.ldk.notification.AbstractNotification;
 import org.labkey.api.util.DateUtil;
-import org.labkey.ehr_compliancedb.EHR_ComplianceDBModule;
-import org.labkey.ehr_compliancedb.EHR_ComplianceDBUserSchema;
 
 
-import java.util.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 //Added 3-29-2016  Blasa
 
@@ -153,12 +143,12 @@ public class EmployeeComplianceNotification extends AbstractNotification
             msg.append("<tr style='font-weight: bold;'><td>Employee ID</td><td>First Name</td><td>Last Name</td><td>Category</td><td>Unit</td><td>Supervisor</td><td>Location</td></tr>\n");
 
 
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
                 {
-                    msg.append("<tr><td>" + (rs.getString("employeeid") == null ? "" : rs.getString("employeeid")) + "</td><td>" + rs.getString("firstName") + "</td><td>" + rs.getString("lastName")  + "</td><td>" + rs.getString("category")  + "</td><td>" + rs.getString("unit")  + "</td><td>" + rs.getString("supervisor") + "</td><td>" + rs.getString("location")+ "</td></tr>\n");
+                    msg.append("<tr><td>" + (rs.getString("employeeid") == null ? "" : rs.getString("employeeid")) + "</td><td>" + rs.getString("firstName") + "</td><td>" + rs.getString("lastName") + "</td><td>" + rs.getString("category") + "</td><td>" + rs.getString("unit") + "</td><td>" + rs.getString("supervisor") + "</td><td>" + rs.getString("location") + "</td></tr>\n");
 
                 }
             });

--- a/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingController.java
+++ b/EHR_Purchasing/src/org/labkey/ehr_purchasing/EHR_PurchasingController.java
@@ -36,13 +36,15 @@ public class EHR_PurchasingController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
-            return new JspView("/org/labkey/ehr_purchasing/view/hello.jsp");
+            return new JspView<>("/org/labkey/ehr_purchasing/view/hello.jsp");
         }
 
+        @Override
         public void addNavTrail(NavTree root) { }
     }
 }

--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMController.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMController.java
@@ -48,8 +48,9 @@ public class EHR_SMController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BeginAction extends SimpleViewAction
+    public static class BeginAction extends SimpleViewAction<Object>
     {
+        @Override
         public ModelAndView getView(Object o, BindException errors)
         {
             JspView<Void> view = new JspView<>("/org/labkey/ehr_sm/view/hello.jsp");
@@ -57,6 +58,7 @@ public class EHR_SMController extends SpringActionController
             return view;
         }
 
+        @Override
         public void addNavTrail(NavTree root) { }
     }
 
@@ -100,6 +102,7 @@ public class EHR_SMController extends SpringActionController
     @RequiresPermission(AdminPermission.class)
     public class AdminAction extends FormViewAction<AdminForm>
     {
+        @Override
         public void addNavTrail(NavTree root) { }
 
         @Override

--- a/EHR_SM/test/src/org/labkey/test/tests/ehr_sm/EHR_SMTest.java
+++ b/EHR_SM/test/src/org/labkey/test/tests/ehr_sm/EHR_SMTest.java
@@ -42,7 +42,7 @@ public class EHR_SMTest extends BaseWebDriverTest
     @BeforeClass
     public static void setupProject()
     {
-        EHR_SMTest init = (EHR_SMTest)getCurrentTest();
+        EHR_SMTest init = getCurrentTest();
 
         init.doSetup();
     }

--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ABI7500ImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ABI7500ImportMethod.java
@@ -162,7 +162,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
         return meta;
     }
 
-    private class Parser extends DefaultAssayParser
+    private static class Parser extends DefaultAssayParser
     {
         private final Double CYCLE_LIMIT = 45.0;
         private static final String TASK_FIELD = "Task";
@@ -178,7 +178,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
         @Override
         public Pair<ExpExperiment, ExpRun> saveBatch(JSONObject json, File file, String fileName, ViewContext ctx) throws BatchValidationException
         {
-            Integer templateId = json.getInt("TemplateId");
+            int templateId = json.getInt("TemplateId");
 
             Pair<ExpExperiment, ExpRun> result = super.saveBatch(json, file, fileName, ctx);
 
@@ -217,7 +217,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
 
                     if (!inResults)
                     {
-                        if (row.size() == 0)
+                        if (row.isEmpty())
                             continue;
 
                         if (row.get(0).equals("Detector Name"))
@@ -229,7 +229,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
                         if (inDetectors)
                         {
                             String detector = row.get(0);
-                            Map<String, Double> map = new HashMap<String, Double>();
+                            Map<String, Double> map = new HashMap<>();
                             map.put("slope", Double.parseDouble(row.get(1)));
                             map.put("intercept", Double.parseDouble(row.get(2)));
                             map.put("rSquared", Double.parseDouble(row.get(3)));
@@ -262,7 +262,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
                     }
                     else
                     {
-                        out.writeNext(row.toArray(new String[row.size()]));
+                        out.writeNext(row.toArray(new String[0]));
                     }
                 }
 
@@ -284,7 +284,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
         @Override
         protected List<Map<String, Object>> processRowsFromFile(List<Map<String, Object>> rows, ImportContext context) throws BatchValidationException
         {
-            List<Map<String, Object>> newRows = new ArrayList<Map<String, Object>>();
+            List<Map<String, Object>> newRows = new ArrayList<>();
             ParserErrors errors = context.getErrors();
 
             //add slope to run info
@@ -308,7 +308,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
                 {
                     rowIdx++;
                     Map<String, Object> row = rowsIter.next();
-                    Map<String, Object> map = new CaseInsensitiveHashMap<Object>(row);
+                    Map<String, Object> map = new CaseInsensitiveHashMap<>(row);
 
                     if (row.size() != 9)
                     {
@@ -444,7 +444,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
         {
             Map<String, Double> detectorInfo = _detectorMap.get(map.get(DETECTOR_FIELD));
             Double ct = map.get("cp") == null ? null : Double.parseDouble(map.get("cp").toString());
-            Double sampleVol = Double.parseDouble(String.valueOf(map.get("sampleVol")));
+            double sampleVol = Double.parseDouble(String.valueOf(map.get("sampleVol")));
             Double intercept = detectorInfo.get("intercept");
             Double slope = detectorInfo.get("slope");
             Double volPerRxn = Double.parseDouble(String.valueOf(map.get("volPerRxn")));
@@ -463,14 +463,14 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
 
         private void calculateViralLoads(List<Map<String, Object>> rows)
         {
-            Map<String, List<Map<String, Object>>> rowMap = new HashMap<String, List<Map<String, Object>>>();
+            Map<String, List<Map<String, Object>>> rowMap = new HashMap<>();
             Double lowestStd = 0.0;
             for (Map<String, Object> row : rows)
             {
                 String key = (String)row.get(NAME_FIELD);
                 List<Map<String, Object>> list = rowMap.get(key);
                 if (list == null)
-                    list = new ArrayList<Map<String, Object>>();
+                    list = new ArrayList<>();
 
                 if (TYPE.Standard.getTemplateText().equals(row.get(CATEGORY_FIELD)))
                 {
@@ -505,7 +505,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
 
                 avgCopies = avgCopies / list.size();
                 Double stdDev = new StandardDeviation().evaluate(values);
-                Double cv = stdDev / avgCopies;
+                double cv = stdDev / avgCopies;
 
                 //NOTE: at some point I should make this configurable
                 //flag any record with %CV > 66, but only if at least 1 replicate has copies/rxn above limitOfDetection
@@ -573,14 +573,14 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
             response.setHeader("Pragma", "private");
             response.setHeader("Cache-Control", "private");
 
-            Map<Integer, String[]> rowMap = new HashMap<Integer, String[]>();
+            Map<Integer, String[]> rowMap = new HashMap<>();
 
             int rowIdx = 0;
             for (JSONObject row : results)
             {
                 rowIdx++;
 
-                List<String> fields = new ArrayList<String>();
+                List<String> fields = new ArrayList<>();
 
                 //build the row
                 Integer wellNum = (Integer)wellMap.get(row.getString("well"));
@@ -594,13 +594,13 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
                 fields.add(type.getTemplateText());
                 fields.add(TYPE.getQuantity(type, row.getString(SUBJECT_FIELD)));
 
-                rowMap.put(wellNum, fields.toArray(new String[fields.size()]));
+                rowMap.put(wellNum, fields.toArray(new String[0]));
             }
 
             if (errors.hasErrors())
                 throw errors;
 
-            List<String[]> rows = new ArrayList<String[]>();
+            List<String[]> rows = new ArrayList<>();
             rows.add(new String[]{"*** SDS Setup File Version", "3"});
             rows.add(new String[]{"*** Output Plate Size", "96"});
             rows.add(new String[]{"*** Output Plate ID", json.getString("templateName") + ".sds"});
@@ -642,8 +642,8 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
 
     private Map<String, Map<String, String>> getDetectorsForResults(List<JSONObject> results)
     {
-        final Map<String, Map<String, String>> ret = new HashMap<String, Map<String, String>>();
-        Set<String> distinctAssays = new HashSet<String>();
+        final Map<String, Map<String, String>> ret = new HashMap<>();
+        Set<String> distinctAssays = new HashSet<>();
         for (JSONObject row : results)
         {
             distinctAssays.add(row.getString(ASSAYNAME_FIELD));
@@ -651,12 +651,12 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
 
         TableInfo table = Viral_Load_AssaySchema.getInstance().getSchema().getTable(Viral_Load_AssaySchema.TABLE_ABI7500_DETECTORS);
         TableSelector ts = new TableSelector(table, new SimpleFilter(FieldKey.fromString("assayName"), distinctAssays, CompareType.IN), null);
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException
             {
-                Map<String, String> row = new HashMap<String, String>();
+                Map<String, String> row = new HashMap<>();
                 row.put("detector", object.getString("detector"));
                 row.put("reporter", object.getString("reporter"));
                 row.put("quencher", object.getString("quencher"));
@@ -673,8 +673,8 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
         //ensure each subject/date has at least 2 neg controls
         JSONObject resultDefaults = json.optJSONObject("Results");
         JSONArray rawResults = json.getJSONArray("ResultRows");
-        List<JSONObject> results = new ArrayList<JSONObject>();
-        Set<String> distinctWells = new HashSet<String>();
+        List<JSONObject> results = new ArrayList<>();
+        Set<String> distinctWells = new HashSet<>();
         Map<Object, Object> wellMap = getWellMap96("well_96", "addressbyrow_96");
 
         String[] requiredFields = new String[]{"well", SUBJECT_FIELD, CATEGORY_FIELD, ASSAYNAME_FIELD};
@@ -710,7 +710,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
             if (missingRequired)
                 continue;
 
-            TYPE type = null;
+            TYPE type;
             try
             {
                 type = TYPE.getByDatabaseCategoryValue(row.getString(CATEGORY_FIELD));
@@ -782,7 +782,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
         }
 
         Map<String, Map<String, String>> detectorRows = getDetectorsForResults(results);
-        if (detectorRows.size() == 0)
+        if (detectorRows.isEmpty())
         {
             errors.addRowError(new ValidationException("No detectors were found for these samples."));
             throw errors;

--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/AbstractWNPRCImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/AbstractWNPRCImportMethod.java
@@ -401,10 +401,10 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
             map.put("sampleVol", 1.0);
 
         //This is the size (ml or mg) of the source material (plasma/serum/urine/etc.)
-        Double sampleVol = Double.parseDouble(map.get("sampleVol").toString());
+        double sampleVol = Double.parseDouble(map.get("sampleVol").toString());
 
-        Double viralLoad = 0.0;
-        Double dilutionFactor = 0.0;
+        double viralLoad = 0.0;
+        double dilutionFactor = 0.0;
         if (copiesPerRxn != null && sampleVol > 0)
         {
             dilutionFactor = (1.0 / sampleVol) * (eluateVol / volPerRxn);
@@ -417,8 +417,8 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
     }
 
     protected class Parser extends DefaultAssayParser {
-        private String HAS_RESULT = "__hasResult__";
-        private int _assayId;
+        private final String HAS_RESULT = "__hasResult__";
+        private final int _assayId;
         final String[] lookup = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ,.".split("");
         //The expected number of columns in the import data
         private int _expectedColumnCount = Integer.MAX_VALUE;
@@ -444,6 +444,7 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
         }
 
         //Needs to be overridden within the Parser class of each ImportMethod that extends AbstractWNPRCImportMethod
+        @Override
         protected TabLoader getTabLoader(String contents) throws IOException {
             return null;
         }
@@ -531,6 +532,7 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
             return newRows;
         }
 
+        @Override
         protected void ensureTemplateRowsHaveResults(Map<String, Map<String, Object>> templateRows, ImportContext context) throws BatchValidationException {
             for (String key : templateRows.keySet()) {
                 Map<String, Object> row = templateRows.get(key);
@@ -563,7 +565,7 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
                 else if (hexString.length() == 2) {
                     hexString = "0" + hexString;
                 }
-                else if (hexString.length() == 0) {
+                else if (hexString.isEmpty()) {
                     hexString = "000" + hexString;
                 }
 
@@ -577,19 +579,17 @@ public class AbstractWNPRCImportMethod extends DefaultVLImportMethod
             }
             char[] objectId = base16Duples.toString().toCharArray();
 
-            StringBuilder returnObjectId = new StringBuilder();
+            String returnObjectId = String.valueOf(objectId, 0, 8) +
+                    "-" +
+                    String.valueOf(objectId, 8, 4) +
+                    "-" +
+                    String.valueOf(objectId, 12, 4) +
+                    "-" +
+                    String.valueOf(objectId, 16, 4) +
+                    "-" +
+                    String.valueOf(objectId, 20, 12);
 
-            returnObjectId.append(objectId, 0, 8);
-            returnObjectId.append("-");
-            returnObjectId.append(objectId, 8, 4);
-            returnObjectId.append("-");
-            returnObjectId.append(objectId, 12, 4);
-            returnObjectId.append("-");
-            returnObjectId.append(objectId, 16, 4);
-            returnObjectId.append("-");
-            returnObjectId.append(objectId, 20, 12);
-
-            return returnObjectId.toString();
+            return returnObjectId;
         }
     }
 

--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/DefaultVLImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/DefaultVLImportMethod.java
@@ -157,7 +157,7 @@ class DefaultVLImportMethod extends DefaultAssayImportMethod
         if (!map.containsKey("sampleVol"))
             map.put("sampleVol", 1.0);
 
-        Double sampleVol = Double.parseDouble(map.get("sampleVol").toString());
+        double sampleVol = Double.parseDouble(map.get("sampleVol").toString());
 
         double viralLoad;
         if (copiesPerRxn != null)

--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ViralLoadAssayDataProvider.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ViralLoadAssayDataProvider.java
@@ -110,7 +110,7 @@ public class ViralLoadAssayDataProvider extends AbstractAssayDataProvider
     @Override
     public List<NavItem> getSettingsItems(Container c, User u)
     {
-        List<NavItem> items = new ArrayList<NavItem>();
+        List<NavItem> items = new ArrayList<>();
         String categoryName = "Viral Load Assay";
         if (ContainerManager.getSharedContainer().equals(c))
         {

--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -1020,7 +1020,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
                 }
                 expectedVals = expected.get(sb.toString());
             }
-            assertNotNull("Unable to find expected values: " + sb.toString(), expectedVals);
+            assertNotNull("Unable to find expected values: " + sb, expectedVals);
 
             assertEquals("Incorrect subjectId on row: " + i, expectedVals[0], subjectId);
             assertEquals("Incorrect category on row: " + i, expectedVals[1], category);

--- a/ehr/api-src/org/labkey/api/ehr/EHROwnable.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHROwnable.java
@@ -26,7 +26,7 @@ import org.labkey.api.security.User;
  */
 public abstract class EHROwnable
 {
-    protected Module _owner = null;
+    protected Module _owner;
 
     public EHROwnable(Module owner)
     {

--- a/ehr/api-src/org/labkey/api/ehr/EHRService.java
+++ b/ehr/api-src/org/labkey/api/ehr/EHRService.java
@@ -239,7 +239,7 @@ abstract public class EHRService
         Scheduled("Scheduled"),
         Completed("Completed");
 
-        private String _label;
+        private final String _label;
 
         QCSTATES(String label)
         {

--- a/ehr/api-src/org/labkey/api/ehr/buttons/MarkCompletedButton.java
+++ b/ehr/api-src/org/labkey/api/ehr/buttons/MarkCompletedButton.java
@@ -34,7 +34,7 @@ public class MarkCompletedButton extends SimpleButtonConfigFactory
     protected String _schemaName;
     protected String _queryName;
     protected Boolean _forceDateOnlyField;
-    private Class<? extends Permission> _perm;
+    private final Class<? extends Permission> _perm;
 
     public MarkCompletedButton(Module owner, String schemaName, String queryName)
     {

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/AbstractFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/AbstractFormSection.java
@@ -66,7 +66,7 @@ abstract public class AbstractFormSection implements FormSection
 
     private List<String> _configSources = new ArrayList<>();
 
-    private List<Supplier<ClientDependency>> _clientDependencies = new ArrayList<>();
+    private final List<Supplier<ClientDependency>> _clientDependencies = new ArrayList<>();
 
     protected static final Logger _log = LogManager.getLogger(AbstractFormSection.class);
 
@@ -195,8 +195,8 @@ abstract public class AbstractFormSection implements FormSection
         ENCOUNTER("TEMPLATE_ENCOUNTER", "APPLYFORMTEMPLATE_ENCOUNTER"),
         NONE(null, null);
 
-        private String _formBtn;
-        private String _sectionBtn;
+        private final String _formBtn;
+        private final String _sectionBtn;
 
         TEMPLATE_MODE(String sectionBtn, String formBtn)
         {

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/BloodDrawFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/BloodDrawFormSection.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class BloodDrawFormSection extends SimpleGridPanel
 {
-    boolean _isRequest = false;
+    boolean _isRequest;
 
     public BloodDrawFormSection(boolean isRequest)
     {

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/BulkEditFormType.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/BulkEditFormType.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public class BulkEditFormType extends AbstractDataEntryForm
 {
-    private String _keyField;
+    private final String _keyField;
 
     protected BulkEditFormType(DataEntryFormContext ctx, Module owner, String name, String label, String category, String keyField, List<FormSection> sections)
     {

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/DefaultDataEntryFormFactory.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/DefaultDataEntryFormFactory.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class DefaultDataEntryFormFactory implements DataEntryFormFactory
 {
-    private Logger _log = LogManager.getLogger(DefaultDataEntryFormFactory.class);
+    private final Logger _log = LogManager.getLogger(DefaultDataEntryFormFactory.class);
     Class<? extends DataEntryForm> _clazz;
     Module _module;
 
@@ -62,11 +62,11 @@ public class DefaultDataEntryFormFactory implements DataEntryFormFactory
     /** Implementation for creating instances of {@link TaskForm} variations */
     public static class TaskFactory implements DataEntryFormFactory
     {
-        private Module _owner;
-        private String _category;
-        private String _name;
-        private String _label;
-        private List<FormSection> _sections;
+        private final Module _owner;
+        private final String _category;
+        private final String _name;
+        private final String _label;
+        private final List<FormSection> _sections;
 
         public TaskFactory(Module owner, String category, String name, String label, List<FormSection> sections)
         {

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/EncounterForm.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/EncounterForm.java
@@ -45,7 +45,7 @@ public class EncounterForm extends TaskForm
 
     public static EncounterForm create(DataEntryFormContext ctx, Module owner, String category, String name, String label, List<FormSection> formSections)
     {
-        List<FormSection> sections = new ArrayList<FormSection>();
+        List<FormSection> sections = new ArrayList<>();
         sections.add(new TaskFormSection());
         sections.add(new EncounterFormSection());
         sections.add(new AnimalDetailsFormSection());

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/RequestFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/RequestFormSection.java
@@ -42,8 +42,8 @@ public class RequestFormSection extends SimpleFormSection
     {
         JSONObject ret = super.toJSON(ctx, includeFormElements);
 
-        Map<String, Object> formConfig = new HashMap<String, Object>();
-        Map<String, Object> bindConfig = new HashMap<String, Object>();
+        Map<String, Object> formConfig = new HashMap<>();
+        Map<String, Object> bindConfig = new HashMap<>();
         bindConfig.put("createRecordOnLoad", true);
         formConfig.put("bindConfig", bindConfig);
         ret.put("formConfig", formConfig);

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/SingleQueryFormProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/SingleQueryFormProvider.java
@@ -26,10 +26,10 @@ import org.labkey.api.module.Module;
  */
 public class SingleQueryFormProvider
 {
-    private Module _owner;
-    private String _schemaName;
-    private String _queryName;
-    private SingleQueryFormSection _section;
+    private final Module _owner;
+    private final String _schemaName;
+    private final String _queryName;
+    private final SingleQueryFormSection _section;
 
     public SingleQueryFormProvider(Module owner, String schemaName, String queryName, SingleQueryFormSection section)
     {

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/forms/ArrivalFormType.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/forms/ArrivalFormType.java
@@ -15,14 +15,11 @@
  */
 package org.labkey.api.ehr.dataentry.forms;
 
-import org.labkey.api.ehr.dataentry.AnimalDetailsFormSection;
 import org.labkey.api.ehr.dataentry.DataEntryFormContext;
 import org.labkey.api.ehr.dataentry.FormSection;
 import org.labkey.api.ehr.dataentry.TaskForm;
-import org.labkey.api.ehr.dataentry.TaskFormSection;
 import org.labkey.api.module.Module;
 
-import java.util.Arrays;
 import java.util.List;
 
 public class ArrivalFormType extends TaskForm

--- a/ehr/api-src/org/labkey/api/ehr/dataentry/forms/NewAnimalFormSection.java
+++ b/ehr/api-src/org/labkey/api/ehr/dataentry/forms/NewAnimalFormSection.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class NewAnimalFormSection extends SimpleFormSection
 {
-    private boolean _allowSetSpecies;
+    private final boolean _allowSetSpecies;
 
     public NewAnimalFormSection(String schemaName, String queryName, String label, boolean allowSetSpecies)
     {

--- a/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/AbstractDemographicsProvider.java
@@ -110,7 +110,7 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
 
         if (debugEnabled)
             startRowProcessing = LocalDateTime.now();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException
@@ -118,7 +118,7 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
                 Results rs = new ResultsImpl(object, cols);
                 String id = ti.getColumn("Id").getStringValue(rs);
 
-                Map<String, Object> map = ret.computeIfAbsent(id, (x)->new TreeMap<>());
+                Map<String, Object> map = ret.computeIfAbsent(id, (x) -> new TreeMap<>());
                 processRow(rs, cols, map);
             }
         });
@@ -209,7 +209,7 @@ abstract public class AbstractDemographicsProvider extends EHROwnable implements
 
     protected Map<FieldKey, ColumnInfo> getColumns(TableInfo ti)
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("Id"));
         keys.addAll(getFieldKeys());
 

--- a/ehr/api-src/org/labkey/api/ehr/demographics/ActiveAssignmentsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/ActiveAssignmentsDemographicsProvider.java
@@ -39,7 +39,7 @@ public class ActiveAssignmentsDemographicsProvider extends AbstractListDemograph
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/ehr/api-src/org/labkey/api/ehr/demographics/ActiveCasesDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/ActiveCasesDemographicsProvider.java
@@ -39,7 +39,7 @@ public class ActiveCasesDemographicsProvider extends AbstractListDemographicsPro
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("objectid"));
         keys.add(FieldKey.fromString("Id"));

--- a/ehr/api-src/org/labkey/api/ehr/demographics/ActiveFlagsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/ActiveFlagsDemographicsProvider.java
@@ -39,7 +39,7 @@ public class ActiveFlagsDemographicsProvider extends AbstractListDemographicsPro
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/ehr/api-src/org/labkey/api/ehr/demographics/ActiveProblemsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/ActiveProblemsDemographicsProvider.java
@@ -40,7 +40,7 @@ public class ActiveProblemsDemographicsProvider extends AbstractListDemographics
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/ehr/api-src/org/labkey/api/ehr/demographics/ActiveTreatmentsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/ActiveTreatmentsDemographicsProvider.java
@@ -42,7 +42,7 @@ public class ActiveTreatmentsDemographicsProvider extends AbstractListDemographi
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("code"));

--- a/ehr/api-src/org/labkey/api/ehr/demographics/BirthDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/BirthDemographicsProvider.java
@@ -39,7 +39,7 @@ public class BirthDemographicsProvider extends AbstractListDemographicsProvider
     @Override
     protected Set<FieldKey> getFieldKeys()
     {
-        Set<FieldKey> keys = new HashSet<FieldKey>();
+        Set<FieldKey> keys = new HashSet<>();
         keys.add(FieldKey.fromString("lsid"));
         keys.add(FieldKey.fromString("Id"));
         keys.add(FieldKey.fromString("date"));

--- a/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/demographics/WeightsDemographicsProvider.java
@@ -79,7 +79,7 @@ public class WeightsDemographicsProvider extends AbstractListDemographicsProvide
             ts.setForDisplay(true);
             ts.setMaxRows(3);
 
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet object) throws SQLException
@@ -87,7 +87,7 @@ public class WeightsDemographicsProvider extends AbstractListDemographicsProvide
                     Results rs = new ResultsImpl(object, cols);
                     String id = ti.getColumn("Id").getStringValue(rs);
 
-                    Map<String, Object> map = ret.computeIfAbsent(id, (x)->new HashMap<>());
+                    Map<String, Object> map = ret.computeIfAbsent(id, (x) -> new HashMap<>());
                     processRow(rs, cols, map);
                 }
             });

--- a/ehr/api-src/org/labkey/api/ehr/history/AbstractDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/AbstractDataSource.java
@@ -59,11 +59,11 @@ import java.util.Set;
  */
 abstract public class AbstractDataSource extends EHROwnable implements HistoryDataSource
 {
-    private String _schema;
-    private String _query;
+    private final String _schema;
+    private final String _query;
     private String _categoryText;
     private String _primaryGroup;
-    private String _name;
+    private final String _name;
     private boolean _showTime = false;
     protected String _subjectIdField = "Id";
     protected static final Logger _log = LogManager.getLogger(HistoryDataSource.class);

--- a/ehr/api-src/org/labkey/api/ehr/history/AntibioticSensitivityLabworkType.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/AntibioticSensitivityLabworkType.java
@@ -85,7 +85,7 @@ public class AntibioticSensitivityLabworkType extends DefaultLabworkType
     protected Map<String, List<String>> getRows(TableSelector ts, final Collection<ColumnInfo> cols, final boolean redacted)
     {
         final Map<String, Map<String, List<String>>> rows = new CaseInsensitiveHashMap<>();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultAlopeciaDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultAlopeciaDataSource.java
@@ -36,11 +36,10 @@ public class DefaultAlopeciaDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Alopecia Score", "score"));
-        sb.append(safeAppend(rs, "Cause", "cause"));
+        String sb = safeAppend(rs, "Alopecia Score", "score") +
+                safeAppend(rs, "Cause", "cause");
 
-        return sb.toString();
+        return sb;
     }
 }

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultAnimalRecordFlagDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultAnimalRecordFlagDataSource.java
@@ -38,11 +38,10 @@ public class DefaultAnimalRecordFlagDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Remark", "remark"));
-        sb.append(safeAppend(rs, "Entered by", "performedby"));
-        return sb.toString();
+        String sb = safeAppend(rs, "Remark", "remark") +
+                safeAppend(rs, "Entered by", "performedby");
+        return sb;
     }
 
     @Override

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultArrivalDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultArrivalDataSource.java
@@ -38,12 +38,11 @@ public class DefaultArrivalDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
-        sb.append(safeAppend(rs, "Source", "source/value"));
-        sb.append(safeAppend(rs, "Rearing Type", "rearingType/value"));
-        sb.append(safeAppend(rs, "Acquisition Type", "acquisitionType/value"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
-        return sb.toString();
+        String sb = safeAppend(rs, "Source", "source/value") +
+                safeAppend(rs, "Rearing Type", "rearingType/value") +
+                safeAppend(rs, "Acquisition Type", "acquisitionType/value") +
+                safeAppend(rs, "Remark", "remark");
+        return sb;
     }
 
     @Override

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultCasesCloseDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultCasesCloseDataSource.java
@@ -53,13 +53,12 @@ public class DefaultCasesCloseDataSource extends AbstractDataSource
         {
             return null;
         }
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Category", "category"));
-        sb.append(safeAppend(rs, "Case #", "caseno"));
-        sb.append("Opened On: ").append(DateUtil.formatDate(c, start));
+        String sb = safeAppend(rs, "Category", "category") +
+                safeAppend(rs, "Case #", "caseno") +
+                "Opened On: " + DateUtil.formatDate(c, start);
 
-        return sb.toString();
+        return sb;
     }
 
     @Override

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultDrugsDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultDrugsDataSource.java
@@ -116,9 +116,8 @@ public class DefaultDrugsDataSource extends AbstractDataSource
         Map<String, List<HistoryRowImpl>> groupedRowMap = new HashMap<>();
         for (HistoryRow r : rows)
         {
-            if (r instanceof HistoryRowImpl)
+            if (r instanceof HistoryRowImpl row)
             {
-                HistoryRowImpl row = (HistoryRowImpl)r;
                 String key = row.getSubjectId() + "<>" + row.getSortDateString() + "<>" + row.getTimeString();
 
                 List<HistoryRowImpl> existing = groupedRowMap.get(key);

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultLabworkType.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultLabworkType.java
@@ -63,9 +63,9 @@ public class DefaultLabworkType implements LabworkType
     protected String _performedByField = "performedby";
     protected String _remarkField = "remark";
 
-    private String _name;
-    private String _schemaName;
-    private String _queryName;
+    private final String _name;
+    private final String _schemaName;
+    private final String _queryName;
 
     protected String _testIdField = "testid";
     protected String _resultField = "result";
@@ -190,7 +190,7 @@ public class DefaultLabworkType implements LabworkType
     protected Map<String, List<String>> getRows(TableSelector ts, final Collection<ColumnInfo> cols, final boolean redacted)
     {
         final Map<String, List<String>> rows = new CaseInsensitiveHashMap<>();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException
@@ -349,10 +349,9 @@ public class DefaultLabworkType implements LabworkType
 
     protected String getResultTable(List<String> results)
     {
-        StringBuilder sb = new StringBuilder();
-        sb.append("<table>");
-        sb.append("<tr><td>").append(StringUtils.join(results, "</td></tr><tr><td>")).append("</td></tr>");
-        sb.append("</table>");
-        return sb.toString();
+        String sb = "<table>" +
+                "<tr><td>" + StringUtils.join(results, "</td></tr><tr><td>") + "</td></tr>" +
+                "</table>";
+        return sb;
     }
 }

--- a/ehr/api-src/org/labkey/api/ehr/history/DefaultProblemListCloseDataSource.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/DefaultProblemListCloseDataSource.java
@@ -54,12 +54,10 @@ public class DefaultProblemListCloseDataSource extends AbstractDataSource
             return null;
         }
 
-        StringBuilder sb = new StringBuilder();
+        String sb = safeAppend(rs, "Category", "category") +
+                "Opened On: " + DateUtil.formatDate(c, start);
 
-        sb.append(safeAppend(rs, "Category", "category"));
-        sb.append("Opened On: ").append(DateUtil.formatDate(c, start));
-
-        return sb.toString();
+        return sb;
     }
 
     @Override

--- a/ehr/api-src/org/labkey/api/ehr/history/HistoryRowImpl.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/HistoryRowImpl.java
@@ -29,14 +29,14 @@ import java.util.Date;
  */
 public class HistoryRowImpl implements HistoryRow
 {
-    private HistoryDataSource _source;
-    private String _subjectId;
-    private Date _date;
+    private final HistoryDataSource _source;
+    private final String _subjectId;
+    private final Date _date;
     private Date _enddate;
     private Integer _projectId;
-    private String _primaryGroup;
-    private String _categoryText;
-    private String _categoryColor;
+    private final String _primaryGroup;
+    private final String _categoryText;
+    private final String _categoryColor;
     private String _performedBy;
     private String _caseId;
     private String _runId;
@@ -44,11 +44,11 @@ public class HistoryRowImpl implements HistoryRow
     private String _qcStateLabel;
     private Boolean _isPublicData;
     private Boolean _showTime = false;
-    private String _taskId = null;
-    private Integer _taskRowId;
-    private String _formType;
-    private String _objectId;
-    private String _html;
+    private String _taskId;
+    private final Integer _taskRowId;
+    private final String _formType;
+    private final String _objectId;
+    private final String _html;
 
     protected static final Logger _log = LogManager.getLogger(HistoryRowImpl.class);
 

--- a/ehr/api-src/org/labkey/api/ehr/history/SerologyLabworkType.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/SerologyLabworkType.java
@@ -31,9 +31,9 @@ import java.util.Set;
  */
 public class SerologyLabworkType extends DefaultLabworkType
 {
-    private String _sampleTypeField = "tissue/meaning";
-    private String _methodField = "method";
-    private String _numericResultsField = "numericresult";
+    private final String _sampleTypeField = "tissue/meaning";
+    private final String _methodField = "method";
+    private final String _numericResultsField = "numericresult";
 
     public SerologyLabworkType(Module module)
     {

--- a/ehr/api-src/org/labkey/api/ehr/history/SortingLabworkType.java
+++ b/ehr/api-src/org/labkey/api/ehr/history/SortingLabworkType.java
@@ -44,9 +44,9 @@ import java.util.TreeMap;
  */
 public class SortingLabworkType extends DefaultLabworkType
 {
-    private String _testType;
-    private String _testCol = "testid";
-    private String _sortCol = "sort_order";
+    private final String _testType;
+    private final String _testCol = "testid";
+    private final String _sortCol = "sort_order";
 
     private Map<String, Integer> _tests = null;
 
@@ -66,7 +66,7 @@ public class SortingLabworkType extends DefaultLabworkType
 
             _tests = new CaseInsensitiveHashMap<>();
             TableSelector ts = new TableSelector(ti, PageFlowUtil.set(_sortCol, _testCol), new SimpleFilter(FieldKey.fromString("type"), _testType), null);
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -84,7 +84,7 @@ public class SortingLabworkType extends DefaultLabworkType
     protected Map<String, List<String>> getRows(TableSelector ts, final Collection<ColumnInfo> cols, final boolean redacted)
     {
         final Map<String, Map<Integer, List<String>>> rows = new CaseInsensitiveHashMap<>();
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException

--- a/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalator.java
+++ b/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalator.java
@@ -79,7 +79,6 @@ public class EHRSecurityEscalator extends SecurityEscalator
      *                  specified here.
      * @param comment A useful comment explaining why the user needed to be escalated, or rather, what the code is doing
      *                during the escalation.  For example: "Updating
-     * @return
      */
     public static SecurityEscalator beginEscalation(User user, Container container, String comment) {
         SecurityEscalator securityEscalator = new EHRSecurityEscalator(user, container, comment);

--- a/ehr/api-src/org/labkey/api/ehr/table/AssignedAtTimeForeignKey.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/AssignedAtTimeForeignKey.java
@@ -34,9 +34,9 @@ public class AssignedAtTimeForeignKey extends LookupForeignKey
 {
     private static final Logger _log = LogManager.getLogger(AssignedAtTimeForeignKey.class);
 
-    private AbstractTableInfo _tableInfo;
-    private ColumnInfo _pkCol;
-    private UserSchema _ehrSchema;
+    private final AbstractTableInfo _tableInfo;
+    private final ColumnInfo _pkCol;
+    private final UserSchema _ehrSchema;
 
     public AssignedAtTimeForeignKey(AbstractTableInfo tableInfo, ColumnInfo pkCol, UserSchema ehrSchema)
     {
@@ -66,7 +66,7 @@ public class AssignedAtTimeForeignKey extends LookupForeignKey
 
         List<QueryException> errors = new ArrayList<>();
         TableInfo ti = qd.getTable(errors, true);
-        if (errors.size() > 0)
+        if (!errors.isEmpty())
         {
             _log.error("Error creating lookup table for: " + schemaName + "." + queryName + " in container: " + targetSchema.getContainer().getPath());
             for (QueryException error : errors)

--- a/ehr/api-src/org/labkey/api/ehr/table/AssignmentAtTimeForeignKey.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/AssignmentAtTimeForeignKey.java
@@ -34,11 +34,11 @@ public class AssignmentAtTimeForeignKey extends LookupForeignKey
 {
     private static final Logger _log = LogManager.getLogger(AssignmentAtTimeForeignKey.class);
 
-    private AbstractTableInfo _tableInfo;
-    private ColumnInfo _pkCol;
-    private UserSchema _ehrSchema;
-    private String _dateColName;
-    private String _investLastNameCol;
+    private final AbstractTableInfo _tableInfo;
+    private final ColumnInfo _pkCol;
+    private final UserSchema _ehrSchema;
+    private final String _dateColName;
+    private final String _investLastNameCol;
 
     public AssignmentAtTimeForeignKey(AbstractTableInfo tableInfo, ColumnInfo pkCol, UserSchema ehrSchema, String dateColName, String investLastNameCol)
     {
@@ -73,7 +73,7 @@ public class AssignmentAtTimeForeignKey extends LookupForeignKey
 
         List<QueryException> errors = new ArrayList<>();
         TableInfo ti = qd.getTable(errors, true);
-        if (errors.size() > 0)
+        if (!errors.isEmpty())
         {
             _log.error("Error creating lookup table for: " + schemaName + "." + queryName + " in container: " + targetSchema.getContainer().getPath());
             for (QueryException error : errors)

--- a/ehr/src/org/labkey/ehr/EHRActionResolver.java
+++ b/ehr/src/org/labkey/ehr/EHRActionResolver.java
@@ -42,7 +42,7 @@ public class EHRActionResolver extends SpringActionController.DefaultActionResol
         return new EHRHTMLFileActionResolver();
     }
 
-    private class EHRHTMLFileActionResolver extends SpringActionController.HTMLFileActionResolver
+    private static class EHRHTMLFileActionResolver extends SpringActionController.HTMLFileActionResolver
     {
         public EHRHTMLFileActionResolver()
         {

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -154,7 +154,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetDataEntryItemsAction extends ReadOnlyApiAction<GetDataEntryItemsForm>
+    public static class GetDataEntryItemsAction extends ReadOnlyApiAction<GetDataEntryItemsForm>
     {
         @Override
         public ApiResponse execute(GetDataEntryItemsForm form, BindException errors)
@@ -191,7 +191,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class CacheLivingAnimalsAction extends ConfirmAction<CacheLivingAnimalsForm>
+    public static class CacheLivingAnimalsAction extends ConfirmAction<CacheLivingAnimalsForm>
     {
         @Override
         public void validateCommand(CacheLivingAnimalsForm form, Errors errors)
@@ -220,7 +220,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class PrimeDataEntryCacheAction extends ConfirmAction<Object>
+    public static class PrimeDataEntryCacheAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -275,7 +275,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(DeletePermission.class)
-    public class DiscardFormAction extends MutatingApiAction<DiscardFormForm>
+    public static class DiscardFormAction extends MutatingApiAction<DiscardFormForm>
     {
         @Override
         public ApiResponse execute(DiscardFormForm form, BindException errors)
@@ -358,7 +358,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class UpdateQueryAction extends SimpleViewAction<EHRQueryForm>
+    public static class UpdateQueryAction extends SimpleViewAction<EHRQueryForm>
     {
         private EHRQueryForm _form;
 
@@ -590,7 +590,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetDemographicsAction extends ReadOnlyApiAction<GetDemographicsForm>
+    public static class GetDemographicsAction extends ReadOnlyApiAction<GetDemographicsForm>
     {
         @Override
         public ApiResponse execute(GetDemographicsForm form, BindException errors)
@@ -624,7 +624,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SetGeneticCalculationTaskSettingsAction extends MutatingApiAction<ScheduleGeneticCalculationForm>
+    public static class SetGeneticCalculationTaskSettingsAction extends MutatingApiAction<ScheduleGeneticCalculationForm>
     {
         @Override
         public ApiResponse execute(ScheduleGeneticCalculationForm form, BindException errors)
@@ -673,7 +673,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SetRecordDeleteSettingsAction extends MutatingApiAction<RecordDeleteForm>
+    public static class SetRecordDeleteSettingsAction extends MutatingApiAction<RecordDeleteForm>
     {
         @Override
         public ApiResponse execute(RecordDeleteForm form, BindException errors)
@@ -733,13 +733,13 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetAnimalDetailsAction extends ReadOnlyApiAction<AnimalDetailsForm>
+    public static class GetAnimalDetailsAction extends ReadOnlyApiAction<AnimalDetailsForm>
     {
         @Override
         public ApiResponse execute(AnimalDetailsForm form, BindException errors)
         {
-            Map<String, Object> props = new HashMap<String, Object>();
-            Set<String> sources = new HashSet<String>();
+            Map<String, Object> props = new HashMap<>();
+            Set<String> sources = new HashSet<>();
             if (form.isIncludeAssignment())
                 sources.add("assignment");
             if (form.isIncludeFlags())
@@ -814,7 +814,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class GetGeneticCalculationTaskSettingsAction extends ReadOnlyApiAction<ScheduleGeneticCalculationForm>
+    public static class GetGeneticCalculationTaskSettingsAction extends ReadOnlyApiAction<ScheduleGeneticCalculationForm>
     {
         @Override
         public ApiResponse execute(ScheduleGeneticCalculationForm form, BindException errors)
@@ -836,7 +836,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class GetRecordDeleteSettingsAction extends ReadOnlyApiAction<Object>
+    public static class GetRecordDeleteSettingsAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors)
@@ -865,7 +865,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetLabResultSummary extends ReadOnlyApiAction<LabResultSummaryForm>
+    public static class GetLabResultSummary extends ReadOnlyApiAction<LabResultSummaryForm>
     {
         @Override
         public ApiResponse execute(LabResultSummaryForm form, BindException errors)
@@ -981,7 +981,7 @@ public class EHRController extends SpringActionController
 
     @RequiresPermission(ReadPermission.class)
     //TODO: should enable @CSRF if we have SSRS updated to pass token.
-    public class GetClinicalHistoryAction extends ReadOnlyApiAction<HistoryForm>
+    public static class GetClinicalHistoryAction extends ReadOnlyApiAction<HistoryForm>
     {
         @Override
         public ApiResponse execute(HistoryForm form, BindException errors)
@@ -1025,7 +1025,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetCaseHistoryAction extends ReadOnlyApiAction<HistoryForm>
+    public static class GetCaseHistoryAction extends ReadOnlyApiAction<HistoryForm>
     {
         @Override
         public ApiResponse execute(HistoryForm form, BindException errors)
@@ -1089,7 +1089,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class EnsureDatasetPropertiesAction extends ConfirmAction<EnsureDatasetPropertiesForm>
+    public static class EnsureDatasetPropertiesAction extends ConfirmAction<EnsureDatasetPropertiesForm>
     {
         @Override
         public void validateCommand(EnsureDatasetPropertiesForm form, Errors errors)
@@ -1115,7 +1115,7 @@ public class EHRController extends SpringActionController
                 msg.append("\t").append(message).append("<br>");
             }
 
-            if (messages.size() > 0)
+            if (!messages.isEmpty())
                 msg.append("<br>Do you want to make these changes?");
             else
                 msg.append("There are no changes to be made");
@@ -1132,7 +1132,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class EnsureEHRSchemaIndexesAction extends ConfirmAction<Object>
+    public static class EnsureEHRSchemaIndexesAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -1166,7 +1166,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class EnsureQcStatesAction extends ConfirmAction<Object>
+    public static class EnsureQcStatesAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -1192,7 +1192,7 @@ public class EHRController extends SpringActionController
                 msg.append("\t").append(message).append("<br>");
             }
 
-            if (messages.size() > 0)
+            if (!messages.isEmpty())
                 msg.append("<br>Do you want to make these changes?");
             else
                 msg.append("There are no changes to be made");
@@ -1209,7 +1209,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class VerifyDatasetResourcesAction extends SimpleViewAction<Object>
+    public static class VerifyDatasetResourcesAction extends SimpleViewAction<Object>
     {
         public void validateCommand(Object form, Errors errors)
         {
@@ -1233,7 +1233,7 @@ public class EHRController extends SpringActionController
                 msg.append("\t").append(message).append("<br>");
             }
 
-            if (messages.size() == 0)
+            if (messages.isEmpty())
                 msg.append("There are no missing files");
 
             return new HtmlView(msg.toString());
@@ -1247,7 +1247,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class DoGeneticCalculationsAction extends ConfirmAction<Object>
+    public static class DoGeneticCalculationsAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -1340,7 +1340,7 @@ public class EHRController extends SpringActionController
         }
     }
 
-    private abstract class BaseLookupsAction extends MutatingApiAction<PopulateLookupsForm>
+    private abstract static class BaseLookupsAction extends MutatingApiAction<PopulateLookupsForm>
     {
         protected final String _manifestDirectory = "data/";
         protected final String _manifestDefault = "lookupsManifest";
@@ -1568,7 +1568,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class PopulateReportsAction extends MutatingApiAction<PopulateLookupsForm>
+    public static class PopulateReportsAction extends MutatingApiAction<PopulateLookupsForm>
     {
         private final String _reportsPath = "reports/reports.tsv";
         private final String _additionalReportsPath = "reports/additionalReports.tsv";
@@ -1718,7 +1718,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetReportLinksAction extends ReadOnlyApiAction<ReportLinkForm>
+    public static class GetReportLinksAction extends ReadOnlyApiAction<ReportLinkForm>
     {
         @Override
         public ApiResponse execute(ReportLinkForm form, BindException errors)
@@ -1820,12 +1820,12 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetDataEntryFormDetailsAction extends ReadOnlyApiAction<EnterDataForm>
+    public static class GetDataEntryFormDetailsAction extends ReadOnlyApiAction<EnterDataForm>
     {
         @Override
         public ApiResponse execute(EnterDataForm form, BindException errors)
         {
-            Map<String, Object> props = new HashMap<String, Object>();
+            Map<String, Object> props = new HashMap<>();
 
             if (form.getFormType() == null && form.getTaskId() == null && form.getRequestId() == null)
             {
@@ -1874,7 +1874,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class DataEntryFormAction extends SimpleViewAction<EnterDataForm>
+    public static class DataEntryFormAction extends SimpleViewAction<EnterDataForm>
     {
         private String _title = null;
         private DataEntryForm _def;
@@ -1911,7 +1911,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class DataEntryFormForQueryAction extends SimpleViewAction<EnterDataForm>
+    public static class DataEntryFormForQueryAction extends SimpleViewAction<EnterDataForm>
     {
         private String _title = null;
 
@@ -1951,7 +1951,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class DataEntryFormJsonForQueryAction extends ReadOnlyApiAction<EnterDataForm>
+    public static class DataEntryFormJsonForQueryAction extends ReadOnlyApiAction<EnterDataForm>
     {
         @Override
         public ApiResponse execute(EnterDataForm form, BindException errors)
@@ -2073,7 +2073,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class ManageFlagsAction extends MutatingApiAction<ManageFlagsForm>
+    public static class ManageFlagsAction extends MutatingApiAction<ManageFlagsForm>
     {
         @Override
         public ApiResponse execute(ManageFlagsForm form, BindException errors)
@@ -2185,7 +2185,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class BloodPlotDataAction extends ReadOnlyApiAction<IdForm>
+    public static class BloodPlotDataAction extends ReadOnlyApiAction<IdForm>
     {
 
         @Override
@@ -2235,7 +2235,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class ValidateDatasetColsAction extends ConfirmAction<Object>
+    public static class ValidateDatasetColsAction extends ConfirmAction<Object>
     {
         @Override
         public void validateCommand(Object form, Errors errors)
@@ -2297,7 +2297,7 @@ public class EHRController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class GetAnimalLockAction extends ReadOnlyApiAction<Object>
+    public static class GetAnimalLockAction extends ReadOnlyApiAction<Object>
     {
         @Override
         public ApiResponse execute(Object form, BindException errors)
@@ -2307,7 +2307,7 @@ public class EHRController extends SpringActionController
     }
 
     @RequiresPermission(EHRDataEntryPermission.class)
-    public class SetAnimalLockAction extends MutatingApiAction<LockAnimalForm>
+    public static class SetAnimalLockAction extends MutatingApiAction<LockAnimalForm>
     {
         @Override
         public ApiResponse execute(LockAnimalForm form, BindException errors)

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -364,7 +364,7 @@ public class EHRManager
                     }
                 }
 
-                if (commitChanges && toUpdate.size() > 0)
+                if (commitChanges && !toUpdate.isEmpty())
                 {
                     Table.update(u, studyTable, toUpdate, s.getContainer().getId());
                     shouldClearCache = true;
@@ -1131,7 +1131,7 @@ public class EHRManager
             }
         }
 
-        if (oldIds.size() == 0)
+        if (oldIds.isEmpty())
         {
             //this should not happen
             throw new SQLException("Unexpected: propertyId " + pd.getPropertyURI() + " does not exists for domain: " + d.getTypeURI());
@@ -1251,27 +1251,27 @@ public class EHRManager
 
             // forEachMap is much more efficient than iterating ResultSet and calling ResultSetUtil.mapRow(rs)
             TableSelector ts = new TableSelector(ti, colNames, filter, null);
-            ts.forEachMap(new Selector.ForEachBlock<Map<String, Object>>()
+            ts.forEachMap(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(Map<String, Object> map)
                 {
-                Map<String, Object> row = new CaseInsensitiveHashMap<>();
-                row.putAll(map);
+                    Map<String, Object> row = new CaseInsensitiveHashMap<>();
+                    row.putAll(map);
 
-                if (row.containsKey("requestid") && row.get("requestid") != null)
-                {
-                    row.put("requestid", null);
-                    row.put("qcstate", null);
-                    row.put("taskid", null);
-                    row.put("qcstateLabel", "Request: Approved");
+                    if (row.containsKey("requestid") && row.get("requestid") != null)
+                    {
+                        row.put("requestid", null);
+                        row.put("qcstate", null);
+                        row.put("taskid", null);
+                        row.put("qcstateLabel", "Request: Approved");
 
-                    requestsToQueue.add(row);
-                }
-                else
-                {
-                    keysToDelete.add(row);
-                }
+                        requestsToQueue.add(row);
+                    }
+                    else
+                    {
+                        keysToDelete.add(row);
+                    }
                 }
             });
 
@@ -1402,7 +1402,7 @@ public class EHRManager
         filter.addCondition(FieldKey.fromString("date"), date, CompareType.DATE_LTE);
 
         TableSelector ts =  new TableSelector(flagsTable, PageFlowUtil.set("lsid", "Id", "date", "enddate", "remark"), filter, null);
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException
@@ -1444,7 +1444,7 @@ public class EHRManager
             }
 
             BatchValidationException errors = new BatchValidationException();
-            if (rows.size() > 0)
+            if (!rows.isEmpty())
                 flagsTable.getUpdateService().insertRows(u, flagsTable.getUserSchema().getContainer(), rows, errors, null, getExtraContext());
 
             if (errors.hasErrors())
@@ -1498,7 +1498,7 @@ public class EHRManager
         filter.addCondition(FieldKey.fromString("Id"), animalIds, CompareType.IN);
         filter.addCondition(FieldKey.fromString("isActive"), true);
         TableSelector ts = new TableSelector(flagsTable, PageFlowUtil.set("lsid", "Id", "date", "enddate", "remark"), filter, null);
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException
@@ -1517,7 +1517,7 @@ public class EHRManager
 
         try
         {
-            if (rows.size() > 0)
+            if (!rows.isEmpty())
             {
                 BatchValidationException batchValidationException = new BatchValidationException();
                 flagsTable.getUpdateService().updateRows(u, flagsTable.getUserSchema().getContainer(), rows, oldKeys, batchValidationException, null, getExtraContext());
@@ -1539,7 +1539,7 @@ public class EHRManager
 
     public Map<String, Object> getExtraContext()
     {
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new HashMap<>();
         map.put("quickValidation", true);
         map.put("generatedByServer", true);
 
@@ -1604,7 +1604,7 @@ public class EHRManager
         return ret;
     }
 
-    private String LOCK_PROP_KEY = getClass().getName() + "||animalLock";
+    private final String LOCK_PROP_KEY = getClass().getName() + "||animalLock";
 
     public void lockAnimalCreation(Container c, User u, Boolean lock, Integer startingId, Integer idCount)
     {

--- a/ehr/src/org/labkey/ehr/EHRProperties.java
+++ b/ehr/src/org/labkey/ehr/EHRProperties.java
@@ -26,7 +26,7 @@ import org.labkey.api.exp.property.SystemProperty;
  */
 public class EHRProperties
 {
-    static private String URI = "urn:ehr.labkey.org/#";
+    static private final String URI = "urn:ehr.labkey.org/#";
 
     public static SystemProperty REMARK = new SystemProperty(URI + "Remark", PropertyType.MULTI_LINE)
     {

--- a/ehr/src/org/labkey/ehr/EHRUpgradeCode.java
+++ b/ehr/src/org/labkey/ehr/EHRUpgradeCode.java
@@ -44,7 +44,7 @@ public class EHRUpgradeCode implements UpgradeCode
              PreparedStatement stmt = transaction.getConnection().prepareStatement(
                 "INSERT INTO ehr_lookups.calendar\n" +
                         "\t(TargetDateTime, TargetDate, Year, Month, Day, DayAfter)\n" +
-                        "\tVALUES (?, ?, ?, ?, ?, ?)");)
+                        "\tVALUES (?, ?, ?, ?, ?, ?)"))
         {
             while (cal.get(Calendar.YEAR) < 2030)
             {

--- a/ehr/src/org/labkey/ehr/buttons/LocationEditButton.java
+++ b/ehr/src/org/labkey/ehr/buttons/LocationEditButton.java
@@ -15,14 +15,9 @@
  */
 package org.labkey.ehr.buttons;
 
-import org.labkey.api.ehr.buttons.EHRShowEditUIButton;
 import org.labkey.api.ehr.security.EHRLocationEditPermission;
-import org.labkey.api.ehr.security.EHRProjectEditPermission;
 import org.labkey.api.ldk.buttons.ShowEditUIButton;
 import org.labkey.api.module.Module;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
 

--- a/ehr/src/org/labkey/ehr/buttons/ProcedureEditButton.java
+++ b/ehr/src/org/labkey/ehr/buttons/ProcedureEditButton.java
@@ -17,8 +17,6 @@ package org.labkey.ehr.buttons;
 
 import org.labkey.api.ehr.buttons.EHRShowEditUIButton;
 import org.labkey.api.ehr.security.EHRProcedureManagementPermission;
-import org.labkey.api.ehr.security.EHRProjectEditPermission;
-import org.labkey.api.ldk.buttons.ShowEditUIButton;
 import org.labkey.api.module.Module;
 
 import java.util.HashMap;

--- a/ehr/src/org/labkey/ehr/buttons/ProjectEditButton.java
+++ b/ehr/src/org/labkey/ehr/buttons/ProjectEditButton.java
@@ -17,8 +17,6 @@ package org.labkey.ehr.buttons;
 
 import org.labkey.api.ehr.buttons.EHRShowEditUIButton;
 import org.labkey.api.ehr.security.EHRProjectEditPermission;
-import org.labkey.api.ehr.security.EHRProtocolEditPermission;
-import org.labkey.api.ldk.buttons.ShowEditUIButton;
 import org.labkey.api.module.Module;
 
 import java.util.HashMap;

--- a/ehr/src/org/labkey/ehr/buttons/ProtocolEditButton.java
+++ b/ehr/src/org/labkey/ehr/buttons/ProtocolEditButton.java
@@ -17,7 +17,6 @@ package org.labkey.ehr.buttons;
 
 import org.labkey.api.ehr.buttons.EHRShowEditUIButton;
 import org.labkey.api.ehr.security.EHRProtocolEditPermission;
-import org.labkey.api.ldk.buttons.ShowEditUIButton;
 import org.labkey.api.module.Module;
 
 import java.util.HashMap;

--- a/ehr/src/org/labkey/ehr/dataentry/DataEntryManager.java
+++ b/ehr/src/org/labkey/ehr/dataentry/DataEntryManager.java
@@ -56,9 +56,9 @@ public class DataEntryManager
 {
     private static final DataEntryManager _instance = new DataEntryManager();
     private static final Logger _log = LogManager.getLogger(DataEntryManager.class);
-    private List<DataEntryFormFactory> _forms = new ArrayList<>();
-    private Map<String, List<FieldKey>> _defaultFieldKeys = new HashMap<>();
-    private List<SingleQueryFormProvider> _queryProviders =  new ArrayList<>();
+    private final List<DataEntryFormFactory> _forms = new ArrayList<>();
+    private final Map<String, List<FieldKey>> _defaultFieldKeys = new HashMap<>();
+    private final List<SingleQueryFormProvider> _queryProviders =  new ArrayList<>();
     private final Cache<String, Object> _cache;
 
     private DataEntryManager()
@@ -205,10 +205,10 @@ public class DataEntryManager
 
     public static class DataEntryFormContextImpl implements DataEntryFormContext
     {
-        private User _user;
-        private Container _container;
-        private Map<String, TableInfo> _tableMap = new HashMap<>();
-        private Map<String, UserSchema> _userSchemas = new HashMap<>();
+        private final User _user;
+        private final Container _container;
+        private final Map<String, TableInfo> _tableMap = new HashMap<>();
+        private final Map<String, UserSchema> _userSchemas = new HashMap<>();
         private Map<String, Dataset> _datasetMap = null;
 
         public DataEntryFormContextImpl(Container c, User u)

--- a/ehr/src/org/labkey/ehr/dataentry/RecordDeleteRunner.java
+++ b/ehr/src/org/labkey/ehr/dataentry/RecordDeleteRunner.java
@@ -150,7 +150,7 @@ public class RecordDeleteRunner implements Job
                 }
 
                 _log.info("deleting " + keys.size() + " records from table: " + ti.getName() + " in container: " + ti.getUserSchema().getContainer().getPath());
-                ti.getUpdateService().deleteRows(ti.getUserSchema().getUser(), ti.getUserSchema().getContainer(), keys, null, new HashMap<String, Object>());
+                ti.getUpdateService().deleteRows(ti.getUserSchema().getUser(), ti.getUserSchema().getContainer(), keys, null, new HashMap<>());
             }
         }
         catch (BatchValidationException | InvalidKeyException | QueryUpdateServiceException | SQLException e)

--- a/ehr/src/org/labkey/ehr/dataentry/SingleQueryForm.java
+++ b/ehr/src/org/labkey/ehr/dataentry/SingleQueryForm.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class SingleQueryForm extends AbstractDataEntryForm
 {
-    private TableInfo _table;
+    private final TableInfo _table;
 
     private SingleQueryForm(DataEntryFormContext ctx, Module owner, String name, String label, String category, TableInfo ti, List<FormSection> sections)
     {

--- a/ehr/src/org/labkey/ehr/demographics/AnimalRecordImpl.java
+++ b/ehr/src/org/labkey/ehr/demographics/AnimalRecordImpl.java
@@ -230,7 +230,7 @@ public class AnimalRecordImpl implements AnimalRecord
     public String getCurrentRoom()
     {
         List<Map<String, Object>> housing = getActiveHousing();
-        if (housing != null && housing.size() > 0)
+        if (housing != null && !housing.isEmpty())
             return (String)housing.get(0).get("room");
 
         return null;
@@ -240,7 +240,7 @@ public class AnimalRecordImpl implements AnimalRecord
     public String getCurrentCage()
     {
         List<Map<String, Object>> housing = getActiveHousing();
-        if (housing != null && housing.size() > 0)
+        if (housing != null && !housing.isEmpty())
             return (String)housing.get(0).get("cage");
 
         return null;
@@ -300,7 +300,7 @@ public class AnimalRecordImpl implements AnimalRecord
         if (_props.containsKey("source"))
         {
             List<Map<String, Object>> rows = (List)_props.get("source");
-            if (rows.size() > 0)
+            if (!rows.isEmpty())
                 return (Date)rows.get(0).get("date");
         }
 

--- a/ehr/src/org/labkey/ehr/history/ClinicalHistoryManager.java
+++ b/ehr/src/org/labkey/ehr/history/ClinicalHistoryManager.java
@@ -42,7 +42,7 @@ public class ClinicalHistoryManager
     private static final ClinicalHistoryManager _instance = new ClinicalHistoryManager();
     private static final Logger _log = LogHelper.getLogger(ClinicalHistoryManager.class, "Management of clinical history data providers");
 
-    private List<HistoryDataSource> _dataSources = new ArrayList<>();
+    private final List<HistoryDataSource> _dataSources = new ArrayList<>();
 
     private ClinicalHistoryManager()
     {
@@ -104,7 +104,7 @@ public class ClinicalHistoryManager
 
     public void sortRowsByDate(List<HistoryRow> rows)
     {
-        Collections.sort(rows, new Comparator<HistoryRow>()
+        Collections.sort(rows, new Comparator<>()
         {
             @Override
             public int compare(HistoryRow o1, HistoryRow o2)

--- a/ehr/src/org/labkey/ehr/history/DefaultDeliveryDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultDeliveryDataSource.java
@@ -39,14 +39,13 @@ public class DefaultDeliveryDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Delivery Type", "deliveryType/value"));
-        sb.append(safeAppend(rs, "Sire", "sire"));
-        sb.append(safeAppend(rs, "Infant", "infant"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
+        String sb = safeAppend(rs, "Delivery Type", "deliveryType/value") +
+                safeAppend(rs, "Sire", "sire") +
+                safeAppend(rs, "Infant", "infant") +
+                safeAppend(rs, "Remark", "remark");
 
-        return sb.toString();
+        return sb;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/history/DefaultEncountersDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultEncountersDataSource.java
@@ -123,7 +123,7 @@ public class DefaultEncountersDataSource extends AbstractDataSource
             }
         }
 
-        if (sb.length() > 0)
+        if (!sb.isEmpty())
         {
             return sb.toString();
         }
@@ -164,9 +164,8 @@ public class DefaultEncountersDataSource extends AbstractDataSource
         SimpleFilter newFilter = new SimpleFilter();
         for (SimpleFilter.FilterClause fc : filter.getClauses())
         {
-            if (fc instanceof CompareType.CompareClause)
+            if (fc instanceof CompareType.CompareClause cc)
             {
-                CompareType.CompareClause cc = (CompareType.CompareClause)fc;
                 Object val = (cc.getParamVals() != null && cc.getParamVals().length > 0) ? cc.getParamVals()[0] : null;
                 FieldKey fk = FieldKey.fromParts(FieldKey.fromString("recordid"), cc.getFieldKeys().get(0));
                 newFilter.addCondition(fk, val, cc.getCompareType());
@@ -188,7 +187,7 @@ public class DefaultEncountersDataSource extends AbstractDataSource
         TableSelector ts = new TableSelector(snomed, columns.values(), newFilter, null);
         final Map<String, Map<Integer, Map<Integer, String>>> snomedMap = new HashMap<>();
 
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException

--- a/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultLabworkDataSource.java
@@ -150,7 +150,7 @@ public class DefaultLabworkDataSource extends AbstractDataSource
         TableSelector ts = new TableSelector(ti, PageFlowUtil.set("parentid", "flag", "value"), filter, null);
         final Map<String, List<String>> map = new HashMap<>();
 
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException

--- a/ehr/src/org/labkey/ehr/history/DefaultObservationsDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultObservationsDataSource.java
@@ -89,7 +89,7 @@ public class DefaultObservationsDataSource extends AbstractDataSource
 
                 //onprc issue 2324: because items within a task can have different times, the assumption of grouping on taskid can break.  therefore group based on full date/time
                 Date roundedDate = DateUtils.truncate((Date)rowMap.get("date"), Calendar.MINUTE);
-                String key = results.getString(FieldKey.fromString("taskid")) + "||" + rowMap.get("Id") + "||" + rowMap.get("categoryText") + "||" + rowMap.get("categoryGroup") + "||" + roundedDate.toString();
+                String key = results.getString(FieldKey.fromString("taskid")) + "||" + rowMap.get("Id") + "||" + rowMap.get("categoryText") + "||" + rowMap.get("categoryGroup") + "||" + roundedDate;
                 List<Map<String, Object>> obsRows = idMap.get(key);
                 if (obsRows == null)
                     obsRows = new ArrayList<>();
@@ -192,7 +192,7 @@ public class DefaultObservationsDataSource extends AbstractDataSource
 
         if (rs.getString(FieldKey.fromString("remark")) != null)
         {
-            if (sb.length() > 0)
+            if (!sb.isEmpty())
                 sb.append(".  ");
             sb.append(rs.getString(FieldKey.fromString("remark")));
         }
@@ -205,7 +205,7 @@ public class DefaultObservationsDataSource extends AbstractDataSource
             sb.append("</span>");
         }
 
-        if (sb.length() > 0)
+        if (!sb.isEmpty())
             sb.append("\n");
 
         return sb.toString();

--- a/ehr/src/org/labkey/ehr/history/DefaultPregnanciesDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultPregnanciesDataSource.java
@@ -39,14 +39,13 @@ public class DefaultPregnanciesDataSource extends AbstractDataSource
     @Override
     protected String getHtml(Container c, Results rs, boolean redacted) throws SQLException
     {
-        StringBuilder sb = new StringBuilder();
 
-        sb.append(safeAppend(rs, "Sire", "sire"));
-        sb.append(safeAppend(rs, "Confirmation Type", "confirmationType/value"));
-        sb.append(safeAppend(rs, "Estimated Delivery Date", "estDeliveryDate"));
-        sb.append(safeAppend(rs, "Remark", "remark"));
+        String sb = safeAppend(rs, "Sire", "sire") +
+                safeAppend(rs, "Confirmation Type", "confirmationType/value") +
+                safeAppend(rs, "Estimated Delivery Date", "estDeliveryDate") +
+                safeAppend(rs, "Remark", "remark");
 
-        return sb.toString();
+        return sb;
     }
 
     @Override

--- a/ehr/src/org/labkey/ehr/history/LabworkManager.java
+++ b/ehr/src/org/labkey/ehr/history/LabworkManager.java
@@ -18,10 +18,7 @@ package org.labkey.ehr.history;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.ehr.history.LabworkType;
-import org.labkey.api.module.Module;
 import org.labkey.api.security.User;
-import org.labkey.api.util.Pair;
-import org.labkey.ehr.EHRServiceImpl;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,7 +37,7 @@ import java.util.Map;
 public class LabworkManager
 {
     private static final LabworkManager _instance = new LabworkManager();
-    private List<LabworkType> _types = new ArrayList<>();
+    private final List<LabworkType> _types = new ArrayList<>();
 
     private LabworkManager()
     {

--- a/ehr/src/org/labkey/ehr/notification/DataEntrySummary.java
+++ b/ehr/src/org/labkey/ehr/notification/DataEntrySummary.java
@@ -108,7 +108,7 @@ public class DataEntrySummary implements NotificationSection
             if (tsRequest.exists())
             {
                 hasRequests = true;
-                tsRequest.forEach(new Selector.ForEachBlock<ResultSet>()
+                tsRequest.forEach(new Selector.ForEachBlock<>()
                 {
                     @Override
                     public void exec(ResultSet rs) throws SQLException
@@ -156,7 +156,7 @@ public class DataEntrySummary implements NotificationSection
             if (tsTasks.exists())
             {
                 hasTasks = true;
-                tsTasks.forEach(new Selector.ForEachBlock<ResultSet>()
+                tsTasks.forEach(new Selector.ForEachBlock<>()
                 {
                     @Override
                     public void exec(ResultSet rs) throws SQLException

--- a/ehr/src/org/labkey/ehr/notification/OverdueWeightsNotification.java
+++ b/ehr/src/org/labkey/ehr/notification/OverdueWeightsNotification.java
@@ -91,7 +91,6 @@ public class OverdueWeightsNotification extends AbstractEHRNotification
 
     /**
      * find animals not weighed in the past 60 days
-     * @param msg
      */
     private void animalsNotWeightedInPast60Days(Container c, User u, StringBuilder msg)
     {
@@ -187,7 +186,8 @@ public class OverdueWeightsNotification extends AbstractEHRNotification
         if (ts.getRowCount() > 0)
         {
             msg.append("<b>WARNING: The following animals do not have a weight:</b><br>\n");
-            ts.forEach(new TableSelector.ForEachBlock<ResultSet>(){
+            ts.forEach(new TableSelector.ForEachBlock<>()
+            {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
                 {

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -255,7 +255,7 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                             "\tVALUES (?, ?, ?, ?, ?, ?, ?, ?)"))
             {
                 log.info("Inserting rows");
-                String line = null;
+                String line;
                 int lineNum = 0;
                 while ((line = reader.readLine()) != null)
                 {

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsInitTask.java
@@ -142,13 +142,13 @@ public class GeneticCalculationsInitTask extends PipelineJob.Task<GeneticCalcula
                 long count = ts.getRowCount();
                 if (count > 0)
                 {
-                    ts.forEach(new Selector.ForEachBlock<ResultSet>()
+                    ts.forEach(new Selector.ForEachBlock<>()
                     {
                         @Override
                         public void exec(ResultSet rs) throws SQLException
                         {
                             String[] row = new String[]{rs.getString("Id"), rs.getString("Dam"), rs.getString("Sire"), rs.getString("Gender"), rs.getString("Species")};
-                            for (int i=0;i<row.length;i++)
+                            for (int i = 0; i < row.length; i++)
                             {
                                 //R wont accept empty strings in the input, so we need to replace them with NA
                                 if (StringUtils.isEmpty(row[i]))

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsRTask.java
@@ -17,7 +17,6 @@ package org.labkey.ehr.pipeline;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
 import org.labkey.api.pipeline.AbstractTaskFactory;

--- a/ehr/src/org/labkey/ehr/query/buttons/ExcelImportButton.java
+++ b/ehr/src/org/labkey/ehr/query/buttons/ExcelImportButton.java
@@ -15,14 +15,12 @@
  */
 package org.labkey.ehr.query.buttons;
 
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.security.EHRCompletedUpdatePermission;
 import org.labkey.api.ldk.table.SimpleButtonConfigFactory;
 import org.labkey.api.module.Module;
 import org.labkey.api.query.DetailsURL;
-import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.template.ClientDependency;
 
 /**

--- a/ehr/src/org/labkey/ehr/security/AbstractEHRRole.java
+++ b/ehr/src/org/labkey/ehr/security/AbstractEHRRole.java
@@ -15,13 +15,8 @@
  */
 package org.labkey.ehr.security;
 
-import org.labkey.api.data.Container;
-import org.labkey.api.module.ModuleLoader;
-import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.api.security.roles.AbstractModuleScopedRole;
-import org.labkey.api.security.roles.AbstractRole;
 import org.labkey.ehr.EHRModule;
 
 /**

--- a/ehr/src/org/labkey/ehr/security/EHRBehaviorEntryRole.java
+++ b/ehr/src/org/labkey/ehr/security/EHRBehaviorEntryRole.java
@@ -17,7 +17,6 @@ package org.labkey.ehr.security;
 
 import org.labkey.api.ehr.security.EHRBehaviorEntryPermission;
 import org.labkey.api.ehr.security.EHRDataEntryPermission;
-import org.labkey.api.ehr.security.EHRSurgeryEntryPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;

--- a/ehr/src/org/labkey/ehr/security/EHRPathologyEntryRole.java
+++ b/ehr/src/org/labkey/ehr/security/EHRPathologyEntryRole.java
@@ -17,7 +17,6 @@ package org.labkey.ehr.security;
 
 import org.labkey.api.ehr.security.EHRDataEntryPermission;
 import org.labkey.api.ehr.security.EHRPathologyEntryPermission;
-import org.labkey.api.ehr.security.EHRSurgeryEntryPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;

--- a/ehr/src/org/labkey/ehr/security/EHRProcedureManagementRole.java
+++ b/ehr/src/org/labkey/ehr/security/EHRProcedureManagementRole.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.ehr.security;
 
-import org.labkey.api.ehr.security.EHRBehaviorEntryPermission;
 import org.labkey.api.ehr.security.EHRDataEntryPermission;
 import org.labkey.api.ehr.security.EHRProcedureManagementPermission;
 import org.labkey.api.security.permissions.DeletePermission;

--- a/ehr/src/org/labkey/ehr/security/EHRProtocolManagementRole.java
+++ b/ehr/src/org/labkey/ehr/security/EHRProtocolManagementRole.java
@@ -16,7 +16,6 @@
 package org.labkey.ehr.security;
 
 import org.labkey.api.ehr.security.EHRDataEntryPermission;
-import org.labkey.api.ehr.security.EHRProjectEditPermission;
 import org.labkey.api.ehr.security.EHRProtocolEditPermission;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;

--- a/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
+++ b/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
@@ -21,10 +21,7 @@ import org.labkey.api.data.TableInfo;
 import org.labkey.api.ehr.EHRQCState;
 import org.labkey.api.ehr.EHRService;
 import org.labkey.api.ehr.security.EHRSecurityEscalator;
-import org.labkey.api.security.HasPermission;
 import org.labkey.api.security.SecurableResource;
-import org.labkey.api.security.SecurityPolicy;
-import org.labkey.api.security.SecurityPolicyManager;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.DeletePermission;
 import org.labkey.api.security.permissions.InsertPermission;
@@ -37,7 +34,6 @@ import org.labkey.api.study.StudyService;
 import org.labkey.ehr.EHRManager;
 import org.labkey.ehr.dataentry.DataEntryManager;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -173,7 +169,7 @@ public class EHRSecurityManager
         return true;
     }
 
-    public static enum EVENT_TYPE {
+    public enum EVENT_TYPE {
         insert(InsertPermission.class),
         update(UpdatePermission.class),
         delete(DeletePermission.class);

--- a/ehr/src/org/labkey/ehr/security/EHRTemplateCreatorRole.java
+++ b/ehr/src/org/labkey/ehr/security/EHRTemplateCreatorRole.java
@@ -16,7 +16,6 @@
 package org.labkey.ehr.security;
 
 import org.labkey.api.ehr.security.EHRTemplateCreatorPermission;
-import org.labkey.api.security.permissions.Permission;
 
 /**
  * Created by Josh on 2/25/2016.

--- a/ehr/src/org/labkey/ehr/table/AgeDisplayColumn.java
+++ b/ehr/src/org/labkey/ehr/table/AgeDisplayColumn.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 
 import java.util.Calendar;
-import java.util.Date;
 
 /**
  * User: bimber

--- a/ehr/src/org/labkey/ehr/table/AgeMonthsDisplayColumn.java
+++ b/ehr/src/org/labkey/ehr/table/AgeMonthsDisplayColumn.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 
 import java.util.Calendar;
-import java.util.Date;
 
 /**
  * User: bimber

--- a/ehr/src/org/labkey/ehr/table/AgeYearMonthsDisplayColumn.java
+++ b/ehr/src/org/labkey/ehr/table/AgeYearMonthsDisplayColumn.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 
 import java.util.Calendar;
-import java.util.Date;
 
 public class AgeYearMonthsDisplayColumn extends AbstractAgeDisplayColumn
 {

--- a/ehr/src/org/labkey/ehr/table/AgeYearsMonthsDaysDisplayColumn.java
+++ b/ehr/src/org/labkey/ehr/table/AgeYearsMonthsDaysDisplayColumn.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.ColumnInfo;
 
 import java.util.Calendar;
-import java.util.Date;
 
 public class AgeYearsMonthsDaysDisplayColumn extends AbstractAgeDisplayColumn
 {

--- a/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
+++ b/ehr/src/org/labkey/ehr/table/DefaultEHRCustomizer.java
@@ -761,7 +761,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
             {
                 sb.append(d.getName() + ", ");
             }
-            _log.info("datasets present: " + sb.toString());
+            _log.info("datasets present: " + sb);
 
             return null;
         }
@@ -1044,9 +1044,8 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         {
             for (ButtonConfig btn : existingBtns)
             {
-                if (btn instanceof UserDefinedButtonConfig)
+                if (btn instanceof UserDefinedButtonConfig ub)
                 {
-                    UserDefinedButtonConfig ub = (UserDefinedButtonConfig)btn;
                     if (MORE_ACTIONS.equals(ub.getText()))
                     {
                         moreActionsBtn = ub;
@@ -1059,7 +1058,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
         if (moreActionsBtn == null)
         {
             //abort if there are no custom buttons
-            if (buttons.size() == 0)
+            if (buttons.isEmpty())
                 return;
 
             moreActionsBtn = new UserDefinedButtonConfig();
@@ -1590,7 +1589,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
 
                 List<QueryException> errors = new ArrayList<>();
                 TableInfo ti = qd.getTable(errors, true);
-                if (errors.size() > 0 || ti == null)
+                if (!errors.isEmpty() || ti == null)
                 {
                     _log.warn("Error creating housing at time lookup table for: " + schemaName + "." + queryName + " in container: " + targetSchema.getContainer().getPath());
                     for (QueryException e : errors)
@@ -1712,7 +1711,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
 
                 List<QueryException> errors = new ArrayList<>();
                 TableInfo ti = qd.getTable(errors, true);
-                if (errors.size() > 0)
+                if (!errors.isEmpty())
                 {
                     _log.warn("Error creating survivorship lookup table for: " + schemaName + "." + queryName + " in container: " + targetSchema.getContainer().getPath());
                     for (QueryException e : errors)
@@ -1871,7 +1870,7 @@ public class DefaultEHRCustomizer extends AbstractTableCustomizer
 
                 List<QueryException> errors = new ArrayList<>();
                 TableInfo ti = qd.getTable(errors, true);
-                if (errors.size() > 0)
+                if (!errors.isEmpty())
                 {
                     _log.warn("Error creating age at time lookup table for: " + schemaName + "." + queryName + " in container: " + targetSchema.getContainer().getPath());
                     for (QueryException e : errors)

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -824,7 +824,8 @@ public class TriggerScriptHelper
     public void updateDemographicsRecord(List<Map<String, Object>> updatedRows) throws QueryUpdateServiceException, SQLException, BatchValidationException, InvalidKeyException
     {
         // updatedRows object may be a JS array where isEmpty() isn't reliable, so use size() == 0 instead
-        if (updatedRows == null || updatedRows.isEmpty())
+        //noinspection SizeReplaceableByIsEmpty
+        if (updatedRows == null || updatedRows.size() == 0)
             return;
 
         updatedRows = new ArrayList<>(updatedRows);
@@ -1885,7 +1886,7 @@ public class TriggerScriptHelper
         Set<String> ignoredObjectIds = new HashSet<>();
         Date highestOpenEnded = null;
 
-        if (recordsInTransaction != null && !recordsInTransaction.isEmpty())
+        if (recordsInTransaction != null)
         {
             for (Map<String, Object> origMap : recordsInTransaction)
             {
@@ -2205,7 +2206,7 @@ public class TriggerScriptHelper
 
                 animals.add(id);
 
-                if (recordsInTransaction != null && !recordsInTransaction.isEmpty())
+                if (recordsInTransaction != null)
                 {
                     for (Map<String, Object> r : recordsInTransaction)
                     {

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -824,7 +824,7 @@ public class TriggerScriptHelper
     public void updateDemographicsRecord(List<Map<String, Object>> updatedRows) throws QueryUpdateServiceException, SQLException, BatchValidationException, InvalidKeyException
     {
         // updatedRows object may be a JS array where isEmpty() isn't reliable, so use size() == 0 instead
-        if (updatedRows == null || updatedRows.size() == 0)
+        if (updatedRows == null || updatedRows.isEmpty())
             return;
 
         updatedRows = new ArrayList<>(updatedRows);
@@ -936,7 +936,7 @@ public class TriggerScriptHelper
             return null;
 
         List<String> testNames = Arrays.asList(StringUtils.split(services, ",;"));
-        if (testNames.size() == 0)
+        if (testNames.isEmpty())
             return null;
 
         Map<String, Map<String, Object>> serviceMap = getBloodDrawServicesMap();
@@ -981,13 +981,13 @@ public class TriggerScriptHelper
             }
         }
 
-        if (msgs.size() == 0)
+        if (msgs.isEmpty())
         {
             return null;
         }
         else
         {
-            return msgs.toArray(new String[msgs.size()]);
+            return msgs.toArray(new String[0]);
         }
     }
 
@@ -1124,7 +1124,7 @@ public class TriggerScriptHelper
         filter.addCondition(FieldKey.fromString("countsAgainstVolume"), true);
 
         // Don't pull database records that may be old versions of records that are changing in this transaction
-        if (ignoredObjectIds.size() > 0)
+        if (!ignoredObjectIds.isEmpty())
         {
             filter.addCondition(FieldKey.fromString("objectid"), ignoredObjectIds, CompareType.NOT_IN);
         }
@@ -1485,7 +1485,7 @@ public class TriggerScriptHelper
                 {
                     String subject = "EHR " + formtype + " " + label;
                     Set<UserPrincipal> recipients = getRecipients(notify1, notify2, notify3);
-                    if (recipients.size() == 0)
+                    if (recipients.isEmpty())
                     {
                         _log.warn("No recipients, unable to send EHR trigger script email");
                         return;
@@ -1639,7 +1639,7 @@ public class TriggerScriptHelper
                     {
                         for (UserPrincipal u : SecurityManager.getAllGroupMembers((Group)up, MemberType.ACTIVE_USERS))
                         {
-                            if (((User)u).isActive())
+                            if (u.isActive())
                                 recipients.add(u);
                         }
                     }
@@ -1655,7 +1655,7 @@ public class TriggerScriptHelper
     {
         List<String> errorMsgs = new ArrayList<>();
 
-        Map<String, Object> demographicsProps = new HashMap<String, Object>();
+        Map<String, Object> demographicsProps = new HashMap<>();
         for (String key : new String[]{"Id", "gender", "species", "dam", "sire", "origin", "source", "geographic_origin", "birth"})
         {
             if (row.containsKey(key))
@@ -1730,7 +1730,7 @@ public class TriggerScriptHelper
 
         TableSelector ts = new TableSelector(ti, Collections.singleton("Id"), filter, null);
 
-        Set<String> ret = new HashSet<String>();
+        Set<String> ret = new HashSet<>();
         ret.addAll(Arrays.asList(ts.getArray(String.class)));
 
         return ret;
@@ -1738,7 +1738,7 @@ public class TriggerScriptHelper
 
     public void updateStatusField(List<String> ids, Map<String, List<Date>> liveBirths, Map<String, List<Date>> arrivals, Map<String, List<Date>> deaths, Map<String, List<Date>> departures) throws QueryUpdateServiceException, SQLException, BatchValidationException, InvalidKeyException
     {
-        List<Map<String, Object>> rows = new ArrayList<Map<String, Object>>();
+        List<Map<String, Object>> rows = new ArrayList<>();
 
         Set<String> idsInDemographics = hasDemographicsRecord(ids);
         for (String id : ids)
@@ -1885,7 +1885,7 @@ public class TriggerScriptHelper
         Set<String> ignoredObjectIds = new HashSet<>();
         Date highestOpenEnded = null;
 
-        if (recordsInTransaction != null && recordsInTransaction.size() > 0)
+        if (recordsInTransaction != null && !recordsInTransaction.isEmpty())
         {
             for (Map<String, Object> origMap : recordsInTransaction)
             {
@@ -2013,7 +2013,7 @@ public class TriggerScriptHelper
                 }
             }
 
-            if (emails.size() == 0)
+            if (emails.isEmpty())
             {
                 _log.warn("No emails, unable to send EHR trigger script email");
                 return;
@@ -2049,7 +2049,7 @@ public class TriggerScriptHelper
                     String subject = "Death notification: " + id;
 
                     Set<UserPrincipal> recipients = NotificationService.get().getRecipients(new DeathNotification(), getContainer());
-                    if (recipients.size() == 0)
+                    if (recipients.isEmpty())
                     {
                         _log.warn("No recipients, skipping death notification");
                         return;
@@ -2070,7 +2070,7 @@ public class TriggerScriptHelper
                     //find housing overlapping date of death
                     TableInfo housing = getTableInfo("study", "demographicsLastHousing");
                     TableSelector housingTs = new TableSelector(housing, PageFlowUtil.set("room", "cage"), new SimpleFilter(FieldKey.fromString("Id"), id), null);
-                    housingTs.forEach(new Selector.ForEachBlock<ResultSet>()
+                    housingTs.forEach(new Selector.ForEachBlock<>()
                     {
                         @Override
                         public void exec(ResultSet rs) throws SQLException
@@ -2100,7 +2100,7 @@ public class TriggerScriptHelper
 
                     if (assignmentTs.exists())
                     {
-                        assignmentTs.forEach(new Selector.ForEachBlock<ResultSet>()
+                        assignmentTs.forEach(new Selector.ForEachBlock<>()
                         {
                             @Override
                             public void exec(ResultSet object) throws SQLException
@@ -2137,7 +2137,7 @@ public class TriggerScriptHelper
 
                         if (groupTs.exists())
                         {
-                            groupTs.forEach(new Selector.ForEachBlock<ResultSet>()
+                            groupTs.forEach(new Selector.ForEachBlock<>()
                             {
                                 @Override
                                 public void exec(ResultSet object) throws SQLException
@@ -2188,7 +2188,7 @@ public class TriggerScriptHelper
         TableSelector ts = new TableSelector(ti, filter, null);
         final List<String> errors = new ArrayList<>();
         final String ALL_SPECIES = "All Species";
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet rs) throws SQLException
@@ -2205,12 +2205,12 @@ public class TriggerScriptHelper
 
                 animals.add(id);
 
-                if (recordsInTransaction != null && recordsInTransaction.size() > 0)
+                if (recordsInTransaction != null && !recordsInTransaction.isEmpty())
                 {
                     for (Map<String, Object> r : recordsInTransaction)
                     {
-                        String id = (String)r.get("Id");
-                        Number project = (Number)r.get("project");
+                        String id = (String) r.get("Id");
+                        Number project = (Number) r.get("project");
                         if (id == null || project == null)
                         {
                             continue;
@@ -2239,7 +2239,7 @@ public class TriggerScriptHelper
                 int remaining = totalAllowed - animals.size();
                 if (remaining < 0)
                 {
-                    errors.add("There are not enough spaces on protocol: " + protocol + ". Allowed: " + (totalAllowedNull ? "none": totalAllowed) + ", used: " + animals.size());
+                    errors.add("There are not enough spaces on protocol: " + protocol + ". Allowed: " + (totalAllowedNull ? "none" : totalAllowed) + ", used: " + animals.size());
                 }
             }
         });
@@ -2378,7 +2378,7 @@ public class TriggerScriptHelper
             return null;
 
         List<String> testNames = Arrays.asList(StringUtils.split(services, ",;"));
-        if (testNames.size() == 0)
+        if (testNames.isEmpty())
             return null;
 
         Map<String, Map<String, Object>> serviceMap = getBloodDrawServicesMap();
@@ -2531,9 +2531,9 @@ public class TriggerScriptHelper
 
         //sort on date
         records = new ArrayList<>(records);
-        records.sort(new Comparator<Map<String, Object>>()
+        records.sort(new Comparator<>()
         {
-            private SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd kk:mm");
+            private final SimpleDateFormat dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd kk:mm");
 
             @Override
             public int compare(Map<String, Object> o1, Map<String, Object> o2)
@@ -2621,9 +2621,9 @@ public class TriggerScriptHelper
         }
 
         TableSelector ts = new TableSelector(flagTable, Collections.singleton("lsid"), filter, null);
-        Long count = ts.getRowCount();
+        long count = ts.getRowCount();
 
-        return count.intValue();
+        return (int) count;
     }
 
     public void ensureSingleFlagCategoryActive(String id, String flag, String objectId, final Date enddate)
@@ -2666,7 +2666,7 @@ public class TriggerScriptHelper
             QueryUpdateService qus = flagsTable.getUpdateService();
 
             TableSelector ts = new TableSelector(flagsTable, PageFlowUtil.set("lsid", "Id", "enddate"), filter, null);
-            ts.forEach(new Selector.ForEachBlock<ResultSet>()
+            ts.forEach(new Selector.ForEachBlock<>()
             {
                 @Override
                 public void exec(ResultSet rs) throws SQLException
@@ -2683,7 +2683,7 @@ public class TriggerScriptHelper
 
             try
             {
-                if (rows.size() > 0)
+                if (!rows.isEmpty())
                 {
                     Map<String, Object> extraContext = getExtraContext();
                     extraContext.put("skipAnnounceChangedParticipants", true);
@@ -2693,15 +2693,7 @@ public class TriggerScriptHelper
                         throw batchValidationException;
                 }
             }
-            catch (InvalidKeyException e)
-            {
-                throw new RuntimeException(e);
-            }
-            catch (BatchValidationException e)
-            {
-                throw new RuntimeException(e);
-            }
-            catch (QueryUpdateServiceException e)
+            catch (InvalidKeyException | QueryUpdateServiceException | BatchValidationException e)
             {
                 throw new RuntimeException(e);
             }
@@ -2730,7 +2722,7 @@ public class TriggerScriptHelper
 
     public void reportCageChange(List<String> keys)
     {
-        if (keys == null || keys.size() == 0)
+        if (keys == null || keys.isEmpty())
             return;
 
         SimpleFilter.OrClause clause = new SimpleFilter.OrClause();

--- a/ehr/test/src/org/labkey/test/pages/ehr/BaseColonyOverviewPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/BaseColonyOverviewPage.java
@@ -39,7 +39,7 @@ public abstract class BaseColonyOverviewPage extends LabKeyPage
         return Locator.tag("div").withClasses("tab-pane", "active").notHidden().findElement(getDriver());
     }
 
-    protected abstract class OverviewTab extends Component
+    protected abstract static class OverviewTab extends Component
     {
         private final WebElement el;
 

--- a/ehr/test/src/org/labkey/test/pages/ehr/EHRLookupPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/EHRLookupPage.java
@@ -16,6 +16,7 @@ public class EHRLookupPage extends LabKeyPage<EHRLookupPage.ElementCache>
         super(driver);
         waitForPage();
     }
+    @Override
     public void waitForPage()
     {
         waitFor(() -> {

--- a/ehr/test/src/org/labkey/test/pages/ehr/ParticipantViewPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/ParticipantViewPage.java
@@ -262,7 +262,7 @@ public class ParticipantViewPage<EC extends ParticipantViewPage.ElementCache> ex
         }
     }
 
-    public abstract class Tab
+    public abstract static class Tab
     {
         final WebElement _el;
         private String _label;

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractEHRTest.java
@@ -433,7 +433,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         Locator completeDiv = Locator.tagContainingText("div", "Populate Complete");
         List<WebElement> completeEl = completeDiv.findElements(getDriver());
         clickButton("Populate " + tableLabel, 0);
-        if (completeEl.size() > 0)
+        if (!completeEl.isEmpty())
             longWait().until(ExpectedConditions.stalenessOf(completeEl.get(0)));
         waitForElement(completeDiv, POPULATE_TIMEOUT_MS);
         Assert.assertFalse("Error populating " + tableLabel, elementContains(Locator.id("msgbox"), "ERROR"));
@@ -447,7 +447,7 @@ abstract public class AbstractEHRTest extends BaseWebDriverTest implements Advan
         Locator completeDiv = Locator.tagContainingText("div", "Delete Complete");
         List<WebElement> completeEl = completeDiv.findElements(getDriver());
         clickButton(("All".equals(tableLabel) ? "Delete " : "Delete Data From ") + tableLabel, 0);
-        if (completeEl.size() > 0)
+        if (!completeEl.isEmpty())
             longWait().until(ExpectedConditions.stalenessOf(completeEl.get(0)));
         waitForElement(completeDiv, POPULATE_TIMEOUT_MS);
         Assert.assertFalse("Error deleting " + tableLabel, elementContains(Locator.id("msgbox"), "ERROR"));

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -320,7 +320,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
     private void calculateAverage()
     {
-        if (_saveRowsTimes.size() == 0)
+        if (_saveRowsTimes.isEmpty())
             return;
 
         long sum = 0;

--- a/ehr/test/src/org/labkey/test/tests/ehr/ComplianceTrainingTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/ComplianceTrainingTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 @BaseWebDriverTest.ClassTimeout(minutes = 5)
 public abstract class ComplianceTrainingTest extends BaseWebDriverTest implements AdvancedSqlTest
 {
-    private String listZIP = TestFileUtils.getLabKeyRoot() + "/server/modules/ehrModules/EHR_ComplianceDB/tools/SOP_Lists.zip";
+    private final String listZIP = TestFileUtils.getLabKeyRoot() + "/server/modules/ehrModules/EHR_ComplianceDB/tools/SOP_Lists.zip";
 
     @Override
     protected String getProjectName()
@@ -61,7 +61,7 @@ public abstract class ComplianceTrainingTest extends BaseWebDriverTest implement
     @BeforeClass
     public static void doSetup()
     {
-        ComplianceTrainingTest initTest = (ComplianceTrainingTest)getCurrentTest();
+        ComplianceTrainingTest initTest = getCurrentTest();
         initTest.setUpTest();
         initTest.cleanupRecords(false);
     }
@@ -74,7 +74,7 @@ public abstract class ComplianceTrainingTest extends BaseWebDriverTest implement
     private final String requirementName1 = prefix + "req1";
     private final String requirementName2 = prefix + "req2";
     private final String requirementName3 = prefix + "req3";
-    private EHRClientAPIHelper _apiHelper = new EHRClientAPIHelper(this, getProjectName());
+    private final EHRClientAPIHelper _apiHelper = new EHRClientAPIHelper(this, getProjectName());
 
 
 
@@ -358,7 +358,7 @@ public abstract class ComplianceTrainingTest extends BaseWebDriverTest implement
             select.addFilter(new Filter("requirementname", reqName, Filter.Operator.EQUAL));
             SelectRowsResponse resp = select.execute(cn, getProjectName());
 
-            if (resp.getRows().size() == 0)
+            if (resp.getRows().isEmpty())
             {
                 insertCmd = new InsertRowsCommand("ehr_compliancedb", "requirements");
                 rowMap = new HashMap<>();
@@ -374,7 +374,7 @@ public abstract class ComplianceTrainingTest extends BaseWebDriverTest implement
             select.addFilter(new Filter("categoryname", category, Filter.Operator.EQUAL));
             resp = select.execute(cn, getProjectName());
 
-            if (resp.getRows().size() == 0)
+            if (resp.getRows().isEmpty())
             {
                 insertCmd = new InsertRowsCommand("ehr_compliancedb", "employeecategory");
                 rowMap = new HashMap<>();

--- a/ehr/test/src/org/labkey/test/tests/ehr/EHRBillingHelper.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/EHRBillingHelper.java
@@ -43,8 +43,8 @@ import static org.junit.Assert.assertEquals;
 
 public class EHRBillingHelper
 {
-    private BaseWebDriverTest _test;
-    private String _projectName;
+    private final BaseWebDriverTest _test;
+    private final String _projectName;
     private String _folderName;
     private String _modulePath;
     private String _containerPath;
@@ -168,7 +168,7 @@ public class EHRBillingHelper
             {
                 for (Map.Entry<String, List<String>> entry : item.getColumnTextCheckMap().entrySet())
                 {
-                    List<String> input = new ArrayList<String>();
+                    List<String> input = new ArrayList<>();
                     for (Map<String, Object> row : resp.getRows())
                     {
                         if (row.get(entry.getKey()) != null)
@@ -225,7 +225,6 @@ public class EHRBillingHelper
             {
                 results.setFilter("chargeId/chargeCategoryid", "Equals", item.getChargeCategoryID());
                 filterDescription += separator + "ChargeCategoryId: " + item.getChargeCategoryID();
-                separator = ", ";
             }
 
             assertEquals("Wrong row count for " + filterDescription, item.getRowCount(), results.getDataRowCount());
@@ -266,13 +265,13 @@ public class EHRBillingHelper
     public static class InvoicedItem
     {
         private String _animalId;
-        private String _category;
-        private int _rowCount;
-        private String _totalCost;
-        private String _totalQuantity;
+        private final String _category;
+        private final int _rowCount;
+        private final String _totalCost;
+        private final String _totalQuantity;
         private String _chargeCategoryId;
         private String _chargeID;
-        private Map<String, List<String>> _columnTextChecks = new HashMap<>();
+        private final Map<String, List<String>> _columnTextChecks = new HashMap<>();
 
         public InvoicedItem(String category, int rowCount, String totalQuantity, String totalCost)
         {

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRTestHelper.java
@@ -55,7 +55,7 @@ import static org.labkey.test.util.TestLogger.log;
 
 public class EHRTestHelper
 {
-    private BaseWebDriverTest _test;
+    private final BaseWebDriverTest _test;
 
     public EHRTestHelper(BaseWebDriverTest test)
     {
@@ -104,7 +104,7 @@ public class EHRTestHelper
         WebDriverWait wait = new WebDriverWait(test.getDriver(), Duration.ofSeconds(secTimeout));
         try
         {
-            return wait.until(new ExpectedCondition<Boolean>()
+            return wait.until(new ExpectedCondition<>()
             {
                 @Override
                 public Boolean apply(WebDriver d)

--- a/ehr_billing/api-src/org/labkey/api/ehr_billing/notification/BillingNotificationProvider.java
+++ b/ehr_billing/api-src/org/labkey/api/ehr_billing/notification/BillingNotificationProvider.java
@@ -29,52 +29,52 @@ public interface BillingNotificationProvider
     /**
      * @return Center specific Billing module.
      */
-    public Module getModule();
+    Module getModule();
 
     /**
      * @return Notification Name - ex. 'Billing Notification' or 'Finance Notification'.
      */
-    public String getName();
+    String getName();
 
     /**
      * @return Scheduled cron job string - ex. "0 0 8 * * ?" will send notification every day at 8:00 am
      */
-    public String getCronString();
+    String getCronString();
 
     /**
      * @return Description of your scheduled cron job. ex "Every Day at 8:00AM"
      */
-    public String getScheduleDescription();
+    String getScheduleDescription();
 
     /**
      * @return Description of what your billing notification entails.
      */
-    public String getDescription();
+    String getDescription();
 
     /**
      * @return Map of Category and queryName to run. Queries are expected to be ehr_billing queries.
      */
-    public Map<String, String> getCategoriesToQuery();
+    Map<String, String> getCategoriesToQuery();
 
     /**
      * @return Map of Category and Containers in which the corresponding queries listed in getCategoriesToQuery() live.
      */
-    public Map<String, Container> getQueryCategoryContainerMapping(Container c);
+    Map<String, Container> getQueryCategoryContainerMapping(Container c);
 
     /**
      * @return List of field descriptors, essentially a calculated column in your queries that you'd want to show as part of the notification.
      */
-    public List<FieldDescriptor> getFieldDescriptor();
+    List<FieldDescriptor> getFieldDescriptor();
 
     /**
      * @return Additional notifications that are not covered in BillingNotification.java
      */
-    public List<StringBuilder> getAdditionalNotifications(User user);
+    List<StringBuilder> getAdditionalNotifications(User user);
 
     /**
      * @return name or abbreviation of your Primate Center
      */
-    public String getCenterName();
+    String getCenterName();
 
     /**
      * @param u User
@@ -83,12 +83,12 @@ public interface BillingNotificationProvider
      * @param msg a StringBuilder instance to append message to if preferred esp. in the case when billing schema is not enabled in a given container
      * @return false if billing public linked schema is not enabled in a given container c, true otherwise.
      */
-    public boolean isBillingSchemaEnabled(User u, Container c, String alertType, StringBuilder msg);
+    boolean isBillingSchemaEnabled(User u, Container c, String alertType, StringBuilder msg);
 
     /**
      * @return Name of center specific billing schema
      */
-    public String getCenterSpecificBillingSchema();
+    String getCenterSpecificBillingSchema();
 
     /**
      * @param u User
@@ -98,7 +98,7 @@ public interface BillingNotificationProvider
      * @return A List of {@link ChargeCategoryInfo} - ChargeCategoryInfo class holds data to display under the 'Charge Summary' section of the notification per custom category.
      * See WNPRC Billing's implementation of this method for an example.
      */
-    public default List<ChargeCategoryInfo> getAdditionalChargeCategoryInfo(User u, Container c, Date startDate, Date endDate)
+    default List<ChargeCategoryInfo> getAdditionalChargeCategoryInfo(User u, Container c, Date startDate, Date endDate)
     {
         return Collections.emptyList();
     }

--- a/ehr_billing/api-src/org/labkey/api/ehr_billing/notification/FieldDescriptor.java
+++ b/ehr_billing/api-src/org/labkey/api/ehr_billing/notification/FieldDescriptor.java
@@ -21,10 +21,10 @@ import org.labkey.api.query.FieldKey;
 import java.sql.SQLException;
 
 public class FieldDescriptor {
-    private String _fieldName;
-    private boolean _flagIfNonNull;
-    private String _label;
-    private boolean _shouldHighlight;
+    private final String _fieldName;
+    private final boolean _flagIfNonNull;
+    private final String _label;
+    private final boolean _shouldHighlight;
 
     public FieldDescriptor(String fieldName, boolean flagIfNonNull, String label, boolean shouldHighlight)
     {

--- a/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/BillingPipelineJobSupport.java
+++ b/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/BillingPipelineJobSupport.java
@@ -23,15 +23,15 @@ import java.util.Date;
 
 public interface BillingPipelineJobSupport
 {
-    public Date getStartDate();
+    Date getStartDate();
 
-    public Date getEndDate();
+    Date getEndDate();
 
-    public String getComment();
+    String getComment();
 
-    public String getName();
+    String getName();
 
-    public File getAnalysisDir();
+    File getAnalysisDir();
 
     /*
      * Returns Pair of previous matching billing run's objectId and rowId

--- a/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
+++ b/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
@@ -16,7 +16,6 @@
 package org.labkey.api.ehr_billing.pipeline;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingContainerListener.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingContainerListener.java
@@ -19,7 +19,6 @@ package org.labkey.ehr_billing;
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager.ContainerListener;
-import org.labkey.api.data.DatabaseTableType;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingController.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingController.java
@@ -79,7 +79,7 @@ public class EHR_BillingController extends SpringActionController
     }
 
     @RequiresPermission(UpdatePermission.class)
-    public class RunBillingPipelineAction extends MutatingApiAction<BillingPipelineForm>
+    public static class RunBillingPipelineAction extends MutatingApiAction<BillingPipelineForm>
     {
         @Override
         public ApiResponse execute(BillingPipelineForm form, BindException errors)
@@ -129,13 +129,13 @@ public class EHR_BillingController extends SpringActionController
     }
 
     @RequiresPermission(EHR_BillingAdminPermission.class)
-    public class DeleteBillingPeriodAction extends ConfirmAction<QueryForm>
+    public static class DeleteBillingPeriodAction extends ConfirmAction<QueryForm>
     {
         @Override
         public void validateCommand(QueryForm form, Errors errors)
         {
             Set<String> ids = DataRegionSelection.getSelected(form.getViewContext(), true);
-            if (ids.size() == 0)
+            if (ids.isEmpty())
             {
                 errors.reject(ERROR_MSG, "Must select at least one item to delete");
             }
@@ -175,7 +175,7 @@ public class EHR_BillingController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class UpdateQueryAction extends SimpleViewAction<QueryForm>
+    public static class UpdateQueryAction extends SimpleViewAction<QueryForm>
     {
         private QueryForm _form;
 

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingManager.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingManager.java
@@ -25,7 +25,6 @@ import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
-import org.labkey.api.ehr.EHRService;
 import org.labkey.api.exp.api.ExperimentService;
 import org.labkey.api.module.Module;
 import org.labkey.api.module.ModuleLoader;
@@ -48,7 +47,7 @@ import java.util.Map;
 
 public class EHR_BillingManager
 {
-    private static EHR_BillingManager _instance = new EHR_BillingManager();
+    private static final EHR_BillingManager _instance = new EHR_BillingManager();
     public static final String EHR_BillingContainerPropName = "BillingContainer";
 
     private EHR_BillingManager()
@@ -101,7 +100,7 @@ public class EHR_BillingManager
                 {
                     Map<String, Object> map = new CaseInsensitiveHashMap<>();
                     map.put("invoiceId", null);
-                    map = Table.update(user, miscCharges, map, objectid);
+                    Table.update(user, miscCharges, map, objectid);
                 }
 
                 TableSelector tsInvoiceRuns = new TableSelector(invoiceRuns, objectIdFilter, null);

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingUserSchema.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingUserSchema.java
@@ -18,7 +18,6 @@ package org.labkey.ehr_billing;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.User;

--- a/ehr_billing/src/org/labkey/ehr_billing/notification/BillingNotification.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/notification/BillingNotification.java
@@ -295,10 +295,10 @@ public class BillingNotification extends AbstractNotification
         TableInfo ti = qd.getTable(us, errors, true);
 
         Map<String, Object> params = new HashMap<>();
-        Long numDays = ((DateUtils.truncate(new Date(), Calendar.DATE).getTime() - start.getTimeInMillis()) / DateUtils.MILLIS_PER_DAY) + 1;
+        long numDays = ((DateUtils.truncate(new Date(), Calendar.DATE).getTime() - start.getTimeInMillis()) / DateUtils.MILLIS_PER_DAY) + 1;
         params.put("StartDate", start.getTime());
         params.put("EndDate", endDate.getTime());
-        params.put("NumDays", numDays.intValue());
+        params.put("NumDays", (int) numDays);
 
         Set<FieldKey> fieldKeys = new HashSet<>();
         for (ColumnInfo col : ti.getColumns())
@@ -319,7 +319,7 @@ public class BillingNotification extends AbstractNotification
         final double[] totalQuantity = {0.0}; // 1 element final array since 'final' is required in the below exec method
         final double[] totalCost = {0.0};// 1 element final array since 'final' is required in the below exec method
 
-        ts.forEach(new Selector.ForEachBlock<ResultSet>()
+        ts.forEach(new Selector.ForEachBlock<>()
         {
             @Override
             public void exec(ResultSet object) throws SQLException
@@ -327,7 +327,7 @@ public class BillingNotification extends AbstractNotification
                 Results rs = new ResultsImpl(object, cols);
 
                 Double unitCost = rs.getDouble(FieldKey.fromString("unitCost"));
-                Double quantity = rs.getDouble(FieldKey.fromString("quantity"));
+                double quantity = rs.getDouble(FieldKey.fromString("quantity"));
                 totalQuantity[0] += quantity;
                 totalCost[0] += (unitCost * quantity);
 

--- a/ehr_billing/src/org/labkey/ehr_billing/notification/BillingNotificationServiceImpl.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/notification/BillingNotificationServiceImpl.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 public class BillingNotificationServiceImpl extends BillingNotificationService
 {
-    private Map<String, BillingNotificationProvider> _billingNotificationProviders = new HashMap<>();
+    private final Map<String, BillingNotificationProvider> _billingNotificationProviders = new HashMap<>();
 
 
     @Override

--- a/ehr_billing/src/org/labkey/ehr_billing/pipeline/BillingTask.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/pipeline/BillingTask.java
@@ -494,7 +494,7 @@ public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
                     procedureRow.put("chargeId", chargeId);
 
                     // add additional charge info
-                    ChargeInfo ci = getChargeInfo(chargeId, chargeInfoArrayList, (Date) procedureRow.get("date"));
+                    ChargeInfo ci = getChargeInfo(chargeId, chargeInfoArrayList, procedureRow.get("date"));
                     procedureRow.put("item", ci.getItem());
                     procedureRow.put("category", ci.getCategory());
 
@@ -509,7 +509,7 @@ public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
                     // calculate total cost with additional/other rate (ex. tier rate for WNPRC)
                     Double otherRate = (Double) procedureRow.get("otherRate");
                     Double unitCostWithOtherRate;
-                    Double totalCostWithOtherRate;
+                    double totalCostWithOtherRate;
                     if (null != otherRate &&
                             null != processingService.getAdditionalUnitCostColName() &&
                             null != processingService.getAdditionalTotalCostColName())

--- a/ehr_billing/src/org/labkey/ehr_billing/query/EHRBillingTriggerHelper.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/query/EHRBillingTriggerHelper.java
@@ -41,9 +41,9 @@ import java.util.Map;
  */
 public class EHRBillingTriggerHelper
 {
-    private Container _container;
-    private User _user;
-    private Map<Integer, Map<String, Object>> _cachedCharges = new HashMap<>();
+    private final Container _container;
+    private final User _user;
+    private final Map<Integer, Map<String, Object>> _cachedCharges = new HashMap<>();
 
     public EHRBillingTriggerHelper(int userId, String containerId)
     {

--- a/snd/api-src/org/labkey/api/snd/Event.java
+++ b/snd/api-src/org/labkey/api/snd/Event.java
@@ -59,7 +59,7 @@ public class Event
     private String _objectId;
 
     // This will store a count of the different severity of exceptions
-    private Map<ValidationException.SEVERITY, Integer> _exceptionCount = new HashMap<>();
+    private final Map<ValidationException.SEVERITY, Integer> _exceptionCount = new HashMap<>();
     private ValidationException _eventException = null;
 
     public static final String EVENT_ID = "eventId";
@@ -428,7 +428,7 @@ public class Event
                 if (severity == null)
                     severity = ValidationException.SEVERITY.WARN;
 
-                if (msg.length() > 0)
+                if (!msg.isEmpty())
                     msg.append(", ");
 
                 msg.append(count + " warning");
@@ -442,7 +442,7 @@ public class Event
                 if (severity == null)
                     severity = ValidationException.SEVERITY.INFO;
 
-                if (msg.length() > 0)
+                if (!msg.isEmpty())
                     msg.append(", ");
 
                 msg.append(count + " info");
@@ -450,7 +450,7 @@ public class Event
                     msg.append("s");
             }
 
-            if (msg.length() > 0)
+            if (!msg.isEmpty())
             {
                 msg.append(" found");
 

--- a/snd/api-src/org/labkey/api/snd/EventNarrativeOption.java
+++ b/snd/api-src/org/labkey/api/snd/EventNarrativeOption.java
@@ -22,7 +22,7 @@ public enum EventNarrativeOption
     HTML_NARRATIVE("htmlNarrative"),
     REDACTED_HTML_NARRATIVE("redactedHtmlNarrative");
 
-    private String _key;
+    private final String _key;
 
     EventNarrativeOption(String key)
     {

--- a/snd/api-src/org/labkey/api/snd/EventTrigger.java
+++ b/snd/api-src/org/labkey/api/snd/EventTrigger.java
@@ -16,10 +16,8 @@
 package org.labkey.api.snd;
 
 import org.labkey.api.data.Container;
-import org.labkey.api.query.BatchValidationException;
 import org.labkey.api.security.User;
 
-import java.util.List;
 import java.util.Map;
 
 public interface EventTrigger

--- a/snd/api-src/org/labkey/api/snd/SNDDomainKind.java
+++ b/snd/api-src/org/labkey/api/snd/SNDDomainKind.java
@@ -17,9 +17,7 @@ package org.labkey.api.snd;
 
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.CoreSchema;
 import org.labkey.api.data.SQLFragment;
-import org.labkey.api.data.dialect.SqlDialect;
 import org.labkey.api.exp.property.Domain;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.query.ExtendedTableDomainKind;

--- a/snd/api-src/org/labkey/api/snd/SNDSequencer.java
+++ b/snd/api-src/org/labkey/api/snd/SNDSequencer.java
@@ -29,8 +29,8 @@ public enum SNDSequencer
     EVENTID ("org.labkey.snd.api.Event", 2000000),
     EVENTDATAID ("org.labkey.snd.api.EventData", 5000000);
 
-    private String sequenceName;
-    private int minId;
+    private final String sequenceName;
+    private final int minId;
 
     SNDSequencer(String name, int id)
     {

--- a/snd/api-src/org/labkey/api/snd/SuperPackage.java
+++ b/snd/api-src/org/labkey/api/snd/SuperPackage.java
@@ -26,7 +26,6 @@ import org.labkey.api.security.User;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.labkey.api.snd.Package.PKG_ATTRIBUTES;
 

--- a/snd/src/org/labkey/snd/SNDController.java
+++ b/snd/src/org/labkey/snd/SNDController.java
@@ -102,7 +102,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresLogin
-    public class BeginAction extends SimpleRedirectAction
+    public static class BeginAction extends SimpleRedirectAction<Object>
     {
         @Override
         public URLHelper getRedirectURL(Object o)
@@ -258,7 +258,7 @@ public class SNDController extends SpringActionController
 
                 superPackage.setRequired(false); // Top level super packages required is always false
 
-                if (null != jsonSubPackages && jsonSubPackages.length() > 0)
+                if (null != jsonSubPackages && !jsonSubPackages.isEmpty())
                 {
                     for (JSONObject jsonSubPackage : JsonUtil.toJSONObjectList(jsonSubPackages))
                     {
@@ -415,7 +415,7 @@ public class SNDController extends SpringActionController
             return new ApiSimpleResponse();
         }
 
-        private class SuperPackageInfo
+        private static class SuperPackageInfo
         {
             int _sortOrder;
             boolean _required;
@@ -460,7 +460,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(SNDPackageViewerPermission.class)
-    public class GetPackagesAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    public static class GetPackagesAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
         @Override
         public void validateForm(SimpleApiJsonForm form, Errors errors)
@@ -525,7 +525,7 @@ public class SNDController extends SpringActionController
                 }
 
                 SNDService sndService = SNDService.get();
-                if (ids.size() > 0 && sndService != null)
+                if (!ids.isEmpty() && sndService != null)
                 {
                     pkgs.addAll(sndService.getPackages(getViewContext().getContainer(), getUser(), ids,
                             includeExtraFields, includeLookups, includeFullSubpackages));
@@ -576,7 +576,7 @@ public class SNDController extends SpringActionController
                 errors.reject(ERROR_MSG, "Missing referenceId.");
             }
 
-            if (!json.has("startDate") || json.getString("startDate") == null || json.getString("startDate").equals(""))
+            if (!json.has("startDate") || json.getString("startDate") == null || json.getString("startDate").isEmpty())
             {
                 errors.reject(ERROR_MSG, "Missing startDate.");
             }
@@ -627,7 +627,7 @@ public class SNDController extends SpringActionController
                 }
             }
 
-            if (json.has("endDate") && (json.isNull("endDate") || json.getString("endDate").equals("")))
+            if (json.has("endDate") && (json.isNull("endDate") || json.getString("endDate").isEmpty()))
             {
                 json.remove("endDate");
             }
@@ -733,7 +733,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(SNDProjectViewerPermission.class)
-    public class GetProjectAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    public static class GetProjectAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
         @Override
         public void validateForm(SimpleApiJsonForm form, Errors errors)
@@ -789,7 +789,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class GetEventAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    public static class GetEventAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
         @Override
         public void validateForm(SimpleApiJsonForm form, Errors errors)
@@ -1063,7 +1063,7 @@ public class SNDController extends SpringActionController
         {
             List<EventData> eventDataList = new ArrayList<>();
 
-            if ((eventDataJson != null) && (eventDataJson.length() > 0))
+            if ((eventDataJson != null) && (!eventDataJson.isEmpty()))
             {
                 for (int i = 0; i < eventDataJson.length(); i++)
                 {
@@ -1113,7 +1113,7 @@ public class SNDController extends SpringActionController
         {
             List<AttributeData> attributesDataList = new ArrayList<>();
 
-            if ((attributesDataJson != null) && (attributesDataJson.length() > 0))
+            if ((attributesDataJson != null) && (!attributesDataJson.isEmpty()))
             {
                 String propertyName = null;
                 int propertyId = -1;
@@ -1152,7 +1152,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class RegisterTestTriggerFactoryAction extends ReadOnlyApiAction<SimpleApiJsonForm>
+    public static class RegisterTestTriggerFactoryAction extends ReadOnlyApiAction<SimpleApiJsonForm>
     {
         @Override
         public Object execute(SimpleApiJsonForm form, BindException errors)
@@ -1191,7 +1191,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class ClearNarrativeCacheAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class ClearNarrativeCacheAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public Object execute(SimpleApiJsonForm form, BindException errors)
@@ -1202,7 +1202,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class FillInNarrativeCacheAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class FillInNarrativeCacheAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public Object execute(SimpleApiJsonForm form, BindException errors)
@@ -1213,7 +1213,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class PopulateQCStatesAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class PopulateQCStatesAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public Object execute(SimpleApiJsonForm form, BindException errors)
@@ -1225,7 +1225,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class SecurityAction extends SimpleViewAction
+    public static class SecurityAction extends SimpleViewAction
     {
 
         @Override
@@ -1271,7 +1271,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class AdminAction extends SimpleViewAction
+    public static class AdminAction extends SimpleViewAction<Object>
     {
 
         @Override
@@ -1292,7 +1292,7 @@ public class SNDController extends SpringActionController
     }
 
     @RequiresPermission(AdminPermission.class)
-    public class UpdateRoleAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class UpdateRoleAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public Object execute(SimpleApiJsonForm form, BindException errors)

--- a/snd/src/org/labkey/snd/SNDManager.java
+++ b/snd/src/org/labkey/snd/SNDManager.java
@@ -68,7 +68,6 @@ import org.labkey.api.query.ValidationException;
 import org.labkey.api.security.User;
 import org.labkey.api.security.roles.FolderAdminRole;
 import org.labkey.api.security.roles.RoleManager;
-import org.labkey.api.settings.AppProps;
 import org.labkey.api.settings.LookAndFeelProperties;
 import org.labkey.api.snd.AttributeData;
 import org.labkey.api.snd.Category;
@@ -122,7 +121,7 @@ public class SNDManager
 
     private final Cache<String, Map<String, Map<String, Object>>> _cache;
 
-    private List<TableInfo> _attributeLookups = new ArrayList<>();
+    private final List<TableInfo> _attributeLookups = new ArrayList<>();
 
     public static final String RANGE_PARTICIPANTID = "ParticipantId";
 
@@ -262,7 +261,7 @@ public class SNDManager
             throw new RuntimeException(e);
         }
 
-        if (rows == null || rows.size() < 1)
+        if (rows == null || rows.isEmpty())
             return null;
 
         return rows.get(0).get(tableInfo.getTitleColumn());
@@ -297,7 +296,7 @@ public class SNDManager
         SqlSelector selector = new SqlSelector(userSchema.getDbSchema(), sql);
         List<Object> lookupRows = selector.getArrayList(Object.class);
 
-        if (lookupRows.size() < 1)
+        if (lookupRows.isEmpty())
             return null;
 
         return lookupRows.get(0);
@@ -573,11 +572,6 @@ public class SNDManager
      * Return a cached map of Package Categories by PkgId
      * If pkgIds is not null, get for list of pkgIds, else get for entire database.
      *
-     * @param c
-     * @param u
-     * @param pkgIds
-     * @param errors
-     * @return
      */
     private Map<Integer, Map<Integer, String>> getBulkPackageCategories(Container c, User u, @Nullable List<Integer> pkgIds, BatchValidationException errors)
     {
@@ -657,10 +651,6 @@ public class SNDManager
 
     /**
      * Retrieve extensible fields as an argument and add them as extraFields to pkg object
-     * @param pkg
-     * @param extraFields
-     * @param row
-     * @return
      */
     public Package addExtraFieldsToPackage(Package pkg, List<GWTPropertyDescriptor> extraFields, @Nullable Map<String, Object> row)
     {
@@ -714,7 +704,7 @@ public class SNDManager
         sql.append(" WHERE sp.PkgId = ?").add(packageId);
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        if (selector.getArrayList(SuperPackage.class).size() > 0)
+        if (!selector.getArrayList(SuperPackage.class).isEmpty())
             return selector.getArrayList(Integer.class);
         else
             return null;
@@ -755,7 +745,7 @@ public class SNDManager
         sql.append(")");
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        if (selector.getArrayList(SuperPackage.class).size() > 0)
+        if (!selector.getArrayList(SuperPackage.class).isEmpty())
             return selector.getArrayList(SuperPackage.class);
         else
             return null;
@@ -780,7 +770,7 @@ public class SNDManager
         sql.append(") AND sp2.ParentSuperPkgId IS NULL");
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        if (selector.getArrayList(SuperPackage.class).size() > 0)
+        if (!selector.getArrayList(SuperPackage.class).isEmpty())
             return selector.getArrayList(SuperPackage.class);
         else
             return null;
@@ -792,7 +782,7 @@ public class SNDManager
     @Nullable
     public static List<SuperPackage> filterTopLevelSuperPkgs(Container c, User u, List<Integer> superPackageIds)
     {
-        if ((superPackageIds == null) || (superPackageIds.size() == 0))
+        if ((superPackageIds == null) || (superPackageIds.isEmpty()))
             return null;
 
         UserSchema schema = getSndUserSchema(c, u);
@@ -804,7 +794,7 @@ public class SNDManager
         sql.append(") AND sp.ParentSuperPkgId IS NULL");
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        if (selector.getArrayList(SuperPackage.class).size() > 0)
+        if (!selector.getArrayList(SuperPackage.class).isEmpty())
             return selector.getArrayList(SuperPackage.class);
         else
             return null;
@@ -823,7 +813,7 @@ public class SNDManager
         sql.append(" WHERE sp.ParentSuperPkgId = ?").add(parentSuperPackageId);
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        if (selector.getArrayList(Integer.class).size() > 0)
+        if (!selector.getArrayList(Integer.class).isEmpty())
             return selector.getArrayList(SuperPackage.class);
         else
             return null;
@@ -835,7 +825,7 @@ public class SNDManager
     @Nullable
     public static List<SuperPackage> filterChildSuperPkgs(Container c, User u, List<Integer> superPackageIds, Integer parentSuperPackageId)
     {
-        if ((superPackageIds == null) || (superPackageIds.size() == 0))
+        if ((superPackageIds == null) || (superPackageIds.isEmpty()))
             return null;
 
         UserSchema schema = getSndUserSchema(c, u);
@@ -847,7 +837,7 @@ public class SNDManager
         sql.append(") AND sp.ParentSuperPkgId = ?").add(parentSuperPackageId);
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        if (selector.getArrayList(SuperPackage.class).size() > 0)
+        if (!selector.getArrayList(SuperPackage.class).isEmpty())
             return selector.getArrayList(SuperPackage.class);
         else
             return null;
@@ -864,7 +854,7 @@ public class SNDManager
         SQLFragment sql = new SQLFragment("SELECT sp.SuperPkgId FROM ");
         sql.append(schema.getTable(SNDSchema.SUPERPKGS_TABLE_NAME), "sp");
         sql.append(" WHERE");
-        if ((superPackages != null) && (superPackages.size() > 0))
+        if ((superPackages != null) && (!superPackages.isEmpty()))
         {
             sql.append(" sp.SuperPkgId NOT IN (");
             Iterator<SuperPackage> superPackageIterator = superPackages.iterator();
@@ -881,7 +871,7 @@ public class SNDManager
         sql.append(" sp.ParentSuperPkgId = ?").add(parentSuperPackageId);
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        if (selector.getArrayList(Integer.class).size() > 0)
+        if (!selector.getArrayList(Integer.class).isEmpty())
             return selector.getArrayList(Integer.class);
         else
             return null;
@@ -952,7 +942,7 @@ public class SNDManager
             List<Integer> pkgIds = new ArrayList<>();
             pkgIds.add(superPackage.getPkgId());
             List<Package> pkgs = getPackages(c, u, pkgIds, true, true, true, errors);
-            if (pkgs.size() > 0)
+            if (!pkgs.isEmpty())
             {
                 superPackage.setPkg(pkgs.get(0));
             }
@@ -1115,19 +1105,6 @@ public class SNDManager
 
     /**
      * Does same as createPackage but retrieves superPackage and package info from cached map objects from arguments instead of database queries
-     * @param c
-     * @param u
-     * @param row
-     * @param packageExtraFields
-     * @param superPackages
-     * @param childrenByParentId
-     * @param pkgCategoriesByPkgId
-     * @param lookups
-     * @param includeExtraFields
-     * @param includeLookups
-     * @param includeFullSubpackages
-     * @param errors
-     * @return
      */
     private Package getBulkPackage(Container c, User u, Map<String, Object> row, List<GWTPropertyDescriptor> packageExtraFields,
                                  List<SuperPackage> superPackages, Map<Integer, List<SuperPackage>> childrenByParentId,
@@ -1216,20 +1193,6 @@ public class SNDManager
 
     /**
      * Does same as getPackages but retrieves the superPackage and package info from cached object maps instead of database queries
-     * @param c
-     * @param u
-     * @param pkgIds
-     * @param pkgQus
-     * @param packageExtraFields
-     * @param superPackages
-     * @param childrenByParentId
-     * @param pkgCategoriesByPkgId
-     * @param lookups
-     * @param includeExtraFields
-     * @param includeLookups
-     * @param includeFullSubpackages
-     * @param errors
-     * @return
      */
     public List<Package> getBulkPackages(Container c, User u, List<Integer> pkgIds, QueryUpdateService pkgQus,
                                          List<GWTPropertyDescriptor> packageExtraFields, List<SuperPackage> superPackages,
@@ -1396,7 +1359,7 @@ public class SNDManager
                     rows.add(r);
                 }
 
-                if (rows.size() > 0)
+                if (!rows.isEmpty())
                 {
                     Map<String, Object> row = rows.get(0);
                     if ((Integer) row.get("ReferenceId") != project.getReferenceId() && Boolean.parseBoolean((String) row.get("HasEvent")))
@@ -1426,7 +1389,7 @@ public class SNDManager
                     rows.add(r);
                 }
 
-                if (rows.size() > 0)
+                if (!rows.isEmpty())
                 {
                     for (Map<String, Object> row : rows)
                     {
@@ -1954,7 +1917,7 @@ public class SNDManager
         TableInfo eventDataTable = getTableInfo(schema, SNDSchema.EVENTDATA_TABLE_NAME);
 
         Map<String, ObjectProperty> properties = null;
-        EventData eventData = null;
+        EventData eventData;
         TableSelector ts = null;
 
         // Get from EventData table
@@ -2287,12 +2250,12 @@ public class SNDManager
                     SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
                     List<String> results = selector.getArrayList(String.class);
-                    if (results.size() < 1)
+                    if (results.isEmpty())
                     {
                         event.setException(new ValidationException("Project|revision not found: " + event.getProjectIdRev()));
                     }
 
-                    return results.size() > 0 ? results.get(0) : null;
+                    return !results.isEmpty() ? results.get(0) : null;
                 }
             }
         }
@@ -2546,7 +2509,7 @@ public class SNDManager
                 // Validate first to catch validation errors.  Relying on exception thrown in insertProperties creates issues
                 // with nested transactions containing a lock.
                 List<ValidationException> validationExceptions = validateProperty(c, u, propertyDescriptor, objectProperty);
-                if (validationExceptions.size() > 0)
+                if (!validationExceptions.isEmpty())
                 {
                     attributeData.setException(event, validationExceptions.get(0)); // just handling on exception
                 }
@@ -2629,7 +2592,7 @@ public class SNDManager
             event.setException(new ValidationException("Project is not found."));
         }
 
-        if (!event.hasErrors() && event.getEventData() != null && event.getEventData().size() > 0)
+        if (!event.hasErrors() && event.getEventData() != null && !event.getEventData().isEmpty())
         {
             UserSchema schema = getSndUserSchema(c, u);
 
@@ -2697,7 +2660,7 @@ public class SNDManager
         Map<AttributeData, Boolean> incomingProps = Maps.newHashMap();
         boolean found;
 
-        if (attributes.size() > 0)
+        if (!attributes.isEmpty())
         {
             for (AttributeData attribute : attributes)
             {
@@ -2825,7 +2788,7 @@ public class SNDManager
                                 QueryUpdateService eventNotesQus = null;
 
                                 // make sure there is an event note to insert - event notes are optional - trim spaces
-                                if (event.getEventNotesRow(c).containsKey("note") && event.getEventNotesRow(c).get("note") != null && event.getEventNotesRow(c).get("note").toString().trim().length() > 0)
+                                if (event.getEventNotesRow(c).containsKey("note") && event.getEventNotesRow(c).get("note") != null && !event.getEventNotesRow(c).get("note").toString().trim().isEmpty())
                                     eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
 
                                 try (DbScope.Transaction tx = eventTable.getSchema().getScope().ensureTransaction())
@@ -3029,7 +2992,7 @@ public class SNDManager
                                 QueryUpdateService eventNotesQus = null;
 
                                 // make sure there is an event note to insert - event notes are optional - trim spaces
-                                if (event.getEventNotesRow(c).containsKey("note") && event.getEventNotesRow(c).get("note") != null && event.getEventNotesRow(c).get("note").toString().trim().length() > 0)
+                                if (event.getEventNotesRow(c).containsKey("note") && event.getEventNotesRow(c).get("note") != null && !event.getEventNotesRow(c).get("note").toString().trim().isEmpty())
                                     eventNotesQus = getNewQueryUpdateService(schema, SNDSchema.EVENTNOTES_TABLE_NAME);
 
                                 QueryUpdateService eventsCacheQus = getNewQueryUpdateService(schema, SNDSchema.EVENTSCACHE_TABLE_NAME);
@@ -3089,7 +3052,7 @@ public class SNDManager
     /* deletes and updates cached narratives */
     public int updateNarrativeCache(Container container, User user, Set<Integer>cacheData, @NotNull Logger log, boolean isUpdate)
     {
-        if (cacheData.size() > 0)
+        if (!cacheData.isEmpty())
         {
             log.info("Deleting affected narrative cache rows.");
             List<Map<String, Object>> rows = new ArrayList<>();
@@ -3651,7 +3614,7 @@ public class SNDManager
 
             Map<GWTPropertyDescriptor, Object> extraFields = project.getExtraFields();
 
-            if (extraFields.size() > 0)
+            if (!extraFields.isEmpty())
             {
                 for (Map.Entry<GWTPropertyDescriptor, Object> pd : extraFields.entrySet())
                 {
@@ -3693,7 +3656,7 @@ public class SNDManager
             // add projectItems
             List<Map<String, Object>> pItems = getProjectItemsList(c, u, project.getProjectId(), project.getRevisionNum(), eventDate == null ? activeProjectItemsOnly : false);
 
-            if (pItems.size() > 0)
+            if (!pItems.isEmpty())
             {
                 projectMap.put("ProjectItems", pItems);
             }
@@ -3952,7 +3915,7 @@ public class SNDManager
         List<SuperPackage> fullTreeSuperPkgs;
 
         if (!isFullReload) {
-            fullTreeSuperPkgs = new ArrayList<SuperPackage>();
+            fullTreeSuperPkgs = new ArrayList<>();
             pkgIds.forEach(pkgId -> {
                 SQLFragment packageSql = new SQLFragment("SELECT * FROM ");
                 packageSql.append(SNDSchema.NAME + "." + SNDSchema.SUPERPKGS_FUNCTION_NAME + "(?)").add(pkgId);
@@ -4315,10 +4278,6 @@ public class SNDManager
     /**
      * Query EventNotes table for set of eventIds
      *
-     * @param c
-     * @param u
-     * @param eventIds
-     * @return
      */
     private Map<Integer, String> getBulkEventNotes(Container c, User u, List<Integer> eventIds) {
 
@@ -4340,10 +4299,6 @@ public class SNDManager
     /**
      * Query the Projects table and retrieve the ID concatenated with RevisionNum for a set of objectIds
      *
-     * @param c
-     * @param u
-     * @param objectIds
-     * @return
      */
     private Map<String, String> getBulkProjectIdRevs(Container c, User u, List<String> objectIds) {
 
@@ -4366,14 +4321,6 @@ public class SNDManager
     /**
      * Create a TableSelector object to query a table
      *
-     * @param c
-     * @param u
-     * @param filterValues
-     * @param tableName
-     * @param filterColumn
-     * @param sortColumn
-     * @param isNullColumn
-     * @return
      */
     public <T> TableSelector getTableSelector(Container c, User u, List<T> filterValues, String tableName, String filterColumn, String sortColumn, String isNullColumn) {
 

--- a/snd/src/org/labkey/snd/SNDServiceImpl.java
+++ b/snd/src/org/labkey/snd/SNDServiceImpl.java
@@ -354,7 +354,7 @@ public class SNDServiceImpl implements SNDService
                 if ((event.getEventData() == null || event.getEventData().isEmpty()) &&
                         (!event.getEventNotesRow(c).containsKey("note") ||
                                 event.getEventNotesRow(c).get("note") == null ||
-                                event.getEventNotesRow(c).get("note").toString().trim().length() == 0))
+                                event.getEventNotesRow(c).get("note").toString().trim().isEmpty()))
                 {
                     event = SNDManager.get().deleteEvent(c, u, event);
                 }

--- a/snd/src/org/labkey/snd/query/AttributeDataTable.java
+++ b/snd/src/org/labkey/snd/query/AttributeDataTable.java
@@ -221,7 +221,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
             catch (ValidationException e)
             {
                 logger.error(e.getMessage() + " PkgId " + pkgId, e);
-                throw new UnexpectedException(e, e.getMessage() + "For PkgId: " + pkgId + ".\n");
+                throw UnexpectedException.wrap(e, e.getMessage() + "For PkgId: " + pkgId + ".\n");
             }
 
             return inserted;
@@ -341,7 +341,7 @@ public class AttributeDataTable extends FilteredTable<SNDUserSchema>
                 }
             }
 
-            if (prevObjProps.size() > 0 && pkgId != null)
+            if (!prevObjProps.isEmpty() && pkgId != null)
             {
                 inserted = insertObject(container, user, prevUri, prevObjProps, pkgId, inserted, logger);
             }

--- a/snd/src/org/labkey/snd/query/CategoriesTable.java
+++ b/snd/src/org/labkey/snd/query/CategoriesTable.java
@@ -53,8 +53,6 @@ public class CategoriesTable extends SimpleTable<SNDUserSchema>
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public CategoriesTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
     {

--- a/snd/src/org/labkey/snd/query/EventDataTable.java
+++ b/snd/src/org/labkey/snd/query/EventDataTable.java
@@ -59,14 +59,13 @@ public class EventDataTable extends AbstractSNDTableInfo
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public EventDataTable(SNDUserSchema schema, TableInfo table)
     {
         super(schema, table);
     }
 
+    @Override
     public void addColumns()
     {
         BaseColumnInfo objectid = new BaseColumnInfo("ObjectId", this, JdbcType.INTEGER)
@@ -104,10 +103,10 @@ public class EventDataTable extends AbstractSNDTableInfo
     @Override
     public QueryUpdateService getUpdateService()
     {
-        return new EventDataTable.UpdateService(this);
+        return new UpdateService(this);
     }
 
-    protected class UpdateService extends SNDQueryUpdateService
+    protected static class UpdateService extends SNDQueryUpdateService
     {
         private final SNDManager _sndManager = SNDManager.get();
         private final SNDService _sndService = SNDService.get();
@@ -184,7 +183,7 @@ public class EventDataTable extends AbstractSNDTableInfo
             log.info("End updating exp.Object table. Updated total of " + count + " rows.");
 
             int rowCount = 0;
-            if(data.size() > 0 && null != data.get(0))
+            if(!data.isEmpty() && null != data.get(0))
             {
                 DataIteratorBuilder rowsWithObjectURI = new ListofMapsDataIterator.Builder(data.get(0).keySet(), data);
                 rowCount = _importRowsUsingDIB(user, container, rowsWithObjectURI, null, dataIteratorContext, extraScriptContext);

--- a/snd/src/org/labkey/snd/query/EventNotesDataIterator.java
+++ b/snd/src/org/labkey/snd/query/EventNotesDataIterator.java
@@ -22,12 +22,12 @@ public class EventNotesDataIterator extends AbstractDataIterator
 {
     private static final SNDManager _sndManager = SNDManager.get();
     private static final String EVENT_ID_COL = "eventId";
-    private User _user;
-    private Container _container;
-    private int _eventIdColIndex;
-    private Set<Integer> _eventIds = new HashSet<>();
-    private DataIterator _in;
-    private Logger log = LogHelper.getLogger(EventNotesDataIterator.class, "Fill out event notes");
+    private final User _user;
+    private final Container _container;
+    private final int _eventIdColIndex;
+    private final Set<Integer> _eventIds = new HashSet<>();
+    private final DataIterator _in;
+    private final Logger log = LogHelper.getLogger(EventNotesDataIterator.class, "Fill out event notes");
 
     public static DataIterator wrap(DataIterator in, DataIteratorContext context, Container c, User u)
     {

--- a/snd/src/org/labkey/snd/query/EventNotesTable.java
+++ b/snd/src/org/labkey/snd/query/EventNotesTable.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
 import org.labkey.api.dataiterator.DataIteratorContext;
@@ -46,8 +45,6 @@ public class EventNotesTable extends AbstractSNDTableInfo
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public EventNotesTable(SNDUserSchema schema, TableInfo table)
     {
@@ -57,10 +54,10 @@ public class EventNotesTable extends AbstractSNDTableInfo
     @Override
     public QueryUpdateService getUpdateService()
     {
-        return new EventNotesTable.UpdateService(this);
+        return new UpdateService(this);
     }
 
-    protected class UpdateService extends SNDQueryUpdateService
+    protected static class UpdateService extends SNDQueryUpdateService
     {
         public UpdateService(SimpleUserSchema.SimpleTable ti)
         {

--- a/snd/src/org/labkey/snd/query/EventsCacheTable.java
+++ b/snd/src/org/labkey/snd/query/EventsCacheTable.java
@@ -16,11 +16,9 @@
 package org.labkey.snd.query;
 
 import org.jetbrains.annotations.NotNull;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryUpdateService;
-import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 import org.labkey.snd.SNDUserSchema;
@@ -36,8 +34,6 @@ public class EventsCacheTable extends AbstractSNDTableInfo
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public EventsCacheTable(SNDUserSchema schema, TableInfo table)
     {

--- a/snd/src/org/labkey/snd/query/EventsTable.java
+++ b/snd/src/org/labkey/snd/query/EventsTable.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.dataiterator.DataIteratorBuilder;
@@ -59,8 +58,6 @@ public class EventsTable extends AbstractSNDTableInfo
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     private final SNDManager _sndManager = SNDManager.get();
 
@@ -145,7 +142,7 @@ public class EventsTable extends AbstractSNDTableInfo
 
             Set<Integer> eventIds = handleNarrativeCache(rows, configParameters, errors);
 
-            int result = 0;
+            int result;
             int maxMergeRows = SNDManager.MAX_MERGE_ROWS * 10;
 
             // Large merge triggers importRows path

--- a/snd/src/org/labkey/snd/query/LookupSetsTable.java
+++ b/snd/src/org/labkey/snd/query/LookupSetsTable.java
@@ -15,8 +15,6 @@ public class LookupSetsTable extends SimpleTable<SNDUserSchema> {
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public LookupSetsTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf) { super(schema, table, cf); }
 

--- a/snd/src/org/labkey/snd/query/LookupSetsVirtualTable.java
+++ b/snd/src/org/labkey/snd/query/LookupSetsVirtualTable.java
@@ -18,12 +18,8 @@ package org.labkey.snd.query;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
-import org.labkey.api.data.JdbcType;
-import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.TableInfo;
-import org.labkey.api.query.ExprColumn;
 import org.labkey.api.query.SimpleUserSchema.SimpleTable;
-import org.labkey.snd.SNDSchema;
 import org.labkey.snd.SNDUserSchema;
 
 import java.util.Map;
@@ -38,7 +34,7 @@ public class LookupSetsVirtualTable extends SimpleTable<SNDUserSchema>
     private static final String LABEL_COL = "Label";
     private static final String DESCRIPTION_COL = "Description";
     private static final String LOOKUPSETID_COL = "LookupSetId";
-    private Integer _lookupSetId;
+    private final Integer _lookupSetId;
 
 
     public LookupSetsVirtualTable(SNDUserSchema schema, TableInfo table, String setName, Map<String, Object> map, ContainerFilter cf)

--- a/snd/src/org/labkey/snd/query/LookupsTable.java
+++ b/snd/src/org/labkey/snd/query/LookupsTable.java
@@ -45,8 +45,6 @@ public class LookupsTable extends SimpleTable<SNDUserSchema>
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public LookupsTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
     {
@@ -81,10 +79,10 @@ public class LookupsTable extends SimpleTable<SNDUserSchema>
     @Override
     public QueryUpdateService getUpdateService()
     {
-        return new LookupsTable.UpdateService(this);
+        return new UpdateService(this);
     }
 
-    protected class UpdateService extends SNDQueryUpdateService
+    protected static class UpdateService extends SNDQueryUpdateService
     {
         public UpdateService(SimpleTable ti)
         {

--- a/snd/src/org/labkey/snd/query/PackagesTable.java
+++ b/snd/src/org/labkey/snd/query/PackagesTable.java
@@ -69,8 +69,6 @@ public class PackagesTable extends AbstractSNDTableInfo
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public PackagesTable(SNDUserSchema schema, TableInfo table)
     {

--- a/snd/src/org/labkey/snd/query/ProjectsTable.java
+++ b/snd/src/org/labkey/snd/query/ProjectsTable.java
@@ -53,8 +53,6 @@ public class ProjectsTable extends SimpleTable<SNDUserSchema>
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public ProjectsTable(SNDUserSchema schema, TableInfo table, ContainerFilter cf)
     {

--- a/snd/src/org/labkey/snd/query/SuperPackagesTable.java
+++ b/snd/src/org/labkey/snd/query/SuperPackagesTable.java
@@ -17,7 +17,6 @@ package org.labkey.snd.query;
 
 import org.jetbrains.annotations.NotNull;
 import org.labkey.api.data.Container;
-import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.JdbcType;
 import org.labkey.api.data.SQLFragment;
 import org.labkey.api.data.SimpleFilter;
@@ -57,8 +56,6 @@ public class SuperPackagesTable extends AbstractSNDTableInfo
      * Create the simple table.
      * SimpleTable doesn't add columns until .init() has been called to allow derived classes to fully initialize themselves before adding columns.
      *
-     * @param schema
-     * @param table
      */
     public SuperPackagesTable(SNDUserSchema schema, TableInfo table)
     {

--- a/snd/src/org/labkey/snd/security/QCStateActionEnum.java
+++ b/snd/src/org/labkey/snd/security/QCStateActionEnum.java
@@ -46,8 +46,8 @@ public enum QCStateActionEnum
     DELETE("Delete", new SNDCompletedDeletePermission(), new SNDInProgressDeletePermission(), new SNDRejectedDeletePermission(), new SNDReviewRequiredDeletePermission()),
     READ("Read", new SNDCompletedReadPermission(), new SNDInProgressReadPermission(), new SNDRejectedReadPermission(), new SNDReviewRequiredReadPermission());
 
-    private List<SNDQCStatePermission> _permissions = new ArrayList<>();
-    private String _name;
+    private final List<SNDQCStatePermission> _permissions = new ArrayList<>();
+    private final String _name;
 
     QCStateActionEnum(String name, SNDQCStatePermission... perms)
     {

--- a/snd/src/org/labkey/snd/security/permissions/SNDQCStatePermission.java
+++ b/snd/src/org/labkey/snd/security/permissions/SNDQCStatePermission.java
@@ -21,7 +21,7 @@ import org.labkey.snd.SNDModule;
 
 public class SNDQCStatePermission extends AbstractPermission
 {
-    private QCStateEnum _qcState;
+    private final QCStateEnum _qcState;
 
     SNDQCStatePermission(String name, String description, QCStateEnum qcState)
     {

--- a/snd/src/org/labkey/snd/trigger/SNDTriggerManager.java
+++ b/snd/src/org/labkey/snd/trigger/SNDTriggerManager.java
@@ -46,7 +46,7 @@ public class SNDTriggerManager
         return _instance;
     }
 
-    private Map<Module, EventTriggerFactory> _eventTriggerFactories = new HashMap<>();
+    private final Map<Module, EventTriggerFactory> _eventTriggerFactories = new HashMap<>();
 
     /**
      * Called from SNDService to allow event trigger factories to be registered.  These will be queried for category
@@ -169,7 +169,7 @@ public class SNDTriggerManager
         List<EventTriggerFactory> factories = getTriggerFactories(c);
 
         // Nothing to do
-        if (factories.size() < 1)
+        if (factories.isEmpty())
             return;
 
         List<TriggerAction> triggerActions = getTriggerActions(event, topLevelEventDataPkgs, factories);
@@ -189,7 +189,7 @@ public class SNDTriggerManager
         List<EventTriggerFactory> factories = getTriggerFactories(c);
 
         // Nothing to do
-        if (factories.size() < 1)
+        if (factories.isEmpty())
             return;
 
         List<TriggerAction> triggers = getTriggerActions(event, topLevelEventDataSuperPkgs, factories);

--- a/snd/src/org/labkey/snd/trigger/test/triggers/CalciumTestTrigger.java
+++ b/snd/src/org/labkey/snd/trigger/test/triggers/CalciumTestTrigger.java
@@ -38,7 +38,7 @@ public class CalciumTestTrigger implements EventTrigger
         AttributeData unitsAttribute = TriggerHelper.getAttribute("units", eventData, pkg);
         String amountValue = amountAttribute.getValue();
         String unitsValue = unitsAttribute.getValue();
-        Double newAmountValue = Double.parseDouble(amountValue);
+        double newAmountValue = Double.parseDouble(amountValue);
 
         if (unitsValue != null && amountValue != null)
         {

--- a/snd/src/org/labkey/snd/trigger/test/triggers/ChlorideTestTrigger.java
+++ b/snd/src/org/labkey/snd/trigger/test/triggers/ChlorideTestTrigger.java
@@ -39,7 +39,7 @@ public class ChlorideTestTrigger implements EventTrigger
         AttributeData unitsAttribute = TriggerHelper.getAttribute("units", eventData, pkg);
         String amountValue = amountAttribute.getValue();
         String unitsValue = unitsAttribute.getValue();
-        Double newAmountValue;
+        double newAmountValue;
 
         if (unitsValue != null && amountValue != null)
         {

--- a/snd/src/org/labkey/snd/trigger/test/triggers/TriggerHelper.java
+++ b/snd/src/org/labkey/snd/trigger/test/triggers/TriggerHelper.java
@@ -30,7 +30,7 @@ public class TriggerHelper
 {
     public static final String orderPropName = "triggerOrder";
 
-    private static Map<String, Integer> ELECTROLYTES_TRIGGER_ORDER = new HashMap<>();
+    private static final Map<String, Integer> ELECTROLYTES_TRIGGER_ORDER = new HashMap<>();
 
     static {
         ELECTROLYTES_TRIGGER_ORDER.put("Chloride Test Trigger", 0);

--- a/snd/test/src/org/labkey/test/components/snd/AttributeGridRow.java
+++ b/snd/test/src/org/labkey/test/components/snd/AttributeGridRow.java
@@ -69,7 +69,7 @@ public class AttributeGridRow extends WebDriverComponent<AttributeGridRow.Elemen
     public AttributeGridRow selectLookupKey(String key)
     {
         elementCache().lookupKeySelect.selectByVisibleText(key);
-        if (!key.equals(""))
+        if (!key.isEmpty())
         {
             getWrapper().waitForElement(elementCache().DEFAULT_VALUE_SELECT);
         }
@@ -205,7 +205,7 @@ public class AttributeGridRow extends WebDriverComponent<AttributeGridRow.Elemen
     public static class AttributeGridRowFinder extends WebDriverComponent.WebDriverComponentFinder<AttributeGridRow, AttributeGridRowFinder>
     {
         private Locator _locator;
-        private AttributesGrid _grid;
+        private final AttributesGrid _grid;
 
         private AttributeGridRowFinder(AttributesGrid grid)
         {

--- a/snd/test/src/org/labkey/test/pages/snd/EditCategoriesPage.java
+++ b/snd/test/src/org/labkey/test/pages/snd/EditCategoriesPage.java
@@ -15,14 +15,11 @@
  */
 package org.labkey.test.pages.snd;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.snd.CategoryEditRow;
 import org.labkey.test.pages.LabKeyPage;
-import org.labkey.test.selenium.LazyWebElement;
-import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 

--- a/snd/test/src/org/labkey/test/pages/snd/EditPackagePage.java
+++ b/snd/test/src/org/labkey/test/pages/snd/EditPackagePage.java
@@ -19,7 +19,6 @@ import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.components.html.Checkbox;
-import org.labkey.test.components.html.Input;
 import org.labkey.test.components.snd.AttributesGrid;
 import org.labkey.test.components.snd.FilterSelect;
 import org.labkey.test.components.snd.SuperPackageRow;
@@ -30,8 +29,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
-
-import static org.junit.Assert.assertTrue;
 
 public class EditPackagePage extends LabKeyPage<EditPackagePage.ElementCache>
 {

--- a/snd/test/src/org/labkey/test/pages/snd/PackageListPage.java
+++ b/snd/test/src/org/labkey/test/pages/snd/PackageListPage.java
@@ -18,7 +18,6 @@ package org.labkey.test.pages.snd;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.components.html.BootstrapMenu;
 import org.labkey.test.components.html.Checkbox;
 import org.labkey.test.components.html.Input;
 import org.labkey.test.components.snd.PackageViewerResult;

--- a/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
+++ b/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
@@ -219,7 +219,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         "    }                                                                  \n" +
         "})";
 
-    private static String SAVEPACKAGEAPI_CHILDREN = "LABKEY.Ajax.request({      \n" +
+    private static final String SAVEPACKAGEAPI_CHILDREN = "LABKEY.Ajax.request({      \n" +
         "       method: 'POST',                                                 \n" +
         "		url: LABKEY.ActionURL.buildURL('snd', 'savePackage.api'),       \n" +
         "		success: function(){ callback('Success!'); },                   \n" +
@@ -289,7 +289,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         "		}                                                               \n" +
         "	});";
 
-    private static String UPDATESUPERPACKAGEAPI_CHILDREN = "LABKEY.Ajax.request({\n" +
+    private static final String UPDATESUPERPACKAGEAPI_CHILDREN = "LABKEY.Ajax.request({\n" +
         "		method: 'POST',                                                 \n" +
         "		url: LABKEY.ActionURL.buildURL('snd', 'savePackage.api'),       \n" +
         "		success: function(){ callback('Success!'); },\n" +
@@ -368,7 +368,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         "		}                                                               \n" +
         "	});";
 
-    private static String UPDATESUPERPACKAGEAPI_CLONE = "LABKEY.Ajax.request({      \n" +
+    private static final String UPDATESUPERPACKAGEAPI_CLONE = "LABKEY.Ajax.request({      \n" +
             "		method: 'POST',                                                 \n" +
             "		url: LABKEY.ActionURL.buildURL('snd', 'savePackage.api'),       \n" +
             "		success: function(){ callback('Success!'); },                   \n" +
@@ -448,7 +448,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
             "		}                                                               \n" +
             "	});";
 
-    private static String UPDATESUPERPACKAGEAPI_NOCHILDREN = "LABKEY.Ajax.request({ \n" +
+    private static final String UPDATESUPERPACKAGEAPI_NOCHILDREN = "LABKEY.Ajax.request({ \n" +
             "		method: 'POST',                                                 \n" +
             "		url: LABKEY.ActionURL.buildURL('snd', 'savePackage.api'),       \n" +
             "		success: function(){ callback('Success!'); },                   \n" +
@@ -966,16 +966,16 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
         InsertRowsCommand command = new InsertRowsCommand("snd", "LookupSets");
         List<Map<String, Object>> lookupSetRows = Arrays.asList(
-                new HashMap<String, Object>(Maps.of("SetName", "SurgeryType",
+                new HashMap<>(Maps.of("SetName", "SurgeryType",
                         "Label", "Surgery Type",
                         "Description", "These are surgery types",
                         "ObjectId", UUID.randomUUID().toString())),
-                new HashMap<String, Object>(Maps.of("SetName", "BloodDrawType",
+                new HashMap<>(Maps.of("SetName", "BloodDrawType",
                         "ObjectId", UUID.randomUUID().toString())),
-                new HashMap<String, Object>(Maps.of("SetName", "GenderType",
+                new HashMap<>(Maps.of("SetName", "GenderType",
                         "Label", "Gender",
                         "ObjectId", UUID.randomUUID().toString())),
-                new HashMap<String, Object>(Maps.of("SetName", "VolumeUnitTypes",
+                new HashMap<>(Maps.of("SetName", "VolumeUnitTypes",
                         "Label", "Volume",
                         "Description", "Units of volume",
                         "ObjectId", UUID.randomUUID().toString())));
@@ -1475,7 +1475,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
         // create a new one via the UI
         catPage.addCategory(ourNewCategory, true);
-        catPage = catPage.clickSave();
+        catPage.clickSave();
         waitFor(()-> false, 2000);
 
         SelectRowsCommand catsCmd = new SelectRowsCommand("snd", "PkgCategories");
@@ -1572,7 +1572,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         insertRowsCommand.addRow(TEST1ROW2MAP);
         insertRowsCommand.addRow(TEST1ROW3MAP);
         SaveRowsResponse resp = insertRowsCommand.execute(cn, getProjectName() + "/" + TEST1SUBFOLDER);
-        assertEquals(resp.getRowsAffected().intValue(), 3);
+        assertEquals(3, resp.getRowsAffected().intValue());
 
         goToSchemaBrowser();
         selectQuery("snd", "Pkgs");
@@ -1592,7 +1592,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         UpdateRowsCommand updateRowsCommand = new UpdateRowsCommand("snd", "Pkgs");
         updateRowsCommand.addRow(TEST1ROW3AMAP);
         resp = updateRowsCommand.execute(cn, getProjectName() + "/" + TEST1SUBFOLDER);
-        assertEquals(resp.getRowsAffected().intValue(), 1);
+        assertEquals(1, resp.getRowsAffected().intValue());
 
         goToSchemaBrowser();
         selectQuery("snd", "Pkgs");
@@ -1604,7 +1604,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         DeleteRowsCommand deleteRowsCommand = new DeleteRowsCommand("snd", "Pkgs");
         deleteRowsCommand.addRow(TEST1ROW2MAP);
         resp = deleteRowsCommand.execute(cn, getProjectName() + "/" + TEST1SUBFOLDER);
-        assertEquals(resp.getRowsAffected().intValue(), 1);
+        assertEquals(1, resp.getRowsAffected().intValue());
 
         goToSchemaBrowser();
         selectQuery("snd", "Pkgs");
@@ -2119,7 +2119,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
     private String getPermissionTableValue(int row, int col)
     {
         List<WebElement> els = ((Locator.XPathLocator)getSimpleTableCell(Locator.id("category-security"), row, col)).child("div").child("a").child("input").findElements(getDriver());
-        if (els.size() > 0)
+        if (!els.isEmpty())
         {
             return els.get(0).getAttribute("value");
         }
@@ -2130,7 +2130,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
     private void clickRoleInOpenDropDown(String name)
     {
         List<WebElement> els = Locator.tagWithClassContaining("div", "btn-group open").child("ul").child("li").child("a").withText(name).findElements(getDriver());
-        if (els.size() > 0)
+        if (!els.isEmpty())
         {
             els.get(0).click();
         }


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


