### PR TITLE
Fix intermittent failure in SNDTest and cleanup some helpers

### DIFF
--- a/snd/test/src/org/labkey/test/components/snd/CategoryEditRow.java
+++ b/snd/test/src/org/labkey/test/components/snd/CategoryEditRow.java
@@ -57,7 +57,7 @@ public class CategoryEditRow extends WebDriverComponent<CategoryEditRow.ElementC
     public CategoryEditRow setDescription(String value)
     {
         elementCache().descriptionInput.set(value);
-        getWrapper().waitFor(()-> elementCache().descriptionInput.get() == value, 2000);
+        WebDriverWrapper.waitFor(()-> value.equals(elementCache().descriptionInput.get()), 2000);
         return this;
     }
 
@@ -80,7 +80,7 @@ public class CategoryEditRow extends WebDriverComponent<CategoryEditRow.ElementC
     public void delete()
     {
         getWrapper().fireEvent(elementCache().deleteLI, WebDriverWrapper.SeleniumEvent.mouseover);
-        getWrapper().waitFor(()-> elementCache().deleteLI.isEnabled() && elementCache().deleteLI.isSelected(), 2000);
+        WebDriverWrapper.waitFor(()-> elementCache().deleteLI.isEnabled() && elementCache().deleteLI.isSelected(), 2000);
         elementCache().deleteLI.click();
     }
 
@@ -90,7 +90,7 @@ public class CategoryEditRow extends WebDriverComponent<CategoryEditRow.ElementC
         return new ElementCache();
     }
 
-    protected class ElementCache extends Component.ElementCache
+    protected class ElementCache extends Component<?>.ElementCache
     {
         Input descriptionInput = Input(Locators.descriptionEdit(), getDriver()).timeout(4000).findWhenNeeded(this);
         Checkbox activeCheckBox  = Checkbox.Checkbox(

--- a/snd/test/src/org/labkey/test/components/snd/SuperPackageRow.java
+++ b/snd/test/src/org/labkey/test/components/snd/SuperPackageRow.java
@@ -61,38 +61,41 @@ public class SuperPackageRow extends WebDriverComponent<SuperPackageRow.ElementC
     public SuperPackageRow select() // note: this 'selection' behavior is expressed among assigned packages, not among available packages
     {
         if (!isSelected())
-            newElementCache().desc.click();
-        getWrapper().waitFor(()-> isSelected(),
+            elementCache().desc.click();
+        WebDriverWrapper.waitFor(this::isSelected,
                 "row item never became selected",2000);
         return this;
     }
 
     public String getLabel()
     {
-        return newElementCache().desc.getText();
+        return elementCache().desc.getText();
     }
 
     public SuperPackageRow clickMenuItem(String menuText)
     {
-       getWrapper().fireEvent(newElementCache().menuToggle, WebDriverWrapper.SeleniumEvent.mouseover);
-       newElementCache().menuToggle.click();
-       // wait for the menu to expand
-       getWrapper().waitFor(()-> newElementCache().menuToggle.getAttribute("class").contains("open"), 1000);
-       Locator menuItem = Locator.tagWithAttribute("li", "role", "presentation")
-               .child(Locator.tagWithAttribute("a", "role", "menuitem")
-                       .containing(menuText));
-       WebElement itemToClick = menuItem.waitForElement(getComponentElement(), 2000);
-       getWrapper().fireEvent(newElementCache().menuToggle, WebDriverWrapper.SeleniumEvent.mouseover);
-       getWrapper().waitFor(()-> itemToClick.isEnabled(), 2000);
-       itemToClick.click();
-       // wait for the menu to collapse (or disappear, if 'remove' was the action')
-       getWrapper().waitFor(()-> {
-           try
-           {
-               return newElementCache().menuToggle.getAttribute("aria-expanded").equals("false");
-           }catch (StaleElementReferenceException sere){return true;}
-           }, 1000);
-       return this;
+        getWrapper().mouseOver(this.getComponentElement());
+        elementCache().menuToggle.click();
+        // wait for the menu to expand
+        WebDriverWrapper.waitFor(() -> elementCache().menuToggle.getAttribute("aria-expanded").equals("true"), () -> "Menu didn't open: " + getLabel(), 1000);
+        Locator menuItem = Locator.tagWithAttribute("li", "role", "presentation")
+            .child(Locator.tagWithAttribute("a", "role", "menuitem")
+                .containing(menuText));
+        WebElement itemToClick = menuItem.waitForElement(getComponentElement(), 2000);
+        WebDriverWrapper.waitFor(itemToClick::isEnabled, () -> "Menu item not enabled: " + menuText, 2000);
+        itemToClick.click();
+        // wait for the menu to collapse (or disappear, if 'remove' was the action')
+        WebDriverWrapper.waitFor(() -> {
+            try
+            {
+                return elementCache().menuToggle.getAttribute("aria-expanded").equals("false");
+            }
+            catch (StaleElementReferenceException sere)
+            {
+                return true;
+            }
+        }, "Menu didn't close", 1000);
+        return this;
     }
 
     @Override
@@ -101,7 +104,7 @@ public class SuperPackageRow extends WebDriverComponent<SuperPackageRow.ElementC
         return new ElementCache();
     }
 
-    protected class ElementCache extends Component.ElementCache
+    protected class ElementCache extends Component<?>.ElementCache
     {
         public WebElement menuToggle = Locator.tagWithClassContaining("div", "btn-group") // sometimes dropdown, dropup
                         .child(Locator.id("superpackage-actions"))

--- a/snd/test/src/org/labkey/test/pages/snd/EditCategoriesPage.java
+++ b/snd/test/src/org/labkey/test/pages/snd/EditCategoriesPage.java
@@ -18,10 +18,12 @@ package org.labkey.test.pages.snd;
 import org.labkey.test.Locator;
 import org.labkey.test.WebDriverWrapper;
 import org.labkey.test.WebTestHelper;
+import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.snd.CategoryEditRow;
 import org.labkey.test.pages.LabKeyPage;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import java.util.List;
 
@@ -73,18 +75,32 @@ public class EditCategoriesPage extends LabKeyPage<EditCategoriesPage.ElementCac
 
     public EditCategoriesPage clickSave()
     {
-        waitFor(()-> elementCache().saveButton.getAttribute("disabled")==null,
-                "'Save' button is disabled", 2000);
-        elementCache().saveButton.click();
-        sleep(1000);    // todo: wait for save button to detatch/unmount before re-mounting into next page view
+        return clickSave(false);
+    }
+
+    public EditCategoriesPage clickSaveAndConfirmDelete()
+    {
+        return clickSave(true);
+    }
+
+    public EditCategoriesPage clickSave(boolean confirmDelete)
+    {
+        shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().saveButton)).click();
+        if (confirmDelete)
+        {
+            new ModalDialog.ModalDialogFinder(getDriver())
+                .withBodyTextContaining("Are you sure you want to delete row").find()
+                .dismiss("Submit Changes");
+        }
+        shortWait().until(ExpectedConditions.stalenessOf(elementCache().saveButton));
+        clearCache();
         return new EditCategoriesPage(getDriver());
     }
 
     public PackageListPage clickCancel()
     {
-        waitFor(()-> elementCache().cancelButton.getAttribute("disabled")==null,
-                "'Cancel' button is disabled", 2000);
-        elementCache().cancelButton.click();
+        shortWait().until(ExpectedConditions.elementToBeClickable(elementCache().cancelButton)).click();
+        shortWait().until(ExpectedConditions.stalenessOf(elementCache().cancelButton));
         return new PackageListPage(getDriver());
     }
 
@@ -98,7 +114,7 @@ public class EditCategoriesPage extends LabKeyPage<EditCategoriesPage.ElementCac
     {
         // TODO: Add other elements that are on the page
         WebElement addCategoriesBtn = Locator.tag("div").containing("Add Category")
-                .withChild(Locator.tagWithClass("i", "fa fa-plus-circle"))
+                .withChild(Locator.tagWithClass("i", "fa-plus-circle"))
                 .findWhenNeeded(getDriver()).withTimeout(4000);
         WebElement cancelButton = Locator.button("Cancel").findWhenNeeded(getDriver()).withTimeout(4000);
         WebElement saveButton = Locator.button("Save").findWhenNeeded(getDriver()).withTimeout(4000);

--- a/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
+++ b/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
@@ -16,6 +16,8 @@
 
 package org.labkey.test.tests.snd;
 
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -41,7 +43,6 @@ import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.Git;
 import org.labkey.test.components.CustomizeView;
-import org.labkey.test.components.bootstrap.ModalDialog;
 import org.labkey.test.components.snd.AttributeGridRow;
 import org.labkey.test.components.snd.AttributesGrid;
 import org.labkey.test.components.snd.CategoryEditRow;
@@ -63,12 +64,11 @@ import org.labkey.test.util.PortalHelper;
 import org.labkey.test.util.SqlserverOnlyTest;
 import org.labkey.test.util.StudyHelper;
 import org.labkey.test.util.core.webdav.WebDavUploadHelper;
-import org.openqa.selenium.WebElement;
 
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -859,7 +859,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
     // If values exist this will delete them.  Path of project folder must be valid.
     protected void deleteIfNeeded(String path, String schemaName, String queryName, Map<String, Object> map, String pkName) throws IOException, CommandException
     {
-        Connection cn = createDefaultConnection(false);
+        Connection cn = createDefaultConnection();
 
         SelectRowsCommand selectCmd = new SelectRowsCommand(schemaName, queryName);
         selectCmd.addFilter(new Filter(pkName, map.get(pkName)));
@@ -906,6 +906,12 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         // These will run as part of project setup to populate data
         testSNDImport();
         testPackageApis();
+    }
+
+    @Override
+    protected boolean allowTimeZoneShifting()
+    {
+        return false;
     }
 
     private void setupTest1Project()
@@ -1480,7 +1486,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         waitFor(()-> false, 2000);
 
         SelectRowsCommand catsCmd = new SelectRowsCommand("snd", "PkgCategories");
-        SelectRowsResponse afterCats = catsCmd.execute(createDefaultConnection(false), getProjectName());
+        SelectRowsResponse afterCats = catsCmd.execute(createDefaultConnection(), getProjectName());
 
         assertTrue("our category should have been created, but was not",
                 afterCats.getRows().stream().anyMatch((a)-> a.get("Description").equals(ourNewCategory)));
@@ -1497,22 +1503,18 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         catMap.put("Active", true);
         catMap.put("Comment", "delete me");
         cmd.addRow(catMap);
-        RowsResponse response = cmd.execute(createDefaultConnection(false), getProjectName());
+        RowsResponse response = cmd.execute(createDefaultConnection(), getProjectName());
 
         PackageListPage listPage = PackageListPage.beginAt(this , getProjectName());
         EditCategoriesPage catPage = listPage.clickEditCategories();
 
-        // after clicking 'save' we expect to have to dismiss the dialog for deleting the 'weight' category
-
         catPage.deleteCategory(ourCategory);
-        catPage.clickSave();
-        ModalDialog.finder(getDriver())
-                .withBodyTextContaining("Are you sure you want to delete row").find()
-                .dismiss("Submit Changes");
-        waitFor(()-> false, 2000);
+        catPage.clickSaveAndConfirmDelete();
+
+        sleep(2000);
 
         SelectRowsCommand catsCmd = new SelectRowsCommand("snd", "PkgCategories");
-        SelectRowsResponse afterCats = catsCmd.execute(createDefaultConnection(false), getProjectName());
+        SelectRowsResponse afterCats = catsCmd.execute(createDefaultConnection(), getProjectName());
 
         assertFalse("our category should have been deleted, but was not",
                 afterCats.getRows().stream().anyMatch((a)-> a.get("Description").equals(ourCategory)));
@@ -1530,7 +1532,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         catMap.put("Active", true);
         catMap.put("Comment", "edit me so hard!"); // comment is not shown in the UI
         cmd.addRow(catMap);
-        RowsResponse response = cmd.execute(createDefaultConnection(false), getProjectName());
+        RowsResponse response = cmd.execute(createDefaultConnection(), getProjectName());
         assertEquals(200, response.getStatusCode());
 
         PackageListPage listPage = PackageListPage.beginAt(this , getProjectName());
@@ -1554,7 +1556,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         assertEquals("test edit category should have new description", editedCategory, ourCat.getDescription());
 
         SelectRowsCommand catsCmd = new SelectRowsCommand("snd", "PkgCategories");
-        SelectRowsResponse afterCats = catsCmd.execute(createDefaultConnection(false), getProjectName());
+        SelectRowsResponse afterCats = catsCmd.execute(createDefaultConnection(), getProjectName());
         assertTrue("our category should have been edited, but was not",
                 afterCats.getRows().stream().anyMatch((a)-> a.get("Description").equals(editedCategory)));
         assertFalse("our category should have been edited, but was not",
@@ -1566,7 +1568,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
     {
         clickFolder(TEST1SUBFOLDER);
 
-        Connection cn = createDefaultConnection(false);
+        Connection cn = createDefaultConnection();
 
         InsertRowsCommand insertRowsCommand = new InsertRowsCommand("snd", "Pkgs");
         insertRowsCommand.addRow(TEST1ROW1MAP);
@@ -2121,22 +2123,16 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
     private String getPermissionTableValue(int row, int col)
     {
-        List<WebElement> els = ((Locator.XPathLocator)getSimpleTableCell(Locator.id("category-security"), row, col)).child("div").child("a").child("input").findElements(getDriver());
-        if (!els.isEmpty())
-        {
-            return els.get(0).getAttribute("value");
-        }
-
-        return null;
+        return ((Locator.XPathLocator)getSimpleTableCell(Locator.id("category-security"), row, col)).child("div").child("a").child("input").findElement(getDriver())
+            .getAttribute("value");
     }
 
     private void clickRoleInOpenDropDown(String name)
     {
-        List<WebElement> els = Locator.tagWithClassContaining("div", "btn-group open").child("ul").child("li").child("a").withText(name).findElements(getDriver());
-        if (!els.isEmpty())
-        {
-            els.get(0).click();
-        }
+        Locator.tag("div").withClasses("btn-group", "open").child("ul").child("li").child("a")
+            .withText(name)
+            .findElement(getDriver())
+            .click();
     }
 
     @Test
@@ -2147,7 +2143,7 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         log("Create permission categories");
         List<String> categories = Arrays.asList("Permission category 1", "Permission category 2", "Permission category 3");
         List<String> permissions = Arrays.asList("SND Reader", "SND Basic Submitter", "SND Data Reviewer");
-        List<Integer> categoryRows = new ArrayList<>();
+        Map<String, Integer> categoryRows = new HashMap<>();
         PackageListPage listPage = PackageListPage.beginAt(this , getProjectName());
         EditCategoriesPage catPage = listPage.clickEditCategories();
 
@@ -2155,58 +2151,57 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
         for (String category : categories)
         {
             catPage.addCategory(category, true);
-            catPage = catPage.clickSave();
-            waitFor(() -> false, 2000);
         }
+        catPage.clickSave();
 
         log("Check link on admin page.");
         beginAt(WebTestHelper.buildURL("snd",getProjectName(), "admin"));
 
-        assertElementPresent(Locator.linkWithText("SND Security"));
-        click(Locator.linkWithText("SND Security"));
-        String value;
+        clickAndWait(Locator.linkWithText("SND Security"));
         int rowCount = getTableRowCount("category-security") - 1;
 
         for (int i = 0; i < rowCount; i++)
         {
-            if (categories.contains(getTableCellText(Locator.id("category-security"), i, 0)))
+            String categoryName = getTableCellText(Locator.id("category-security"), i, 0);
+            if (categories.contains(categoryName))
             {
-                value = getPermissionTableValue(i, 1);
-                assertNotNull(value);
+                String value = getPermissionTableValue(i, 1); // Administrator permission
                 assertEquals("None", value);
-                categoryRows.add(i);
+                categoryRows.put(categoryName, i);
             }
         }
+        Assertions.assertThat(categoryRows.keySet()).as("Custom categories")
+            .containsExactlyElementsOf(categories);
 
-        click(Locator.id("a_all_-3"));
+        click(Locator.id("a_all_-3")); // All Categories for Guests
         clickRoleInOpenDropDown("SND Reader");
 
-        for (Integer r : categoryRows)
+        for (Integer r : categoryRows.values())
         {
-            value = getPermissionTableValue(r, 1);
-            assertNotNull(value);
-            assertEquals("SND Reader", value);
+            String value = getPermissionTableValue(r, 1);
+            // Wait for setting to propagate
+            Awaitility.await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertEquals("SND Reader", value));
         }
 
         findButton("Clear All").click();
         acceptAlert();
 
-        for (int k = 0; k < categoryRows.size(); k++)
+        for (String category : categories)
         {
-            value = getPermissionTableValue(categoryRows.get(k), 1);
-            assertNotNull(value);
+            Integer row = categoryRows.get(category);
+            String value = getPermissionTableValue(row, 1);
             assertEquals("None", value);
-            click(getSimpleTableCell(Locator.id("category-security"), categoryRows.get(k), 1));
-            clickRoleInOpenDropDown(permissions.get(k));
+            click(getSimpleTableCell(Locator.id("category-security"), row, 1));
+            clickRoleInOpenDropDown(permissions.get(categories.indexOf(category)));
         }
 
         waitAndClickAndWait(Locator.linkContainingText("Save"));
 
-        for (int j = 0; j < categoryRows.size(); j++)
+        for (String category : categories)
         {
-            value = getPermissionTableValue(categoryRows.get(j), 1);
-            assertNotNull(value);
-            assertEquals(value, permissions.get(j));
+            Integer row = categoryRows.get(category);
+            String value = getPermissionTableValue(row, 1);
+            assertEquals(permissions.get(categories.indexOf(category)), value);
         }
 
     }
@@ -2289,11 +2284,11 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
     private void truncateSndPkg() throws Exception
     {
         //cleanup - truncate snd.pkgs
-        Connection conn = createDefaultConnection(false);
+        Connection conn = createDefaultConnection();
         TruncateTableCommand command = new TruncateTableCommand("snd", "Pkgs");
         command.execute(conn, getProjectName());
 
-        conn = createDefaultConnection(false);
+        conn = createDefaultConnection();
         SelectRowsCommand selectRowsCommand = new SelectRowsCommand("snd", "Pkgs");
         SelectRowsResponse selectRowsResponse = selectRowsCommand.execute(conn, getProjectName());
         assertEquals("Zero row count expected after truncating snd.Pkgs", 0, selectRowsResponse.getRows().size());


### PR DESCRIPTION
#### Rationale
When testing the SND permissions UI, the combo box selection for all categories takes a moment to propagate to the individual categories.
```
org.junit.ComparisonFailure: expected:<[SND Reader]> but was:<[None]>
  at org.junit.Assert.assertEquals(Assert.java:117)
  at org.junit.Assert.assertEquals(Assert.java:146)
  at org.labkey.test.tests.snd.SNDTest.categoryPermissionsUI(SNDTest.java:2188)
```

Also making some improvements to address some test synchronization issues that I was hitting locally but aren't causing problems on TeamCity at the moment.

#### Related Pull Requests
* N/A

#### Changes
* Fix intermittent failure in SNDTest.categoryPermissionsUI
* Cleanup some SND test components
