### PR TITLE
Allow registering multiple InvoicedItemsProcessingService impls

### DIFF
--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-26.001-26.002.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-26.001-26.002.sql
@@ -1,0 +1,7 @@
+-- ehr.Project.Created and ehr.Project.Modified are NULL on SQL Server but NOT NULL on PostgreSQL. Set the NULL values
+-- and switch the columns to NOT NULL to match PostgreSQL.
+UPDATE ehr.Project SET Created = diCreated WHERE Created IS NULL;
+UPDATE ehr.Project SET Modified = diModified WHERE Modified IS NULL;
+
+ALTER TABLE ehr.Project ALTER COLUMN Created DATETIME NOT NULL;
+ALTER TABLE ehr.Project ALTER COLUMN Modified DATETIME NOT NULL;

--- a/ehr/resources/schemas/dbscripts/sqlserver/ehr-26.001-26.002.sql
+++ b/ehr/resources/schemas/dbscripts/sqlserver/ehr-26.001-26.002.sql
@@ -1,7 +1,7 @@
 -- ehr.Project.Created and ehr.Project.Modified are NULL on SQL Server but NOT NULL on PostgreSQL. Set the NULL values
 -- and switch the columns to NOT NULL to match PostgreSQL.
-UPDATE ehr.Project SET Created = diCreated WHERE Created IS NULL;
-UPDATE ehr.Project SET Modified = diModified WHERE Modified IS NULL;
+UPDATE ehr.Project SET Created = COALESCE(diCreated, GETDATE()) WHERE Created IS NULL;
+UPDATE ehr.Project SET Modified = COALESCE(diModified, GETDATE()) WHERE Modified IS NULL;
 
 ALTER TABLE ehr.Project ALTER COLUMN Created DATETIME NOT NULL;
 ALTER TABLE ehr.Project ALTER COLUMN Modified DATETIME NOT NULL;

--- a/ehr/src/org/labkey/ehr/EHRModule.java
+++ b/ehr/src/org/labkey/ehr/EHRModule.java
@@ -135,7 +135,7 @@ public class EHRModule extends ExtendedSimpleModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 26.001;
+        return 26.002;
     }
 
     @Override

--- a/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
+++ b/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
@@ -22,32 +22,45 @@ import org.labkey.api.data.Container;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.module.Module;
 import org.labkey.api.pipeline.PipelineJobException;
 import org.labkey.api.query.FieldKey;
 import org.labkey.api.query.QueryService;
 import org.labkey.api.security.User;
-import org.labkey.api.services.ServiceRegistry;
 import org.labkey.api.util.Pair;
 
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Service to get a list of queries to be processed during a Billing Run. The listing is a collection of
  * BillingPipelineJobProcess objects that define what schema.query to execute and the mapping from that query's
  * columns to the ehr_billing.invoicedItem table's columns.
  * Additionally, get center specific generated invoice number.
- *
- * Currently registered server wide but should allow multiple co-existing services and resolve per container's active modules
  */
 public interface InvoicedItemsProcessingService
 {
-    @Nullable
-    static InvoicedItemsProcessingService get()
+    record Registration(String moduleName, InvoicedItemsProcessingService impl){}
+
+    List<Registration> REGISTRATION_LIST = new CopyOnWriteArrayList<>();
+
+    static void register(Module module, InvoicedItemsProcessingService impl)
     {
-        return ServiceRegistry.get().getService(InvoicedItemsProcessingService.class);
+        REGISTRATION_LIST.add(new Registration(module.getName(), impl));
+    }
+
+    @Nullable
+    static InvoicedItemsProcessingService get(Container c)
+    {
+        // Return the service implementation based on the registering module being active in the provided container
+        return REGISTRATION_LIST.stream()
+            .filter(reg -> c.hasActiveModuleByName(reg.moduleName()))
+            .map(Registration::impl)
+            .findFirst()
+            .orElse(null);
     }
 
     /** @return the inputs to the billing process that are capable of generating charges */

--- a/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
+++ b/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
@@ -49,7 +49,7 @@ public interface InvoicedItemsProcessingService
 
     static void register(Module module, InvoicedItemsProcessingService impl)
     {
-        REGISTRATION_LIST.add(new Registration(module.getName(), impl));
+        REGISTRATION_LIST.addFirst(new Registration(module.getName(), impl));
     }
 
     @Nullable

--- a/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
+++ b/ehr_billing/api-src/org/labkey/api/ehr_billing/pipeline/InvoicedItemsProcessingService.java
@@ -53,11 +53,11 @@ public interface InvoicedItemsProcessingService
     }
 
     @Nullable
-    static InvoicedItemsProcessingService get(Container c)
+    static InvoicedItemsProcessingService get(Container billingContainer)
     {
         // Return the service implementation based on the registering module being active in the provided container
         return REGISTRATION_LIST.stream()
-            .filter(reg -> c.hasActiveModuleByName(reg.moduleName()))
+            .filter(reg -> billingContainer.hasActiveModuleByName(reg.moduleName()))
             .map(Registration::impl)
             .findFirst()
             .orElse(null);

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingController.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingController.java
@@ -104,7 +104,7 @@ public class EHR_BillingController extends SpringActionController
                     throw new PipelineJobException("Cannot create a billing run with the same start and end date");
                 }
 
-                InvoicedItemsProcessingService processingService = InvoicedItemsProcessingService.get();
+                InvoicedItemsProcessingService processingService = InvoicedItemsProcessingService.get(getContainer());
                 if (null != processingService)
                 {
                     Pair<String,String> previousInvoice = processingService.verifyBillingRunPeriod(getUser(), getContainer(), form.getStartDate(), form.getEndDate());

--- a/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingController.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/EHR_BillingController.java
@@ -104,7 +104,7 @@ public class EHR_BillingController extends SpringActionController
                     throw new PipelineJobException("Cannot create a billing run with the same start and end date");
                 }
 
-                InvoicedItemsProcessingService processingService = InvoicedItemsProcessingService.get(getContainer());
+                InvoicedItemsProcessingService processingService = InvoicedItemsProcessingService.get(EHR_BillingManager.get().getBillingContainer(getContainer()));
                 if (null != processingService)
                 {
                     Pair<String,String> previousInvoice = processingService.verifyBillingRunPeriod(getUser(), getContainer(), form.getStartDate(), form.getEndDate());

--- a/ehr_billing/src/org/labkey/ehr_billing/pipeline/BillingTask.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/pipeline/BillingTask.java
@@ -84,7 +84,7 @@ public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
     protected BillingTask(Factory factory, PipelineJob job)
     {
         super(factory, job);
-        _processingService = InvoicedItemsProcessingService.get(job.getContainer());
+        _processingService = InvoicedItemsProcessingService.get(EHR_BillingManager.get().getBillingContainer(job.getContainer()));
     }
 
     public static class Factory extends AbstractTaskFactory<AbstractTaskFactorySettings, Factory>

--- a/ehr_billing/src/org/labkey/ehr_billing/pipeline/BillingTask.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/pipeline/BillingTask.java
@@ -78,11 +78,13 @@ import java.util.Set;
 public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
 {
     private final static DbSchema EHR_BILLING_SCHEMA = EHR_BillingSchema.getInstance().getSchema();
-    private final static InvoicedItemsProcessingService processingService =  InvoicedItemsProcessingService.get();
+
+    private final InvoicedItemsProcessingService _processingService;
 
     protected BillingTask(Factory factory, PipelineJob job)
     {
         super(factory, job);
+        _processingService = InvoicedItemsProcessingService.get(job.getContainer());
     }
 
     public static class Factory extends AbstractTaskFactory<AbstractTaskFactorySettings, Factory>
@@ -148,16 +150,16 @@ public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
         {
             getOrCreateInvoiceRunRecord();
             loadTransactionNumber();
-            processingService.setBillingStartDate(getSupport().getStartDate());
+            _processingService.setBillingStartDate(getSupport().getStartDate());
 
             if (null != _previousInvoice)
             {
-                processingService.processBillingRerun(_invoiceId, _invoiceRowId, getSupport().getStartDate(), getSupport().getEndDate(), getNextTransactionNumber(), user, billingContainer, getJob().getLogger());
+                _processingService.processBillingRerun(_invoiceId, _invoiceRowId, getSupport().getStartDate(), getSupport().getEndDate(), getNextTransactionNumber(), user, billingContainer, getJob().getLogger());
             }
             else
             {
 
-                for (BillingPipelineJobProcess process : processingService.getProcessList())
+                for (BillingPipelineJobProcess process : _processingService.getProcessList())
                 {
                     Container billingRunContainer = process.isUseEHRContainer() ? ehrContainer : billingContainer;
                     runProcessing(process, billingRunContainer);
@@ -166,7 +168,7 @@ public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
 
             updateInvoiceTable(billingContainer);
 
-            processingService.performAdditionalProcessing(_invoiceId, user, container);
+            _processingService.performAdditionalProcessing(_invoiceId, user, container);
 
             transaction.commit();
         }
@@ -278,7 +280,7 @@ public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
     @Nullable
     private String getOrCreateInvoiceRecord(Map<String, Object> row, Date endDate) throws PipelineJobException
     {
-        String invoiceNumber = processingService.getInvoiceNum(row, endDate);
+        String invoiceNumber = _processingService.getInvoiceNum(row, endDate);
         if (null != invoiceNumber)
         {
             try
@@ -499,25 +501,25 @@ public class BillingTask extends PipelineJob.Task<BillingTask.Factory>
 
                     // get cost
                     Double unitCost = ci.getUnitCost();
-                    procedureRow.put(processingService.getUnitCostColName(), unitCost);
+                    procedureRow.put(_processingService.getUnitCostColName(), unitCost);
 
                     // total cost
                     Double totalCost = unitCost * (Double) procedureRow.get("quantity");
-                    procedureRow.put(processingService.getTotalCostColName(), totalCost);
+                    procedureRow.put(_processingService.getTotalCostColName(), totalCost);
 
                     // calculate total cost with additional/other rate (ex. tier rate for WNPRC)
                     Double otherRate = (Double) procedureRow.get("otherRate");
                     Double unitCostWithOtherRate;
                     double totalCostWithOtherRate;
                     if (null != otherRate &&
-                            null != processingService.getAdditionalUnitCostColName() &&
-                            null != processingService.getAdditionalTotalCostColName())
+                            null != _processingService.getAdditionalUnitCostColName() &&
+                            null != _processingService.getAdditionalTotalCostColName())
                     {
                         unitCostWithOtherRate = unitCost + (unitCost * otherRate);
-                        procedureRow.put(processingService.getAdditionalUnitCostColName(), unitCostWithOtherRate);
+                        procedureRow.put(_processingService.getAdditionalUnitCostColName(), unitCostWithOtherRate);
 
                         totalCostWithOtherRate = unitCostWithOtherRate * (Double) procedureRow.get("quantity");
-                        procedureRow.put(processingService.getAdditionalTotalCostColName(), totalCostWithOtherRate);
+                        procedureRow.put(_processingService.getAdditionalTotalCostColName(), totalCostWithOtherRate);
                     }
                 }
                 writeToInvoicedItems(process, procedureRows, getSupport());


### PR DESCRIPTION
#### Rationale
https://github.com/LabKey/kanban/issues/1577

We need to allow multiple modules to register a `InvoicedItemsProcessingService` impl. Provide a module at registration time and a container at retrieval time. Determine the impl to return based on active modules in the container.

#### Related Pull Requests
* https://github.com/LabKey/wnprc-modules/pull/917
* https://github.com/LabKey/tnprcEHRModules/pull/248