### PR TITLE
Wait for active report panel to prevent NPEs

### DIFF
--- a/ehr/test/src/org/labkey/test/pages/ehr/ParticipantViewPage.java
+++ b/ehr/test/src/org/labkey/test/pages/ehr/ParticipantViewPage.java
@@ -115,7 +115,7 @@ public class ParticipantViewPage<EC extends ParticipantViewPage.ElementCache> ex
 
     public WebElement getActiveReportPanel()
     {
-        return activeReportPanel.findElementOrNull(getDriver());
+        return activeReportPanel.waitForElement(getDriver(), 2_000);
     }
 
     public DataRegionTable getActiveReportDataRegion()


### PR DESCRIPTION
#### Rationale
Nothing ever expects `ParticipantViewPage. getActiveReportPanel` to return `null`. Using `findElementOrNull` just leads to occasional NPEs. We should just wait for the panel.

```
java.lang.NullPointerException: Cannot invoke "org.openqa.selenium.SearchContext.findElements(org.openqa.selenium.By)" because "context" is null
  at org.labkey.test.Locator$XPathLocator.findElements(Locator.java:1569)
  at org.labkey.test.Locator.findOptionalElement(Locator.java:387)
  [...]
  at org.labkey.test.components.Component$ComponentFinder.findElement(Component.java:180)
  at org.labkey.test.components.Component$ComponentFinder.find(Component.java:206)
  at org.labkey.test.pages.ehr.ParticipantViewPage.getActiveReportDataRegion(ParticipantViewPage.java:123)
  at org.labkey.test.tests.jhu_ehr.JHU_EHRTest.testRecordBulkMedications(JHU_EHRTest.java:1726)
```

#### Related Pull Requests
* N/A

#### Changes
* Wait for active report panel to prevent NPEs
