### PR TITLE
Rename SaveRowsResponse to RowsResponse

### DIFF
--- a/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
+++ b/Viral_Load_Assay/test/src/org/labkey/test/tests/external/labModules/ViralLoadAssayTest.java
@@ -24,7 +24,7 @@ import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.test.Locator;
@@ -394,7 +394,7 @@ public class ViralLoadAssayTest extends AbstractLabModuleAssayTest
             rowMap.put("detector", DETECTOR_NAME);
             rowMap.put("reporter", "FAM");
             insertCmd.addRow(rowMap);
-            SaveRowsResponse saveResp = insertCmd.execute(cn, getProjectName());
+            RowsResponse saveResp = insertCmd.execute(cn, getProjectName());
             assertEquals("Problem creating record", 1, saveResp.getRowsAffected());
         }
         else

--- a/ehr/test/src/org/labkey/test/util/ehr/EHRClientAPIHelper.java
+++ b/ehr/test/src/org/labkey/test/util/ehr/EHRClientAPIHelper.java
@@ -28,8 +28,7 @@ import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.UpdateRowsCommand;
@@ -110,13 +109,13 @@ public class EHRClientAPIHelper
         return resp.getRowCount().intValue();
     }
 
-    public SaveRowsResponse insertRow(String schema, String query, Map<String, Object> row, boolean expectFailure) throws CommandException
+    public RowsResponse insertRow(String schema, String query, Map<String, Object> row, boolean expectFailure) throws CommandException
     {
         try
         {
             InsertRowsCommand insertCmd = new InsertRowsCommand(schema, query);
             insertCmd.addRow(row);
-            SaveRowsResponse resp = insertCmd.execute(getConnection(), _containerPath);
+            RowsResponse resp = insertCmd.execute(getConnection(), _containerPath);
 
             if (expectFailure)
                 throw new RuntimeException("Expected command to fail");
@@ -137,14 +136,14 @@ public class EHRClientAPIHelper
         }
     }
 
-    public SaveRowsResponse updateRow(String schema, String query, Map<String, Object> row, boolean expectFailure) throws CommandException
+    public RowsResponse updateRow(String schema, String query, Map<String, Object> row, boolean expectFailure) throws CommandException
     {
         try
         {
-            SaveRowsCommand cmd = new UpdateRowsCommand(schema, query);
+            UpdateRowsCommand cmd = new UpdateRowsCommand(schema, query);
             cmd.addRow(row);
 
-            SaveRowsResponse resp = cmd.execute(getConnection(), _containerPath);
+            RowsResponse resp = cmd.execute(getConnection(), _containerPath);
 
             if (expectFailure)
                 throw new RuntimeException("Expected command to fail");
@@ -172,14 +171,14 @@ public class EHRClientAPIHelper
         }
     }
 
-    public SaveRowsResponse deleteRow(String schema, String query, Map<String, Object> row, String pkCol, boolean expectFailure) throws CommandException
+    public RowsResponse deleteRow(String schema, String query, Map<String, Object> row, String pkCol, boolean expectFailure) throws CommandException
     {
         try
         {
             DeleteRowsCommand cmd = new DeleteRowsCommand(schema, query);
             cmd.addRow(row);
 
-            SaveRowsResponse resp = cmd.execute(getConnection(), _containerPath);
+            RowsResponse resp = cmd.execute(getConnection(), _containerPath);
             if (expectFailure)
                 throw new RuntimeException("Expected command to fail");
 
@@ -445,7 +444,7 @@ public class EHRClientAPIHelper
 
         if (!dr.getRows().isEmpty())
         {
-            SaveRowsResponse resp = dr.execute(getConnection(), _containerPath);
+            RowsResponse resp = dr.execute(getConnection(), _containerPath);
             return resp.getRowsAffected().intValue();
         }
 

--- a/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
+++ b/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
@@ -28,7 +28,7 @@ import org.labkey.remoteapi.Connection;
 import org.labkey.remoteapi.query.DeleteRowsCommand;
 import org.labkey.remoteapi.query.Filter;
 import org.labkey.remoteapi.query.InsertRowsCommand;
-import org.labkey.remoteapi.query.SaveRowsResponse;
+import org.labkey.remoteapi.query.RowsResponse;
 import org.labkey.remoteapi.query.SelectRowsCommand;
 import org.labkey.remoteapi.query.SelectRowsResponse;
 import org.labkey.remoteapi.query.TruncateTableCommand;
@@ -1497,7 +1497,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         catMap.put("Active", true);
         catMap.put("Comment", "delete me");
         cmd.addRow(catMap);
-        SaveRowsResponse response = cmd.execute(createDefaultConnection(false), getProjectName());
+        RowsResponse response = cmd.execute(createDefaultConnection(false), getProjectName());
 
         PackageListPage listPage = PackageListPage.beginAt(this , getProjectName());
         EditCategoriesPage catPage = listPage.clickEditCategories();
@@ -1530,7 +1530,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         catMap.put("Active", true);
         catMap.put("Comment", "edit me so hard!"); // comment is not shown in the UI
         cmd.addRow(catMap);
-        SaveRowsResponse response = cmd.execute(createDefaultConnection(false), getProjectName());
+        RowsResponse response = cmd.execute(createDefaultConnection(false), getProjectName());
         assertEquals(200, response.getStatusCode());
 
         PackageListPage listPage = PackageListPage.beginAt(this , getProjectName());
@@ -1572,7 +1572,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         insertRowsCommand.addRow(TEST1ROW1MAP);
         insertRowsCommand.addRow(TEST1ROW2MAP);
         insertRowsCommand.addRow(TEST1ROW3MAP);
-        SaveRowsResponse resp = insertRowsCommand.execute(cn, getProjectName() + "/" + TEST1SUBFOLDER);
+        RowsResponse resp = insertRowsCommand.execute(cn, getProjectName() + "/" + TEST1SUBFOLDER);
         assertEquals(3, resp.getRowsAffected().intValue());
 
         goToSchemaBrowser();


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/labkey-api-java/pull/83 for rationale.

#### Related Pull Requests
- https://github.com/LabKey/labkey-api-java/pull/83

#### Changes
- Rename `SaveRowsResponse` to `RowsResponse`
