### PR TITLE
Remove orphaned files from SND module

### DIFF
--- a/snd/resources/schemas/dbscripts/postgresql/snd-26.000-26.001.sql
+++ b/snd/resources/schemas/dbscripts/postgresql/snd-26.000-26.001.sql
@@ -1,6 +1,0 @@
--- Dropping idx_snd_lookups_lookupsetid [LookupSetId] because it overlaps with idx_snd_lookups_lookupsetid_value [LookupSetId, Value]
-DROP INDEX snd.idx_snd_lookups_lookupsetid;
--- Dropping idx_snd_pkgcategoryjunction_pkgid [PkgId] because it overlaps with pk_snd_pkgcategoryjunction [PkgId, CategoryId]
-DROP INDEX snd.idx_snd_pkgcategoryjunction_pkgid;
--- Dropping idx_snd_eventnotes_eventnoteid [EventNoteId] because it overlaps with pk_snd_eventnotes [EventNoteId]
-DROP INDEX snd.idx_snd_eventnotes_eventnoteid;


### PR DESCRIPTION
#### Rationale
SND has been moved to `ehrModules`. These files sneaked back in during merge conflict resolution from 26.5.

#### Related Pull Requests
* https://github.com/LabKey/ehrModules/pull/1128

#### Changes
* Remove orphaned files from SND module
