### PR TITLE
Avoid complaints about formularyMap when load fails

### DIFF
--- a/ehr/resources/web/ehr/DataEntryUtils.js
+++ b/ehr/resources/web/ehr/DataEntryUtils.js
@@ -734,8 +734,12 @@ EHR.DataEntryUtils = new function(){
                 autoLoad: true,
                 listeners: {
                     delay: 100,
-                    load: function(store){
-                        store.getFormularyMap();
+                    load: function(store, records, successful) {
+                        // Avoid logging complaints about an empty formulary when the browser navigates away mid-load
+                        // The store gives the user feedback already for 500 or similar errors from the server
+                        if (successful) {
+                            store.getFormularyMap();
+                        }
                     }
                 },
                 getFormularyRecords: function(code){


### PR DESCRIPTION
#### Rationale
We're getting intermittent but recurring test failures with logging like:

```
ERROR LogAction                2025-06-14T02:18:21,481     http-nio-8111-exec-6 : Assert true failed: Formulary is an empty map.
User: teamcity@labkey.test
ReferrerURL: http://localhost:8111/Johns%20Hopkins%20RAR/EHR/ehr-dataEntryForm.view?formType=medicationTreatment
Browser: Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0
Platform: Linux x86_64
```

It's happening because the browser is rapidly navigating away from the data entry page while the request to load the formulary is still loading. We can avoid processing the response when the request was interrupted/failed, as the store handles showing the user an error dialog in scenarios like 500 errors from the server.

#### Changes
* Only process the load when it was successful