### PR TITLE
Fix another audit event legacy column name reference

### DIFF
--- a/ehr/resources/queries/auditLog/DemographicsDeleted.sql
+++ b/ehr/resources/queries/auditLog/DemographicsDeleted.sql
@@ -1,9 +1,10 @@
 WITH cte0 AS (
     SELECT
         a.Date,
-        substring(a.DataChanges, a.IdStart, CAST(LOCATE('&', a.DataChanges, LOCATE('&Id=', a.DataChanges) + 1) - a.IdStart AS INTEGER)) as Id
+        substring(a.DataChanges, a.IdStart, CAST(LOCATE('&', a.DataChanges, LOCATE('&Id=', a.DataChanges) + 1) - a.IdStart AS INTEGER)
+        ) as Id
     FROM (
-             SELECT Date,
+             SELECT Created AS Date,
                  DataChanges,
                  LOCATE('&Id=', DataChanges) + LENGTH('&Id=') as IdStart
              FROM DatasetAuditEvent


### PR DESCRIPTION
#### Rationale
"Date" is no longer a column in audit event tables

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6903