### PR TITLE
Move client errors query to "Client API Actions" table

### DIFF
--- a/ehr/resources/queries/auditLog/Client API Actions/EHR Client Errors.qview.xml
+++ b/ehr/resources/queries/auditLog/Client API Actions/EHR Client Errors.qview.xml
@@ -3,15 +3,12 @@
         <column name="CreatedBy"/>
         <column name="Date"/>
         <column name="EventType"/>
-        <column name="Key1"/>
-        <column name="Key2"/>
-        <!--<column name="Key3"/>-->
-
+        <column name="SubType"/>
+        <column name="String1"/>
         <column name="Comment" />
     </columns>
     <filters>
-        <filter column="EventType" operator="eq" value="Client API Actions"/>
-        <filter column="Key1" operator="neqornull" value="LabKey Server Backup" />
+        <filter column="SubType" operator="neqornull" value="LabKey Server Backup" />
     </filters>
    <sorts>
        <sort column="Date" descending="true"/>


### PR DESCRIPTION
#### Rationale
`auditLog.audit` table has been deprecated. Custom view belongs on the successor table.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6892