### PR TITLE
Improve Save Template validation when no fields are selected

### DIFF
--- a/ehr/resources/web/ehr/window/SaveTemplateWindow.js
+++ b/ehr/resources/web/ehr/window/SaveTemplateWindow.js
@@ -202,20 +202,24 @@ Ext4.define('EHR.window.SaveTemplateWindow', {
 
         var tn = this.down('#templateName').getValue();
         var rows = [];
+        var noFieldsSelected = false;
 
         this.down('#theForm').items.each(function(tab){
             var radioGroup = tab.down('#recordSelector');
             var selections = radioGroup.getValue()[radioGroup.down('[name]').name];
-            var fields = tab.down('#fieldSelector').getValue().fields;
-
-            if (!fields.length)
-                return;
-
-            if (!(fields instanceof Array))  // single elements aren't wrapped in an array
-                fields = [fields];
 
             if (selections == 'none')
                 return;
+
+            var fields = tab.down('#fieldSelector').getValue().fields;
+
+            if (!fields || !fields.length){
+                noFieldsSelected = true;
+                return;
+            }
+
+            if (!(fields instanceof Array))  // single elements aren't wrapped in an array
+                fields = [fields];
 
             var store = Ext4.StoreMgr.get(tab.storeId);
 
@@ -249,7 +253,7 @@ Ext4.define('EHR.window.SaveTemplateWindow', {
 
         if (!rows.length){
             Ext4.Msg.hide();
-            Ext4.Msg.alert('Error', "No records selected");
+            Ext4.Msg.alert('Error', noFieldsSelected ? "At least one field is required and none are selected. Note: The field can be blank." : "No records selected");
             return;
         }
 


### PR DESCRIPTION
## Rationale

Submitting the EHR "Save As Template" dialog with every field unchecked threw an uncaught `TypeError: Cannot read properties of undefined (reading 'length')`. The checkboxgroup's `getValue().fields` is `undefined` when nothing is selected, so reading `.length` crashed `onSubmit` — the user got a silent failure (the template was never saved) plus a console error, instead of any guidance.

## Related Pull Requests

None.

## Changes

- Guard the selected-field list before reading `.length`, so an empty selection no longer throws.
- Evaluate the record-selector `'none'` case before the field check, so a section the user intends to save is distinguished from one explicitly excluded.
- When no fields are selected, show a clear validation message ("At least one field is required and none are selected. Note: The field can be blank.") instead of the generic "No records selected" alert.