### PR TITLE
Mark SND and EHR_ComplianceDB as schema version managed by LabKey

### DIFF
--- a/EHR_ComplianceDB/module.properties
+++ b/EHR_ComplianceDB/module.properties
@@ -1,5 +1,5 @@
 ModuleClass: org.labkey.ehr_compliancedb.EHR_ComplianceDBModule
-ManageVersion: false
+ManageVersion: true
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql, pgsql

--- a/snd/module.properties
+++ b/snd/module.properties
@@ -4,3 +4,4 @@ Description: Dynamically defined hierarchical datasets.
 License: Apache 2.0
 LicenseURL: http://www.apache.org/licenses/LICENSE-2.0
 SupportedDatabases: mssql
+ManageVersion: true


### PR DESCRIPTION
#### Rationale
We manage the schema versions of these modules