### PR TITLE
Use "Id" for insert rows key instead of "participantid" (which is a column alias)

### DIFF
--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -690,7 +690,6 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                 }
 
                 row.put("Id", subjectId);
-                //row.put("participantid", subjectId);
                 row.put("date", date);
                 row.put("coefficient", Double.parseDouble(fields[1]));
 

--- a/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
+++ b/ehr/src/org/labkey/ehr/pipeline/GeneticCalculationsImportTask.java
@@ -689,8 +689,8 @@ public class GeneticCalculationsImportTask extends PipelineJob.Task<GeneticCalcu
                     continue;
                 }
 
-                //row.put("Id", subjectId);
-                row.put("participantid", subjectId);
+                row.put("Id", subjectId);
+                //row.put("participantid", subjectId);
                 row.put("date", date);
                 row.put("coefficient", Double.parseDouble(fields[1]));
 


### PR DESCRIPTION
#### Rationale
The related PR updated which column alias mapping is generated during the insert rows call made for the GeneticCalculationsImportTask dataset data. This PR updates the data row keys to use the column name instead of the alias.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6939/files#diff-2a61025ca8763e384dc685f377df1b80ae666e6d01f5182f2b10abfc7c894accL252

#### Changes
- import dataset row data using "Id" as the subject key
