### PR TITLE
Avoid checks that will never be satisfied (Strings vs enums)

### DIFF
--- a/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ABI7500ImportMethod.java
+++ b/Viral_Load_Assay/src/org/labkey/viral_load_assay/assay/ABI7500ImportMethod.java
@@ -383,22 +383,6 @@ public class ABI7500ImportMethod extends DefaultVLImportMethod
                         continue;
                     }
 
-                    if (TYPE.Standard.equals(category))
-                    {
-                        map.putIfAbsent("sampleVol", 1);
-
-                        if (!(map.get(QUANTITY_FIELD) instanceof Double))
-                        {
-                            errors.addError("Row " + rowIdx + ": Quantity for standard was not a number: " + map.get(QUANTITY_FIELD));
-                            continue;
-                        }
-                    }
-                    else if (TYPE.NEG_CTL.equals(category))
-                    {
-                        map.putIfAbsent("sampleVol", 1);
-
-                    }
-
                     for (String field :  new String[]{"sampleVol", "volPerRxn", "eluateVol"})
                     {
                         if (map.get(field) == null)


### PR DESCRIPTION
#### Rationale
These if() statements will never evaluate true as they're comparing Strings and enums for equality. It's been that way since at least 2013.

#### Changes
* Delete the effectively dead code