### PR TITLE
Migrate away from deprecated SampleTypeService method

### DIFF
--- a/EHR_SM/src/org/labkey/ehr_sm/EHR_SMController.java
+++ b/EHR_SM/src/org/labkey/ehr_sm/EHR_SMController.java
@@ -116,7 +116,7 @@ public class EHR_SMController extends SpringActionController
         {
             PropertyManager.PropertyMap props = PropertyManager.getProperties(getContainer(), EHR_SMManager.ANIMAL_SAMPLE_PROP_SET_NAME);
             adminForm.setSelectedAnimalSampleTypes(props.keySet().toArray(new String[0]));
-            adminForm.setAnimalSampleTypes(SampleTypeService.get().getSampleTypes(getContainer(), getUser(), true));
+            adminForm.setAnimalSampleTypes(SampleTypeService.get().getSampleTypes(getContainer(), true));
             adminForm.setSampleReceivedCol(props.get(EHR_SMManager.ANIMAL_SAMPLE_RECEIVED_PROP));
 
             JspView<AdminForm> view = new JspView<>("/org/labkey/ehr_sm/view/admin.jsp", adminForm, errors);
@@ -129,7 +129,7 @@ public class EHR_SMController extends SpringActionController
         public boolean handlePost(AdminForm adminForm, BindException errors)
         {
             WritablePropertyMap props = PropertyManager.getWritableProperties(getContainer(), EHR_SMManager.ANIMAL_SAMPLE_PROP_SET_NAME, true);
-            for (ExpSampleType animalSampleType : SampleTypeService.get().getSampleTypes(getContainer(), getUser(), true))
+            for (ExpSampleType animalSampleType : SampleTypeService.get().getSampleTypes(getContainer(), true))
             {
                 if (Arrays.stream(adminForm.getSelectedAnimalSampleTypes()).anyMatch(s -> s.equals(animalSampleType.getName())))
                 {


### PR DESCRIPTION
#### Rationale
Method no longer takes a `User` parameter

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7276
