### PR TITLE
Actually wait for SND permissions to propagate

### DIFF
--- a/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
+++ b/snd/test/src/org/labkey/test/tests/snd/SNDTest.java
@@ -2178,9 +2178,9 @@ public class SNDTest extends BaseWebDriverTest implements SqlserverOnlyTest
 
         for (Integer r : categoryRows.values())
         {
-            String value = getPermissionTableValue(r, 1);
             // Wait for setting to propagate
-            Awaitility.await().atMost(Duration.ofSeconds(1)).untilAsserted(() -> assertEquals("SND Reader", value));
+            Awaitility.await().atMost(Duration.ofSeconds(1)).untilAsserted(() ->
+                assertEquals("SND Reader", getPermissionTableValue(r, 1)));
         }
 
         findButton("Clear All").click();


### PR DESCRIPTION
#### Rationale
The previous fix didn't actually wait for the permissions to update.

#### Related Pull Requests
* #1020 

#### Changes
* Actually wait for SND permissions to propagate