### PR TITLE
EHR study participant override

### DIFF
--- a/ehr/resources/views/participant.html
+++ b/ehr/resources/views/participant.html
@@ -1,0 +1,6 @@
+
+<script nonce="<%=scriptNonce%>">
+    const id = LABKEY.ActionURL.getParameter("participantId");
+    const url = LABKEY.ActionURL.buildURL("ehr", "participantView", null, {participantId: id})
+    window.location.href = url;
+</script>


### PR DESCRIPTION
#### Rationale
There are still a couple places in EHR, such as site search results, that show the base study participant view. This PR overrides that view to use EHR participant view. Goes to base EHR participantView but this action should be overridden to custom participantViews as necessary.

#### Changes
* participant HTML override with redirect
