### PR TITLE
Better handling of GeneticCalculationsImportTask cancels

### DIFF
--- a/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
+++ b/ehr/resources/web/ehr/panel/GeneticCalculationSettingsPanel.js
@@ -7,6 +7,7 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
     extend: 'Ext.panel.Panel',
 
     initComponent: function(){
+        Ext4.QuickTips.init();
         Ext4.apply(this, {
             //width: 550,
             border: false,
@@ -48,6 +49,15 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
                 fieldLabel: 'Hour Of Day',
                 itemId: 'hourOfDay',
                 width: 400
+            },{
+                xtype: 'numberfield',
+                hideTrigger: true,
+                fieldLabel: 'Day of Week',
+                itemId: 'dayOfWeek',
+                helpPopup: 'If provided, the job will run on the specified day of the week (1-7 or Sun-Sat). If blank, it will run each day.',
+                width: 400,
+                minValue: 1,
+                maxValue: 7
             },{
                 xtype: 'textfield',
                 fieldLabel: 'Container Path',
@@ -96,6 +106,7 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
         this.down('#isScheduled').setValue(results.isScheduled);
         this.down('#enabled').setValue(results.enabled);
         this.down('#hourOfDay').setValue(results.hourOfDay);
+        this.down('#dayOfWeek').setValue(results.dayOfWeek);
         this.down('#containerPath').setValue(results.containerPath);
         this.down('#kinshipValidation').setValue(results.kinshipValidation);
         this.down('#allowImportDuringBusinessHours').setValue(results.allowImportDuringBusinessHours)
@@ -109,6 +120,7 @@ Ext4.define('EHR.panel.GeneticCalculationSettingsPanel', {
                 containerPath: this.down('#containerPath').getValue(),
                 enabled: this.down('#enabled').getValue(),
                 hourOfDay: this.down('#hourOfDay').getValue(),
+                dayOfWeek: this.down('#dayOfWeek').getValue(),
                 kinshipValidation: this.down('#kinshipValidation').getValue(),
                 allowImportDuringBusinessHours: this.down('#allowImportDuringBusinessHours').getValue()
             },

--- a/ehr/src/org/labkey/ehr/EHRController.java
+++ b/ehr/src/org/labkey/ehr/EHRController.java
@@ -640,7 +640,7 @@ public class EHRController extends SpringActionController
                 errors.reject(ERROR_MSG, "Unable to find container for path: " + form.getContainerPath());
                 return null;
             }
-            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay(), form.isKinshipValidation(), form.isAllowImportDuringBusinessHours());
+            GeneticCalculationsJob.setProperties(form.isEnabled(), c, form.getHourOfDay(), form.getDayOfWeek(), form.isKinshipValidation(), form.isAllowImportDuringBusinessHours());
 
             return new ApiSimpleResponse("success", true);
         }
@@ -758,6 +758,7 @@ public class EHRController extends SpringActionController
         private boolean _enabled;
         private String containerPath;
         private int hourOfDay;
+        private Integer dayOfWeek;
 
         private boolean _kinshipValidation;
         private boolean _allowImportDuringBusinessHours;
@@ -790,6 +791,16 @@ public class EHRController extends SpringActionController
         public void setHourOfDay(int hourOfDay)
         {
             this.hourOfDay = hourOfDay;
+        }
+
+        public Integer getDayOfWeek()
+        {
+            return dayOfWeek;
+        }
+
+        public void setDayOfWeek(Integer dayOfWeek)
+        {
+            this.dayOfWeek = dayOfWeek;
         }
 
         public boolean isKinshipValidation()
@@ -828,6 +839,7 @@ public class EHRController extends SpringActionController
             ret.put("isScheduled", GeneticCalculationsJob.isScheduled());
             ret.put("enabled", GeneticCalculationsJob.isEnabled());
             ret.put("hourOfDay", GeneticCalculationsJob.getHourOfDay());
+            ret.put("dayOfWeek", GeneticCalculationsJob.getDayOfWeek());
             ret.put("kinshipValidation", GeneticCalculationsJob.isKinshipValidation());
             ret.put("allowImportDuringBusinessHours", GeneticCalculationsJob.isAllowImportDuringBusinessHours());
 

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -307,6 +307,14 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                     if (lineNum % 250000 == 0)
                     {
                         log.info("imported " + String.format("%,d", lineNum) + " rows");
+                        if (job != null)
+                        {
+                            job.updateStatusForTask();
+                            if (job.isCancelled())
+                            {
+                                throw new CancelledException();
+                            }
+                        }
                     }
                 }
 

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsJob.java
@@ -97,13 +97,15 @@ public class GeneticCalculationsJob implements Job
         if (hour == null)
             hour = 2;
 
+        Integer day = getDayOfWeek();
+
         JobDetail job = JobBuilder.newJob(GeneticCalculationsJob.class)
                 .withIdentity(GeneticCalculationsJob.class.getCanonicalName())
                 .build();
 
         Trigger trigger = TriggerBuilder.newTrigger()
                 .withIdentity(GeneticCalculationsJob.class.getCanonicalName())
-                .withSchedule(CronScheduleBuilder.dailyAtHourAndMinute(hour, 0))
+                .withSchedule(day == null ? CronScheduleBuilder.dailyAtHourAndMinute(hour, 0) : CronScheduleBuilder.weeklyOnDayAndHourAndMinute(day, hour, 0))
                 .forJob(job)
                 .build();
 
@@ -174,12 +176,23 @@ public class GeneticCalculationsJob implements Job
         return null;
     }
 
-    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay, Boolean isKinshipValidation, Boolean allowImportDuringBusinessHours)
+    public static Integer getDayOfWeek()
+    {
+        Map<String, String> saved = PropertyManager.getProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN);
+
+        if (saved.containsKey("dayOfWeek") & saved.get("dayOfWeek") != null)
+            return Integer.parseInt(saved.get("dayOfWeek"));
+
+        return null;
+    }
+
+    public static void setProperties(Boolean isEnabled, Container c, Integer hourOfDay, @Nullable Integer dayOfWeek, Boolean isKinshipValidation, Boolean allowImportDuringBusinessHours)
     {
         WritablePropertyMap props = PropertyManager.getWritableProperties(GENETICCALCULATIONS_PROPERTY_DOMAIN, true);
         props.put("enabled", isEnabled.toString());
         props.put("container", c.getId());
         props.put("hourOfDay", hourOfDay.toString());
+        props.put("dayOfWeek", dayOfWeek == null ?  null : dayOfWeek.toString());
         props.put("kinshipValidation", isKinshipValidation.toString());
         props.put("allowImportDuringBusinessHours", allowImportDuringBusinessHours.toString());
         props.save();


### PR DESCRIPTION
If the user hits cancel on a pipeline job, they should reasonably expect the job to cancel. While GeneticCalculationsImportTask already has a check for job.isCancelled(), I dont think isCancelled() actually returns the correct value unless job.updateStatusForTask() is called. This PR adds this, which makes the job check the current status of the job every time it completes a batch of imports, and will therefore cancel the job in a more timely manner. 

While I was editing this, I also made an option to specify dayOfWeek, in addition to hourOfDay for the cron schedule. If blank the job will run nightly, as-is. The would allow admins to pick a day of the week to convert this into a weekly job.