### PR TITLE
Adding sortOrder to the getPackages api response when the column is available.

### DIFF
--- a/snd/src/org/labkey/snd/SNDServiceImpl.java
+++ b/snd/src/org/labkey/snd/SNDServiceImpl.java
@@ -474,7 +474,10 @@ public class SNDServiceImpl implements SNDService
                             Object displayable = rs.getObject("displayable");
                             jsonObject.put("displayable",displayable);
                         }
-
+                        if(colNames.contains("sortOrder")) {
+                            Object sortOrder = rs.getObject("sortOrder");
+                            jsonObject.put("sortOrder",sortOrder);
+                        }
                         array.put(jsonObject);
                     }
                 }


### PR DESCRIPTION
This PR has code changes related to adding of 'sortOrder' to the getPackages api response when the column is available. This sortOrder is used by snprc mobile application for sorting of the attribute lookupValues in the dropdown list.
