### PR TITLE
Give EHRSecurityEscalationDomainKind a unique prefix

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.api.ehr.security;
 
-import org.labkey.api.audit.query.AbstractAuditDomainKind;
 import org.labkey.api.data.Container;
 import org.labkey.api.study.security.SecurityEscalationAuditProvider;
 
@@ -27,8 +26,14 @@ public class EHRSecurityEscalatorAuditProvider extends SecurityEscalationAuditPr
     public static String EVENT_TYPE = EHRSecurityEscalationEvent.class.getSimpleName();
     public static String AUDIT_LOG_TITLE = "EHR Security Escalations";
 
+    public EHRSecurityEscalatorAuditProvider()
+    {
+        super(new EHRSecurityEscalationDomainKind());
+    }
+
     @Override
-    public String getDescription() {
+    public String getDescription()
+    {
         return "This audits all uses of the EHR Security Escalation";
     }
 
@@ -45,12 +50,6 @@ public class EHRSecurityEscalatorAuditProvider extends SecurityEscalationAuditPr
     @Override
     public String getAuditLogTitle() {
         return AUDIT_LOG_TITLE;
-    }
-
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
-    {
-        return new EHRSecurityEscalationDomainKind();
     }
 
     public static class EHRSecurityEscalationEvent extends SecurityEscalationEvent

--- a/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
@@ -76,5 +76,11 @@ public class EHRSecurityEscalatorAuditProvider extends SecurityEscalationAuditPr
         {
             super(EVENT_TYPE, EHRSecurityEscalationEvent.class.getName());
         }
+
+        @Override
+        protected String getNamespacePrefix()
+        {
+            return NAMESPACE_PREFIX + "EHRSecurityEscalationDomain";
+        }
     }
 }

--- a/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
+++ b/ehr/api-src/org/labkey/api/ehr/security/EHRSecurityEscalatorAuditProvider.java
@@ -48,8 +48,9 @@ public class EHRSecurityEscalatorAuditProvider extends SecurityEscalationAuditPr
     }
 
     @Override
-    protected AbstractAuditDomainKind getDomainKind() {
-        return new EHRSecurityEscalationDomain();
+    protected AbstractAuditDomainKind getDomainKind()
+    {
+        return new EHRSecurityEscalationDomainKind();
     }
 
     public static class EHRSecurityEscalationEvent extends SecurityEscalationEvent
@@ -69,9 +70,10 @@ public class EHRSecurityEscalatorAuditProvider extends SecurityEscalationAuditPr
         }
     }
 
-    public static class EHRSecurityEscalationDomain extends SecurityEscalationAuditDomainKind
+    public static class EHRSecurityEscalationDomainKind extends SecurityEscalationAuditDomainKind
     {
-        public EHRSecurityEscalationDomain() {
+        public EHRSecurityEscalationDomainKind()
+        {
             super(EVENT_TYPE, EHRSecurityEscalationEvent.class.getName());
         }
     }

--- a/snd/src/org/labkey/snd/NarrativeAuditProvider.java
+++ b/snd/src/org/labkey/snd/NarrativeAuditProvider.java
@@ -42,10 +42,10 @@ public class NarrativeAuditProvider extends AbstractAuditTypeProvider implements
     public static final String COLUMN_NAME_EVENTDATE = "EventDate";
     public static final String COLUMN_NAME_QCSTATE = "QcState";
 
-    static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
+    private static final List<FieldKey> defaultVisibleColumns = new ArrayList<>();
 
-    static {
-
+    static
+    {
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_CREATED_BY));
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_IMPERSONATED_BY));
@@ -57,10 +57,9 @@ public class NarrativeAuditProvider extends AbstractAuditTypeProvider implements
         defaultVisibleColumns.add(FieldKey.fromParts(COLUMN_NAME_QCSTATE));
     }
 
-    @Override
-    protected AbstractAuditDomainKind getDomainKind()
+    public NarrativeAuditProvider()
     {
-        return new org.labkey.snd.NarrativeAuditProvider.NarrativeAuditDomainKind();
+        super(new NarrativeAuditDomainKind());
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
In the course of working on audit domain index handling, I discovered that this class provided a namespace prefix of just "Audit-" (no further clarifier) which overlapped with most other prefixes and caused this domain kind (and its sibling `StudySecurityEscalationDomainKind`) to get attached to many unassociated domains. The class also sported a confusing name.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6967

#### Changes
* Update to a more specific namespace prefix for domains created in the future but add a custom resolver that recognizes the old-style URI
