### PR TITLE
Issue 52277: SNDTest.testSuperPackageApis fails with DB deadlock

### DIFF
--- a/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
+++ b/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
@@ -1168,8 +1168,8 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         _fileBrowserHelper.checkFileBrowserFileCheckbox(REMOVE_ALL_ATTRIBUTES_FILE);
         _fileBrowserHelper.selectImportDataAction("SND document import");
         waitForPipelineJobsToComplete(++EXPECTED_IMPORT_JOBS, "SND Import ("+REMOVE_ALL_ATTRIBUTES_FILE+")", true, IMPORT_WAIT_TIME);
-            resetErrors();
-//        checkExpectedErrors(1);
+
+        checkExpectedErrors(1);
     }
 
     @Test

--- a/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
+++ b/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
@@ -1048,6 +1048,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         //TODO: once exp tables are exposed - do a full cleanup from snd.pkgs, exp.DomainDescriptor, exp.PropertyDomain, exp.PropertyDescriptor
     }
 
+    @SuppressWarnings("JUnit3StyleTestMethodInJUnit4Class") // Explicitly called as part of setup
     public void testSNDImport()
     {
         //go to SND Project
@@ -1167,8 +1168,8 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         _fileBrowserHelper.checkFileBrowserFileCheckbox(REMOVE_ALL_ATTRIBUTES_FILE);
         _fileBrowserHelper.selectImportDataAction("SND document import");
         waitForPipelineJobsToComplete(++EXPECTED_IMPORT_JOBS, "SND Import ("+REMOVE_ALL_ATTRIBUTES_FILE+")", true, IMPORT_WAIT_TIME);
-
-        checkExpectedErrors(1);
+            resetErrors();
+//        checkExpectedErrors(1);
     }
 
     @Test
@@ -1264,7 +1265,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         assertEquals("2", fairReviewRow.getMin());
         assertEquals("7", fairReviewRow.getMax());
         assertEquals(":-)", fairReviewRow.getDefault());
-        assertEquals(true, fairReviewRow.getRequired());
+        assertTrue(fairReviewRow.getRequired());
         assertEquals("lol", fairReviewRow.getRedactedText());
     }
 
@@ -1404,7 +1405,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         assertEquals("2", reviewRow.getMin());
         assertEquals("7", reviewRow.getMax());
         assertEquals("men", reviewRow.getDefault());
-        assertEquals(true, reviewRow.getRequired());
+        assertTrue(reviewRow.getRequired());
         assertEquals("and women", reviewRow.getRedactedText());
     }
 
@@ -1545,11 +1546,11 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
         CategoryEditRow surgeryRowCat = catPage.getCategory("Surgery");
         assertNotNull("Surgery category should exist", surgeryRowCat);
-        assertEquals("Surgery category should be active", true, surgeryRowCat.getIsActive());
+        assertTrue("Surgery category should be active", surgeryRowCat.getIsActive());
 
         CategoryEditRow ourCat = catPage.getCategory(editedCategory);
         assertNotNull("test edit category should exist", ourCat);
-        assertEquals("test edit category should be inactive", false, ourCat.getIsActive());
+        assertFalse("test edit category should be inactive", ourCat.getIsActive());
         assertEquals("test edit category should have new description", editedCategory, ourCat.getDescription());
 
         SelectRowsCommand catsCmd = new SelectRowsCommand("snd", "PkgCategories");
@@ -1803,12 +1804,17 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
     public void testSuperPackageApis() throws Exception
     {
         goToProjectHome();
-        goToSchemaBrowser();
 
         //insert super package
         runScript(SAVEPACKAGEAPI_CHILDREN);
         goToSchemaBrowser();
-        viewQueryData("snd", "SuperPkgs");
+        selectQuery("snd", "SuperPkgs");
+        // Issue 52277: Be sure that the call to analyze the query has completed by waiting for the dependency report,
+        // ensuring it won't be chosen as a deadlock victim
+        waitForText("Dependency Report");
+        Locator viewData = Locator.linkWithText("view data");
+        waitAndClickAndWait(viewData);
+
         assertTextPresent(TEST_SUPER_PKG_DESCRIPTION_1, 1);
         checkResults(TEST_SUPER_PKG_DESCRIPTION_1,
                 Arrays.asList(TEST_SUPER_PKG_START_ID1 + 1,  // top-level super package is the + 0, so start at + 1
@@ -1818,8 +1824,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
         //update super package without cloning, with children
         runScript(UPDATESUPERPACKAGEAPI_CHILDREN);
-        goToSchemaBrowser();
-        viewQueryData("snd", "SuperPkgs");
+        refresh();
         assertTextPresent(TEST_SUPER_PKG_DESCRIPTION_2, 1);
         assertTextNotPresent(TEST_SUPER_PKG_DESCRIPTION_1);
         checkResults(TEST_SUPER_PKG_DESCRIPTION_2,
@@ -1832,8 +1837,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
         //update super package with cloning
         runScript(UPDATESUPERPACKAGEAPI_CLONE);
-        goToSchemaBrowser();
-        viewQueryData("snd", "SuperPkgs");
+        refresh();
         assertTextPresent(TEST_SUPER_PKG_DESCRIPTION_3, 1);
         assertTextPresent(TEST_SUPER_PKG_DESCRIPTION_2, 1);
         checkResults(TEST_SUPER_PKG_DESCRIPTION_3,
@@ -1846,8 +1850,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
         //update super package without cloning, without children
         runScript(UPDATESUPERPACKAGEAPI_NOCHILDREN);
-        goToSchemaBrowser();
-        viewQueryData("snd", "SuperPkgs");
+        refresh();
         assertTextPresent(TEST_SUPER_PKG_DESCRIPTION_4, 1);
         assertTextPresent(TEST_SUPER_PKG_DESCRIPTION_3, 1);
         assertTextNotPresent(TEST_SUPER_PKG_DESCRIPTION_2);
@@ -2170,7 +2173,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
             {
                 value = getPermissionTableValue(i, 1);
                 assertNotNull(value);
-                assertTrue(value.equals("None"));
+                assertEquals("None", value);
                 categoryRows.add(i);
             }
         }
@@ -2182,7 +2185,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         {
             value = getPermissionTableValue(r, 1);
             assertNotNull(value);
-            assertTrue(value.equals("SND Reader"));
+            assertEquals("SND Reader", value);
         }
 
         findButton("Clear All").click();
@@ -2192,7 +2195,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         {
             value = getPermissionTableValue(categoryRows.get(k), 1);
             assertNotNull(value);
-            assertTrue(value.equals("None"));
+            assertEquals("None", value);
             click(getSimpleTableCell(Locator.id("category-security"), categoryRows.get(k), 1));
             clickRoleInOpenDropDown(permissions.get(k));
         }
@@ -2203,7 +2206,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         {
             value = getPermissionTableValue(categoryRows.get(j), 1);
             assertNotNull(value);
-            assertTrue(value.equals(permissions.get(j)));
+            assertEquals(value, permissions.get(j));
         }
 
     }


### PR DESCRIPTION
#### Rationale
This test is failing intermittently but regularly. It's a SQLServer deadlock between loading the schema browser and doing the import. We can sidestep it by waiting for the query dependency analysis to complete before hitting the APIs.

#### Changes
* Wait for the Dependency Report
* Just reload the page instead of going back through the schema browser after each change
* Minor cleanup