### PR TITLE
Use EHR Study Container Entity Id instead of Study Entity Id to generate cache key

### DIFF
--- a/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
+++ b/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
@@ -224,29 +224,25 @@ public class EHRSecurityManager
         if (targetContainer == null)
             return Collections.emptyMap();
 
-        Study study = StudyService.get().getStudy(targetContainer);
-        if (study == null)
-            return Collections.emptyMap();
-
-        String cacheKey = getCacheKey(study, QCSTATE_CACHE_ID);
+        String cacheKey = getCacheKey(c, QCSTATE_CACHE_ID);
         Map<String, EHRQCState> qcStates = (Map<String, EHRQCState>) DataEntryManager.get().getCache().get(cacheKey);
         if (qcStates != null)
             return qcStates;
 
         qcStates = new HashMap<>();
-        for (EHRQCState qc : EHRManager.get().getQCStates(study.getContainer()))
+        for (EHRQCState qc : EHRManager.get().getQCStates(c))
         {
             qcStates.put(qc.getLabel(), qc);
         }
 
         qcStates = Collections.unmodifiableMap(qcStates);
-        DataEntryManager.get().getCache().put(getCacheKey(study, QCSTATE_CACHE_ID), qcStates);
+        DataEntryManager.get().getCache().put(getCacheKey(c, QCSTATE_CACHE_ID), qcStates);
 
         return qcStates;
     }
 
-    private String getCacheKey(Study s, String suffix)
+    private String getCacheKey(Container c, String suffix)
     {
-        return getClass().getName() + "||" + s.getEntityId() + "||" + suffix;
+        return getClass().getName() + "||" + c.getEntityId() + "||" + suffix;
     }
 }

--- a/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
+++ b/ehr/src/org/labkey/ehr/security/EHRSecurityManager.java
@@ -224,19 +224,19 @@ public class EHRSecurityManager
         if (targetContainer == null)
             return Collections.emptyMap();
 
-        String cacheKey = getCacheKey(c, QCSTATE_CACHE_ID);
+        String cacheKey = getCacheKey(targetContainer, QCSTATE_CACHE_ID);
         Map<String, EHRQCState> qcStates = (Map<String, EHRQCState>) DataEntryManager.get().getCache().get(cacheKey);
-        if (qcStates != null)
+        if (qcStates != null && !qcStates.isEmpty())
             return qcStates;
 
         qcStates = new HashMap<>();
-        for (EHRQCState qc : EHRManager.get().getQCStates(c))
+        for (EHRQCState qc : EHRManager.get().getQCStates(targetContainer))
         {
             qcStates.put(qc.getLabel(), qc);
         }
 
         qcStates = Collections.unmodifiableMap(qcStates);
-        DataEntryManager.get().getCache().put(getCacheKey(c, QCSTATE_CACHE_ID), qcStates);
+        DataEntryManager.get().getCache().put(getCacheKey(targetContainer, QCSTATE_CACHE_ID), qcStates);
 
         return qcStates;
     }


### PR DESCRIPTION
#### Rationale
Generating a cache key with the Study Entity Id requires the Study to be loaded. This becomes an issue when populating lookups - ex. for ehr_lookups.procedures, we want to allow procedures trigger to be registered and unregistered (as done in the related PR), which hits the code path addressed in this PR. In tests, lookups are populated before the Study is created, so the Study Entity Id isn't always available at that point - this causes test failures for the clients that populate ehr_lookups.procedures.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/1018

#### Changes
* Use EHR Study Container Entity Id instead of Study Entity Id to generate cache key