### PR TITLE
Support BIGINT Primary Keys

### DIFF
--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ABI7500ImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ABI7500ImportMethod.java
@@ -27,6 +27,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ConvertHelper;
@@ -573,7 +574,7 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
             response.setHeader("Pragma", "private");
             response.setHeader("Cache-Control", "private");
 
-            Map<Integer, String[]> rowMap = new HashMap<>();
+            Map<Integer, String[]> rowMap = new IntHashMap<>();
 
             int rowIdx = 0;
             for (JSONObject row : results)

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -1338,7 +1339,7 @@ public class EHRManager
     {
         DataEntryForm def = getDataEntryFormForTask(c, u, taskId);
 
-        Map<Integer, EHRQCState> qcStateMap = new HashMap<>();
+        Map<Integer, EHRQCState> qcStateMap = new IntHashMap<>();
         for (EHRQCState qc : EHRManager.get().getQCStates(c))
         {
             qcStateMap.put(qc.getRowId(), qc);

--- a/ehr/src/org/labkey/ehr/EHRManager.java
+++ b/ehr/src/org/labkey/ehr/EHRManager.java
@@ -109,6 +109,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import static org.labkey.api.exp.api.ExperimentService.asInteger;
+import static org.labkey.api.exp.api.ExperimentService.asLong;
+
 public class EHRManager
 {
     private static final EHRManager _instance = new EHRManager();
@@ -315,7 +318,7 @@ public class EHRManager
                     row.put("publicdata", qc[2]);
                     row = Table.insert(u, ti, row);
 
-                    qcMap.put((String)row.get("label"), (Integer)row.get("rowid"));
+                    qcMap.put((String)row.get("label"), asInteger(row.get("rowid")));
 
                     shouldClearCache = true;
                 }
@@ -1111,24 +1114,24 @@ public class EHRManager
 
         //find propertyId
         TableSelector ts = new TableSelector(propertyDescriptor, Collections.singleton("propertyid"), new SimpleFilter(FieldKey.fromString("PropertyURI"), pd.getPropertyURI()), null);
-        Integer[] ids = ts.getArray(Integer.class);
+        Long[] ids = ts.getArray(Long.class);
         if (ids.length == 0)
         {
             throw new SQLException("Unknown propertyURI: " + pd.getPropertyURI());
         }
-        int propertyId = ids[0];
+        long propertyId = ids[0];
 
         //first ensure the propertyURI exists
         SQLFragment sql = new SQLFragment("select propertyid from exp.propertydomain p where domainId = ? AND propertyid in (select propertyid from exp.propertydescriptor pd where pd.name " + (expSchema.getSqlDialect().isPostgreSQL() ? "ilike" : "like") + " ?)", d.getTypeId(), pd.getName());
         SqlSelector selector = new SqlSelector(expSchema.getScope(), sql);
-        List<Integer> oldIds = new ArrayList<>();
+        List<Long> oldIds = new ArrayList<>();
 
         try (TableResultSet results = selector.getResultSet())
         {
             while (results.next())
             {
                 Map<String, Object> row = results.getRowMap();
-                oldIds.add((Integer) row.get("propertyid"));
+                oldIds.add(asLong(row.get("propertyid")));
             }
         }
 
@@ -1171,7 +1174,7 @@ public class EHRManager
             executor.execute(updateSql, propertyId, d.getTypeId(), oldIds, minSort);
 
             oldIds.remove(propertyId);
-            for (Integer id : oldIds)
+            for (Long id : oldIds)
             {
                 PropertyDescriptor toDelete = OntologyManager.getPropertyDescriptor(id);
                 if (toDelete != null)

--- a/ehr/src/org/labkey/ehr/history/DefaultEncountersDataSource.java
+++ b/ehr/src/org/labkey/ehr/history/DefaultEncountersDataSource.java
@@ -16,6 +16,7 @@
 package org.labkey.ehr.history;
 
 import org.jetbrains.annotations.NotNull;
+import org.labkey.api.collections.StringHashMap;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -39,7 +40,6 @@ import org.labkey.ehr.EHRSchema;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -185,7 +185,7 @@ public class DefaultEncountersDataSource extends AbstractDataSource
         final Map<FieldKey, ColumnInfo> columns = QueryService.get().getColumns(snomed, colKeys);
 
         TableSelector ts = new TableSelector(snomed, columns.values(), newFilter, null);
-        final Map<String, Map<Integer, Map<Integer, String>>> snomedMap = new HashMap<>();
+        final Map<String, Map<Integer, Map<Integer, String>>> snomedMap = new StringHashMap<>();
 
         ts.forEach(new Selector.ForEachBlock<>()
         {

--- a/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
+++ b/ehr/src/org/labkey/ehr/utils/TriggerScriptHelper.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Aggregate;
 import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.CompareType;
@@ -122,7 +123,7 @@ public class TriggerScriptHelper
     protected final static SimpleDateFormat _dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd kk:mm");
 
     //NOTE: consider moving these to SharedCache, to allow them to be shared across scripts, yet reset from admin console
-    private final Map<Integer, String> _cachedAccounts = new HashMap<>();
+    private final Map<Integer, String> _cachedAccounts = new IntHashMap<>();
     /**
      *  Options that can be set in modules using EHR trigger scripts to opt in/out of or alter the behavior
      *  of certain validations and business logic.  If there are specific aspects of the core EHR trigger code that

--- a/ehr_billing/src/org/labkey/ehr_billing/query/EHRBillingTriggerHelper.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/query/EHRBillingTriggerHelper.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.ehr_billing.query;
 
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerManager;
@@ -32,7 +33,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.ehr_billing.EHR_BillingManager;
 import org.labkey.ehr_billing.EHR_BillingSchema;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -43,7 +43,7 @@ public class EHRBillingTriggerHelper
 {
     private final Container _container;
     private final User _user;
-    private final Map<Integer, Map<String, Object>> _cachedCharges = new HashMap<>();
+    private final Map<Integer, Map<String, Object>> _cachedCharges = new IntHashMap<>();
 
     public EHRBillingTriggerHelper(int userId, String containerId)
     {

--- a/snd/api-src/org/labkey/api/snd/Package.java
+++ b/snd/api-src/org/labkey/api/snd/Package.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.labkey.api.collections.ArrayListMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.Container;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.security.User;
@@ -49,7 +50,7 @@ public class Package
     private boolean _hasEvent;
     private boolean _hasProject;
     private Date _modified; // column will be used as a timestamp
-    private Map<Integer, String> _categories = new HashMap<>();
+    private Map<Integer, String> _categories = new IntHashMap<>();
     private List<GWTPropertyDescriptor> _attributes = new ArrayList<>();
     private List<SuperPackage> _subpackages = new ArrayList<>();
     private Map<GWTPropertyDescriptor, Object> _extraFields = new HashMap<>();

--- a/snd/src/org/labkey/snd/PackageUserSchema.java
+++ b/snd/src/org/labkey/snd/PackageUserSchema.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.collections.CaseInsensitiveHashSet;
 import org.labkey.api.collections.CaseInsensitiveTreeSet;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.AbstractTableInfo;
 import org.labkey.api.data.BaseColumnInfo;
 import org.labkey.api.data.ColumnInfo;
@@ -92,7 +93,7 @@ public class PackageUserSchema extends UserSchema
     PackageTableInfo createPackageTable(String name)
     {
         // find domain for name
-        Map<Integer,Package> pkgs = new HashMap<>();
+        Map<Integer,Package> pkgs = new IntHashMap<>();
         visitAll(p -> {
             if (name.equalsIgnoreCase(p.description))
                 pkgs.put(p.packageId, p);
@@ -291,7 +292,7 @@ public class PackageUserSchema extends UserSchema
             List<SuperPkg> supers = new SqlSelector(getDbSchema(), new SQLFragment(
                     new SQLFragment("SELECT SuperPkgId, ParentSuperPkgId, Pkgs.PkgId, Description FROM snd.Pkgs INNER JOIN snd.SuperPkgs ON Pkgs.PkgId = SuperPkgs.PkgId WHERE Pkgs.Container = ").appendValue(getContainer())
             )).getArrayList(SuperPkg.class);
-            Map<Integer, Package> map = new HashMap<>();
+            Map<Integer, Package> map = new IntHashMap<>();
             supers.forEach(superPkg -> {
                 var package_ = map.computeIfAbsent(superPkg.pkgId, id ->
                 {

--- a/snd/src/org/labkey/snd/SNDController.java
+++ b/snd/src/org/labkey/snd/SNDController.java
@@ -27,6 +27,7 @@ import org.labkey.api.action.SimpleApiJsonForm;
 import org.labkey.api.action.SimpleRedirectAction;
 import org.labkey.api.action.SimpleViewAction;
 import org.labkey.api.action.SpringActionController;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.gwt.client.DefaultValueType;
 import org.labkey.api.gwt.client.model.GWTPropertyDescriptor;
 import org.labkey.api.module.Module;
@@ -188,7 +189,7 @@ public class SNDController extends SpringActionController
             JSONArray jsonCategories = json.getJSONArray("categories");
             if (null != jsonCategories)
             {
-                Map<Integer, String> categories = new HashMap<>();
+                Map<Integer, String> categories = new IntHashMap<>();
                 for (int j = 0; j < jsonCategories.length(); j++)
                 {
                     categories.put(jsonCategories.getInt(j), null);
@@ -227,7 +228,7 @@ public class SNDController extends SpringActionController
             {
                 // Get super packages
                 JSONArray jsonSubPackages = json.getJSONArray("subPackages");  // only first-level children (as super package IDs) should be here
-                Map<Integer, LinkedList<SuperPackageInfo>> superPkgIdToExtraInfoMap = new HashMap<>();  // uses lists because top-level super package IDs might show up multiple times
+                Map<Integer, LinkedList<SuperPackageInfo>> superPkgIdToExtraInfoMap = new IntHashMap<>();  // uses lists because top-level super package IDs might show up multiple times
                 List<Integer> uiSubSuperPkgIds = new ArrayList<>();
 
                 // create super package for root, if needed
@@ -301,7 +302,7 @@ public class SNDController extends SpringActionController
                         {
                             topLevelSuperPkgs = SNDManager.convertToTopLevelSuperPkgs(getContainer(), getUser(), uiSubSuperPkgIds);
                             List<SuperPackage> uiSuperPkgs = SNDManager.getSuperPkgs(getContainer(), getUser(), uiSubSuperPkgIds);
-                            Map<Integer, Integer> superPkgIdToPkgIdMap = new HashMap<>();
+                            Map<Integer, Integer> superPkgIdToPkgIdMap = new IntHashMap<>();
 
                             // need to get proper package IDs from db since they're not coming in from UI
                             if (uiSuperPkgs != null)

--- a/snd/src/org/labkey/snd/SNDManager.java
+++ b/snd/src/org/labkey/snd/SNDManager.java
@@ -31,6 +31,7 @@ import org.labkey.api.cache.Cache;
 import org.labkey.api.cache.CacheManager;
 import org.labkey.api.collections.ArrayListMap;
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.DbScope;
@@ -77,6 +78,7 @@ import org.labkey.api.snd.EventNarrativeOption;
 import org.labkey.api.snd.EventNote;
 import org.labkey.api.snd.Package;
 import org.labkey.api.snd.PackageDomainKind;
+import org.labkey.api.snd.PlainTextNarrativeDisplayColumn;
 import org.labkey.api.snd.Project;
 import org.labkey.api.snd.ProjectItem;
 import org.labkey.api.snd.SNDDomainKind;
@@ -87,7 +89,6 @@ import org.labkey.api.util.PageFlowUtil;
 import org.labkey.snd.query.PackagesTable;
 import org.labkey.snd.security.QCStateActionEnum;
 import org.labkey.snd.security.SNDSecurityManager;
-import org.labkey.api.snd.PlainTextNarrativeDisplayColumn;
 import org.labkey.snd.trigger.SNDTriggerManager;
 
 import java.sql.SQLException;
@@ -552,7 +553,7 @@ public class SNDManager
         sql.append(" WHERE PkgId = ?").add(pkgId);
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        Map<Integer, String> categories = new HashMap<>();
+        Map<Integer, String> categories = new IntHashMap<>();
         try (TableResultSet rs = selector.getResultSet())
         {
             for (Map<String, Object> r : rs)
@@ -592,7 +593,7 @@ public class SNDManager
         }
         SqlSelector selector = new SqlSelector(schema.getDbSchema(), sql);
 
-        Map<Integer, Map<Integer, String>> pkgCategoriesByPkgId = new HashMap<>();
+        Map<Integer, Map<Integer, String>> pkgCategoriesByPkgId = new IntHashMap<>();
 
         try (TableResultSet resultSet = selector.getResultSet())
         {
@@ -3364,7 +3365,7 @@ public class SNDManager
         {
             List<GWTPropertyDescriptor> properties = superPackage.getPkg().getAttributes();
             Map<String, GWTPropertyDescriptor> propsByName = new HashMap<>();
-            Map<Integer, GWTPropertyDescriptor> propsById = new HashMap<>();
+            Map<Integer, GWTPropertyDescriptor> propsById = new IntHashMap<>();
             for (GWTPropertyDescriptor p : properties)
             {
                 propsByName.put(p.getName(), p);
@@ -4210,7 +4211,7 @@ public class SNDManager
                 ));
 
         // Prepare a map for the next level of SuperPackages
-        Map<Integer, Map<Integer, Pair<SuperPackage, Integer>>> nextLevelEventDataSuperPkgs = new HashMap<>();
+        Map<Integer, Map<Integer, Pair<SuperPackage, Integer>>> nextLevelEventDataSuperPkgs = new IntHashMap<>();
         nextLevelEventDataSuperPkgs.put(eventData.getEventId(), new HashMap<>());
 
         // Iterate over child event data and link it to the corresponding child SuperPackage

--- a/snd/src/org/labkey/snd/pipeline/SNDDataHandler.java
+++ b/snd/src/org/labkey/snd/pipeline/SNDDataHandler.java
@@ -347,7 +347,7 @@ public class SNDDataHandler extends AbstractExperimentDataHandler
     }
 
     @Override
-    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, int oldDataRowID)
+    public void runMoved(ExpData newData, Container container, Container targetContainer, String oldRunLSID, String newRunLSID, User user, long oldDataRowID)
     {
 
     }

--- a/snd/src/org/labkey/snd/security/SNDSecurityManager.java
+++ b/snd/src/org/labkey/snd/security/SNDSecurityManager.java
@@ -17,6 +17,7 @@ package org.labkey.snd.security;
 
 
 import org.labkey.api.collections.CaseInsensitiveHashMap;
+import org.labkey.api.collections.IntHashMap;
 import org.labkey.api.data.CompareType;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.CoreSchema;
@@ -50,7 +51,6 @@ import org.labkey.snd.SNDManager;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -127,7 +127,7 @@ public class SNDSecurityManager
 
         SecurityManager.getGroups(c.getProject(), true);
 
-        Map<Integer, MutableSecurityPolicy> policyMap = new HashMap<>();  // Policy cache
+        Map<Integer, MutableSecurityPolicy> policyMap = new IntHashMap<>();  // Policy cache
         MutableSecurityPolicy policy;
         Group group;
         Role role;

--- a/snd/src/org/labkey/snd/security/view/categorySecurity.jsp
+++ b/snd/src/org/labkey/snd/security/view/categorySecurity.jsp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 %>
+<%@ page import="org.labkey.api.collections.IntHashMap" %>
 <%@ page import="org.labkey.api.data.ContainerManager" %>
 <%@ page import="org.labkey.api.security.Group" %>
 <%@ page import="org.labkey.api.security.SecurityPolicy" %>
@@ -68,7 +69,7 @@
     Map<Integer, Category> categories = sndService.getAllCategories(getContainer(), getUser());
     Map<String, Role> roles = sndSecurityManager.getAllSecurityRoles();
 
-    Map<Integer, Map<Integer, String>> roleMapping = new HashMap<>();
+    Map<Integer, Map<Integer, String>> roleMapping = new IntHashMap<>();
     Map<Integer, String> roleNameMap;
     SecurityPolicy policy;
     List<Role> policyRoles;


### PR DESCRIPTION
#### Rationale
Implement support for tables with BIGINT primary keys.  E.g. RowId/ObjectId BIGSERIAL
Because of the large number of shared classes, utilities, services, etc, a lot of code was migrated to used Long.  Code should now assume that an generic integer object key (as opposed to a known table PK), could be a Long.

This PR is aimed at a) Supporting ObjectID BIGSERIAL b) making it possible (but not automatic) to migrate tables that want to use RowId BIGSERIAL.

#### Related Pull Requests
- <!-- list of links to related pull requests (replace this comment) -->

#### Changes
New safer collection classes
  class Int/LongHashMap
  class Int/LongHashSet
explicit Class for key values in Map Objects returned by BaseSelector
  Selector.getValueMap(Class key)
safe "cast" using asInteger or asLong, as opposed to (Integer) and (Long)

<!-- list of standard tasks (remove this comment to enable)
#### Tasks 📍
- [ ] Manual Testing
- [ ] Needs Automation
- [ ] Verify Fix
-->