### PR TITLE
EHR Link Crawler Test

### DIFF
--- a/EHR_App/test/src/org/labkey/test/tests/EHR_AppTest.java
+++ b/EHR_App/test/src/org/labkey/test/tests/EHR_AppTest.java
@@ -12,6 +12,8 @@ import org.labkey.test.tests.ehr.AbstractGenericEHRTest;
 import org.labkey.test.util.PostgresOnlyTest;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 @Category({EHR.class})
 public class EHR_AppTest extends AbstractGenericEHRTest implements PostgresOnlyTest
@@ -118,6 +120,17 @@ public class EHR_AppTest extends AbstractGenericEHRTest implements PostgresOnlyT
     public void preTest()
     {
         goToEHRFolder();
+    }
+
+    @Override
+    protected List<String> skipLinksForValidation()
+    {
+        List<String> links = new ArrayList<>(super.skipLinksForValidation());
+        links.add("Issue_Tracker");
+        links.add("ehr-colonyOverview.view");
+        links.add("ehr-updateTable.view");
+        links.add("ehr-populateLookupData.view");
+        return links;
     }
 
     @Test

--- a/ehr/resources/views/dataAdmin.html
+++ b/ehr/resources/views/dataAdmin.html
@@ -103,7 +103,6 @@ Ext4.onReady(function (){
                 {queryName: 'dental_teeth', schemaName: 'ehr_lookups', title: 'Dental Teeth Field'},
 
                 {queryName: 'encounter_types', schemaName: 'ehr_lookups', title: 'Encounter Types'},
-                {queryName: 'error_types', schemaName: 'ehr_lookups', title: 'Error Report Error Types'},
                 {queryName: 'gender_codes', schemaName: 'ehr_lookups', title: 'Gender Codes'},
                 {queryName: 'hematology_method', schemaName: 'ehr_lookups', title: 'Hematology Method'},
                 {queryName: 'hematology_tests', schemaName: 'ehr_lookups', title: 'Hematology Tests'},

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -391,6 +391,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
             if (clickable)
             {
+                waitFor(() -> (getDriver().getCurrentUrl() != null && !getDriver().getCurrentUrl().equalsIgnoreCase("about:blank")), WAIT_FOR_JAVASCRIPT);
                 URL url = getURL();
                 assertFalse("URL " + url + " is empty.", isPageEmpty());
                 assertNoLabKeyErrors();

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -346,7 +346,8 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
         String href = anchor.getDomAttribute("href");
         if (href != null && !href.startsWith("#"))
         {
-            if (skipLinksForValidation().stream().anyMatch(s -> href.toLowerCase().contains(s.toLowerCase())))
+            String decodedHref = EscapeUtil.decodeUriPath(href);
+            if (skipLinksForValidation().stream().anyMatch(s -> decodedHref.toLowerCase().contains(s.toLowerCase())))
             {
                 log(href + " is specified as an exception to link validation. Skipping validation.");
                 return validUrl;
@@ -367,8 +368,8 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
                 // not a full URL so not external. Carry on.
             }
 
-            // scope this to ehr folder and subfolders
-            if (!EscapeUtil.decodeUriPath(href).contains(getContainerPath()))
+            // scope this to admin, ehr folder and subfolders
+            if (!decodedHref.contains(getContainerPath()) && !decodedHref.startsWith("/admin"))
             {
                 log(href + " is in a different folder than the EHR folder, " + getContainerPath() + ". Skipping validation.");
                 return validUrl;

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -30,7 +30,9 @@ import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.ext4cmp.Ext4ComboRef;
 import org.labkey.test.util.external.labModules.LabModuleHelper;
+import org.labkey.test.util.selenium.WebDriverUtils;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
@@ -307,6 +309,21 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
         resetErrors();  //note: inserting records without permission will log errors by design.  the UI should prevent this from happening, so we want to be aware if it does occur
     }
 
+    // Clicks the link and switches to the window if it's a viable link. Otherwise throws an exception.
+    private void verifyLInk(WebElement link)
+    {
+        int winCount = getDriver().getWindowHandles().size();
+        link.sendKeys(Keys.chord(WebDriverUtils.MODIFIER_KEY, Keys.ENTER));
+
+        // Short wait for a new window to open. If not then throw exception
+        boolean winOpen = waitFor(() -> getDriver().getWindowHandles().size() > winCount, 1000);
+        if (!winOpen)
+            throw new IllegalStateException("Link did not open new window in tab.");
+
+        List<String> windows = new ArrayList<>(getDriver().getWindowHandles());
+        getDriver().switchTo().window(windows.get(1));
+    }
+
     protected List<String> skipLinksForValidation()
     {
         return List.of(
@@ -385,7 +402,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
         try
         {
-            openLinkInNewWindowOrThrow(anchor);
+            verifyLInk(anchor);
         }
         catch (WebDriverException | IllegalStateException e)
         {

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -382,7 +382,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
             try
             {
-                openLinkInNewWindow(anchor);
+                openLinkInNewWindowOrThrow(anchor);
             }
             catch (WebDriverException | IllegalStateException e)
             {

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -391,14 +391,20 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
             if (clickable)
             {
-                waitFor(() -> (getDriver().getCurrentUrl() != null && !getDriver().getCurrentUrl().equalsIgnoreCase("about:blank")), WAIT_FOR_JAVASCRIPT);
-                URL url = getURL();
-                assertFalse("URL " + url + " is empty.", isPageEmpty());
-                assertNoLabKeyErrors();
-                assertElementNotPresent("LabKey error found for URL " + url, Locators.labkeyErrorHeading);
-                validUrl = url.toString(); // wait all the way to here before declaring link valid to handle different types of links
-                switchToWindow(0);
-                quietlyCloseExtraWindows();
+                if (waitFor(() -> (getDriver().getCurrentUrl() != null && !getDriver().getCurrentUrl().equalsIgnoreCase("about:blank")), WAIT_FOR_JAVASCRIPT))
+                {
+                    URL url = getURL();
+                    assertFalse("URL " + url + " is empty.", isPageEmpty());
+                    assertNoLabKeyErrors();
+                    assertElementNotPresent("LabKey error found for URL " + url, Locators.labkeyErrorHeading);
+                    validUrl = url.toString(); // wait all the way to here before declaring link valid to handle different types of links
+                    switchToWindow(0);
+                    quietlyCloseExtraWindows();
+                }
+                else
+                {
+                    log("Link " + href + " did not load properly.");
+                }
             }
         }
         return validUrl;

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -16,7 +16,6 @@
 package org.labkey.test.tests.ehr;
 
 import org.json.JSONObject;
-import org.junit.Assert;
 import org.junit.Test;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.SimplePostCommand;
@@ -49,6 +48,7 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 //Inherit from this class instead of AbstractEHRTest when you want to run these tests, which should work across all ehr modules
 public abstract class AbstractGenericEHRTest extends AbstractEHRTest
@@ -227,7 +227,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
         recallLocation();
         List<String> submenuItems = dr.getHeaderMenuOptions("More Actions");
         List<String> expectedSubmenu = Arrays.asList("Jump To History", "Return Distinct Values","Show Record History","Compare Weights","Edit Records");
-        Assert.assertTrue("More actions menu did not contain expected options. Expected: " + expectedSubmenu + ", but found: " + submenuItems, submenuItems.containsAll(expectedSubmenu));
+        assertTrue("More actions menu did not contain expected options. Expected: " + expectedSubmenu + ", but found: " + submenuItems, submenuItems.containsAll(expectedSubmenu));
     }
 
     private void testUserAgainstAllStates(@LoggedParam EHRUser user)
@@ -391,20 +391,22 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
             if (clickable)
             {
-                if (waitFor(() -> (getDriver().getCurrentUrl() != null && !getDriver().getCurrentUrl().equalsIgnoreCase("about:blank")), WAIT_FOR_JAVASCRIPT))
-                {
-                    URL url = getURL();
-                    assertFalse("URL " + url + " is empty.", isPageEmpty());
-                    assertNoLabKeyErrors();
-                    assertElementNotPresent("LabKey error found for URL " + url, Locators.labkeyErrorHeading);
-                    validUrl = url.toString(); // wait all the way to here before declaring link valid to handle different types of links
-                    switchToWindow(0);
-                    quietlyCloseExtraWindows();
-                }
-                else
-                {
-                    log("Link " + href + " did not load properly.");
-                }
+                // Give page time to load
+                boolean loaded = waitFor(() -> (getDriver().getCurrentUrl() != null && !getDriver().getCurrentUrl().equalsIgnoreCase("about:blank")), WAIT_FOR_PAGE);
+                assertTrue("Link " + href + " did not load in " + WAIT_FOR_PAGE + "ms.", loaded);
+
+                // Assert page is not empty and does not have errors
+                URL url = getURL();
+                assertFalse("URL " + url + " is empty.", isPageEmpty());
+                assertNoLabKeyErrors();
+
+                // assertNoLabKeyErrors does not catch all types of errors
+                assertElementNotPresent("LabKey error found for URL " + url, Locators.labkeyErrorHeading);
+
+                // record link as valid and cleanup
+                validUrl = url.toString();
+                switchToWindow(0);
+                quietlyCloseExtraWindows();
             }
         }
         return validUrl;

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.labkey.remoteapi.CommandResponse;
 import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.Locator;
+import org.labkey.test.Locators;
 import org.labkey.test.pages.ehr.AnimalHistoryPage;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.Ext4Helper;
@@ -29,8 +30,11 @@ import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.ext4cmp.Ext4ComboRef;
 import org.labkey.test.util.external.labModules.LabModuleHelper;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +47,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 //Inherit from this class instead of AbstractEHRTest when you want to run these tests, which should work across all ehr modules
 public abstract class AbstractGenericEHRTest extends AbstractEHRTest
@@ -298,6 +303,144 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
         simpleSignIn(); //NOTE: this is designed to force the test to sign in, assuming our session was timed out from all the API tests
         resetErrors();  //note: inserting records without permission will log errors by design.  the UI should prevent this from happening, so we want to be aware if it does occur
+    }
+
+    protected List<String> skipLinksForValidation()
+    {
+        return List.of(
+                "showAllErrors.view",
+                "query-exportRowsExcel.view",
+                "ldk-runNotification.view"  // need to scope notifications to enabled modules then can remove this
+        ); // Override if there are links to pages that are known to throw errors
+    }
+
+    protected List<String> skipLinksForCrawling()
+    {
+        return List.of(
+                "project-begin.view",
+                "query-begin.view",
+                "query-searchPanel.view",
+                "query-executeQuery.view",
+                "study-manageStudy.view",
+                "ehr-animalHistory.view",
+                "ehr-updateQuery.view",
+                "ehr-updateTable.view",
+                "ehr-populateLookupData.view",
+                "ehr-ensureQcStates.view",
+                "ehr-ehrTemplates.view",
+                "ehr-primeDataEntryCache.view",
+                "ehr-cacheLivingAnimals.view",
+                "core-modulePropertyAdmin.view",
+                "dataintegration-begin.view",
+                "ldk-updateQuery",
+                "junit-begin.view"
+        );
+    }
+
+    private String validLink(WebElement anchor)
+    {
+        boolean clickable = false;
+        String validUrl = null;
+
+        String href = anchor.getDomAttribute("href");
+        if (href != null && !href.startsWith("#"))
+        {
+            if (skipLinksForValidation().stream().anyMatch(s -> href.toLowerCase().contains(s.toLowerCase())))
+            {
+                log(href + " is specified as an exception to link validation. Skipping validation.");
+                return validUrl;
+            }
+
+            // Ensure link is not external
+            try
+            {
+                URL url = new URL(href);
+                if (!url.getHost().equalsIgnoreCase(getURL().getHost()))
+                {
+                    log(href + " is an external link. Skipping validation.");
+                    return validUrl;
+                }
+            }
+            catch (MalformedURLException e)
+            {
+                // not a full URL so not external. Carry on.
+            }
+
+            // scope this to ehr folder and subfolders
+            if (!href.contains(getContainerPath()))
+            {
+                log(href + " is in a different folder. Skipping validation.");
+                return validUrl;
+            }
+        }
+
+        if (anchor.isDisplayed() && anchor.isEnabled())
+        {
+            clickable = true;
+
+            try
+            {
+                openLinkInNewWindow(anchor);
+            }
+            catch (WebDriverException | IllegalStateException e)
+            {
+                clickable = false;
+            }
+
+            if (clickable)
+            {
+                assertFalse(isPageEmpty());
+                assertNoLabKeyErrors();
+                assertElementNotPresent(Locators.labkeyErrorHeading);
+                validUrl = getURL().toString(); // wait all the way to here before declaring link valid to handle different types of links
+                switchToWindow(0);
+                quietlyCloseExtraWindows();
+            }
+        }
+        return validUrl;
+    }
+
+    private void validatePageLinks(Set<String> crawledLinks)
+    {
+        log("Validating links on " + getURL());
+        List<WebElement> anchors = getDriver().findElements(By.xpath("//div[contains(concat(' ', normalize-space(@class), ' '), ' lk-body-ct ')]//a[not(ancestor::form[@data-region-form]) and not(@role='button') and not(contains(@class, 'labkey-button'))]"));
+
+        log(anchors.size() + " possible links found.");
+        int validatedCount = 0;
+        Set<String> validLinksOnPage = new HashSet<>();
+        for (WebElement anchor : anchors)
+        {
+            String href = anchor.getDomAttribute("href");
+            if (href != null && validLinksOnPage.contains(href))
+                continue;
+
+            String validUrl = validLink(anchor);
+            if (validUrl != null)
+            {
+                validatedCount++;
+                validLinksOnPage.add(validUrl);
+            }
+
+        }
+        log(validatedCount + " links validated.");
+
+        for (String s : validLinksOnPage)
+        {
+            if (!crawledLinks.contains(s) && skipLinksForCrawling().stream().noneMatch(link -> s.toLowerCase().contains(link.toLowerCase())))
+            {
+                beginAt(s);
+                crawledLinks.add(s); // mark page as crawled to avoid loops
+                validatePageLinks(crawledLinks);
+            }
+        }
+    }
+
+    @Test
+    public void crawlEhrLinks()
+    {
+        goToEHRFolder();
+        Set<String> crawledLinks = new HashSet<>();
+        validatePageLinks(crawledLinks);
     }
 
     @Test

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -24,6 +24,7 @@ import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.pages.ehr.AnimalHistoryPage;
 import org.labkey.test.util.DataRegionTable;
+import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.Ext4Helper;
 import org.labkey.test.util.LoggedParam;
 import org.labkey.test.util.PortalHelper;
@@ -367,9 +368,9 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
             }
 
             // scope this to ehr folder and subfolders
-            if (!href.contains(getContainerPath()))
+            if (!EscapeUtil.decodeUriPath(href).contains(getContainerPath()))
             {
-                log(href + " is in a different folder. Skipping validation.");
+                log(href + " is in a different folder than the EHR folder, " + getContainerPath() + ". Skipping validation.");
                 return validUrl;
             }
         }

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -344,7 +344,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
     private String validLink(WebElement anchor)
     {
         String href = anchor.getDomAttribute("href");
-        if (href != null && !href.startsWith("#"))
+        if (href != null && !href.startsWith("#") && !href.equalsIgnoreCase("undefined"))
         {
             String decodedHref = EscapeUtil.decodeUriPath(href);
             if (skipLinksForValidation().stream().anyMatch(s -> decodedHref.toLowerCase().contains(s.toLowerCase())))

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -391,10 +391,11 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
 
             if (clickable)
             {
-                assertFalse(isPageEmpty());
+                URL url = getURL();
+                assertFalse("URL " + url + " is empty.", isPageEmpty());
                 assertNoLabKeyErrors();
-                assertElementNotPresent(Locators.labkeyErrorHeading);
-                validUrl = getURL().toString(); // wait all the way to here before declaring link valid to handle different types of links
+                assertElementNotPresent("LabKey error found for URL " + url, Locators.labkeyErrorHeading);
+                validUrl = url.toString(); // wait all the way to here before declaring link valid to handle different types of links
                 switchToWindow(0);
                 quietlyCloseExtraWindows();
             }

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -336,7 +336,8 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
                 "dataintegration-begin.view",
                 "ldk-updateQuery",
                 "junit-begin.view",
-                "admin-"
+                "admin-",
+                "ehr-datasets.view"
         );
     }
 

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -22,6 +22,7 @@ import org.labkey.remoteapi.SimplePostCommand;
 import org.labkey.test.Locator;
 import org.labkey.test.Locators;
 import org.labkey.test.pages.ehr.AnimalHistoryPage;
+import org.labkey.test.util.Crawler;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.EscapeUtil;
 import org.labkey.test.util.Ext4Helper;
@@ -334,15 +335,13 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
                 "core-modulePropertyAdmin.view",
                 "dataintegration-begin.view",
                 "ldk-updateQuery",
-                "junit-begin.view"
+                "junit-begin.view",
+                "admin-"
         );
     }
 
     private String validLink(WebElement anchor)
     {
-        boolean clickable = false;
-        String validUrl = null;
-
         String href = anchor.getDomAttribute("href");
         if (href != null && !href.startsWith("#"))
         {
@@ -369,46 +368,49 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
             }
 
             // scope this to admin, ehr folder and subfolders
-            if (!decodedHref.contains(getContainerPath()) && !decodedHref.startsWith("/admin"))
+            String controller = new Crawler.ControllerActionId(decodedHref).getController();
+            if (!decodedHref.contains(getContainerPath()) && !controller.equalsIgnoreCase("admin"))
             {
                 log(href + " is in a different folder than the EHR folder, " + getContainerPath() + ". Skipping validation.");
                 return null;
             }
         }
 
-        if (anchor.isDisplayed() && anchor.isEnabled())
+        if (!anchor.isDisplayed())
+            return null;
+
+        boolean clickable = true;
+        String validUrl = null;
+
+        try
         {
-            clickable = true;
-
-            try
-            {
-                openLinkInNewWindowOrThrow(anchor);
-            }
-            catch (WebDriverException | IllegalStateException e)
-            {
-                clickable = false;
-            }
-
-            if (clickable)
-            {
-                // Give page time to load
-                boolean loaded = waitFor(() -> (getDriver().getCurrentUrl() != null && !getDriver().getCurrentUrl().equalsIgnoreCase("about:blank")), WAIT_FOR_PAGE);
-                assertTrue("Link " + href + " did not load in " + WAIT_FOR_PAGE + "ms.", loaded);
-
-                // Assert page is not empty and does not have errors
-                URL url = getURL();
-                assertFalse("URL " + url + " is empty.", isPageEmpty());
-                assertNoLabKeyErrors();
-
-                // assertNoLabKeyErrors does not catch all types of errors
-                assertElementNotPresent("LabKey error found for URL " + url, Locators.labkeyErrorHeading);
-
-                // record link as valid and cleanup
-                validUrl = url.toString();
-                switchToWindow(0);
-                quietlyCloseExtraWindows();
-            }
+            openLinkInNewWindowOrThrow(anchor);
         }
+        catch (WebDriverException | IllegalStateException e)
+        {
+            clickable = false;
+        }
+
+        if (clickable)
+        {
+            // Give page time to load
+            boolean loaded = waitFor(() -> (getDriver().getCurrentUrl() != null && !getDriver().getCurrentUrl().equalsIgnoreCase("about:blank")), WAIT_FOR_PAGE);
+            assertTrue("Link " + href + " did not load in " + WAIT_FOR_PAGE + "ms.", loaded);
+
+            // Assert page is not empty and does not have errors
+            URL url = getURL();
+            assertFalse("URL " + url + " is empty.", isPageEmpty());
+            assertNoLabKeyErrors();
+
+            // assertNoLabKeyErrors does not catch all types of errors
+            assertElementNotPresent("LabKey error found for URL " + url, Locators.labkeyErrorHeading);
+
+            // record link as valid and cleanup
+            validUrl = url.toString();
+            getDriver().close();
+            switchToWindow(0);
+        }
+
         return validUrl;
     }
 
@@ -426,7 +428,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
         {
             // Only validate links once
             String href = anchor.getDomAttribute("href");
-            if (href != null && validLinksOnPage.contains(href))
+            if (href != null && (validLinksOnPage.contains(href) || crawledLinks.contains(href)))
                 continue;
 
             // Validate and record valid links

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -415,6 +415,8 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
     private void validatePageLinks(Set<String> crawledLinks)
     {
         log("Validating links on " + getURL());
+
+        // Find all anchors in the body content area, excluding buttons and those in data regions
         List<WebElement> anchors = getDriver().findElements(By.xpath("//div[contains(concat(' ', normalize-space(@class), ' '), ' lk-body-ct ')]//a[not(ancestor::form[@data-region-form]) and not(@role='button') and not(contains(@class, 'labkey-button'))]"));
 
         log(anchors.size() + " possible links found.");
@@ -422,10 +424,12 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
         Set<String> validLinksOnPage = new HashSet<>();
         for (WebElement anchor : anchors)
         {
+            // Only validate links once
             String href = anchor.getDomAttribute("href");
             if (href != null && validLinksOnPage.contains(href))
                 continue;
 
+            // Validate and record valid links
             String validUrl = validLink(anchor);
             if (validUrl != null)
             {
@@ -436,6 +440,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
         }
         log(validatedCount + " links validated.");
 
+        // Recursively crawl valid links that have not yet been crawled and aren't listed as a skip.
         for (String s : validLinksOnPage)
         {
             if (!crawledLinks.contains(s) && skipLinksForCrawling().stream().noneMatch(link -> s.toLowerCase().contains(link.toLowerCase())))

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -360,7 +360,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
                 if (!url.getHost().equalsIgnoreCase(getURL().getHost()))
                 {
                     log(href + " is an external link. Skipping validation.");
-                    return validUrl;
+                    return null;
                 }
             }
             catch (MalformedURLException e)

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -372,7 +372,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
             if (!decodedHref.contains(getContainerPath()) && !decodedHref.startsWith("/admin"))
             {
                 log(href + " is in a different folder than the EHR folder, " + getContainerPath() + ". Skipping validation.");
-                return validUrl;
+                return null;
             }
         }
 

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -439,7 +439,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
     }
 
     @Test
-    public void crawlEhrLinks()
+    public void testCrawlEhrLinks()
     {
         goToEHRFolder();
         Set<String> crawledLinks = new HashSet<>();

--- a/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
+++ b/ehr/test/src/org/labkey/test/tests/ehr/AbstractGenericEHRTest.java
@@ -350,7 +350,7 @@ public abstract class AbstractGenericEHRTest extends AbstractEHRTest
             if (skipLinksForValidation().stream().anyMatch(s -> decodedHref.toLowerCase().contains(s.toLowerCase())))
             {
                 log(href + " is specified as an exception to link validation. Skipping validation.");
-                return validUrl;
+                return null;
             }
 
             // Ensure link is not external


### PR DESCRIPTION
#### Rationale
Core EHR test that crawls links in the EHR folder or subfolders to check for broken links. Help find CSP violations and provide a new test to ensure links expected to work do not have regressions.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2585
* https://github.com/LabKey/johnsHopkinsEHRModules/pull/494
* https://github.com/LabKey/nircEHRModules/pull/559
* https://github.com/LabKey/snprcEHRModules/pull/835
* https://github.com/LabKey/tnprcEHRModules/pull/131
* https://github.com/LabKey/wnprc-modules/pull/855
* https://github.com/LabKey/onprcEHRModules/pull/1402

#### Changes
* Add testCrawlEhrLinks
* Add skip links known to cause trouble in test setups
* Update EHRApp test skip links
