### PR TITLE
Add supportsNonIdFilters to ehr.reports

### DIFF
--- a/ehr/resources/schemas/dbscripts/postgresql/ehr-26.000-26.001.sql
+++ b/ehr/resources/schemas/dbscripts/postgresql/ehr-26.000-26.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr.reports ADD supportsNonIdFilters BOOL DEFAULT NULL;

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-26.000-26.001.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-26.000-26.001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ehr.reports ADD supportsNonIdFilters BIT;

--- a/ehr/resources/schemas/ehr.xml
+++ b/ehr/resources/schemas/ehr.xml
@@ -442,6 +442,9 @@
             <column columnName="reportstatus">
                 <description>Optional, description to be presented to user along with report. Might indicate it's a work in progress, for example.</description>
             </column>
+            <column columnName="supportsNonIdFilters">
+                <nullable>true</nullable>
+            </column>
         </columns>
     </table>
     <table tableName="cage_observations" tableDbType="TABLE" useColumnOrder="true">

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -133,7 +133,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 26.000;
+        return 26.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
As we convert animal history to react, we'll want to allow filters beyond lists of ids. Not all reports currently support that, so this flag will indicate to animal history how to handle the reports.

#### Changes
* Upgrade script to add supportsNonIdFilters to ehr.reports
