### PR TITLE
Fix stored XSS in billing notification charge summary report

### DIFF
--- a/ehr_billing/src/org/labkey/ehr_billing/notification/BillingNotification.java
+++ b/ehr_billing/src/org/labkey/ehr_billing/notification/BillingNotification.java
@@ -464,8 +464,8 @@ public class BillingNotification extends AbstractNotification
 
                     String baseUrl = createURL(containerMap.get(category), centerSpecificBillingSchema, categoryToQuery.get(category), null) + "&query.param.StartDate=" + getDateFormat(c).format(start.getTime()) + "&query.param.EndDate=" + getDateFormat(c).format(endDate.getTime());
                     String projUrl = baseUrl + ("None".equals(tokens[1]) ? "&query.project~isblank" : "&query.project~eq=" + tokens[1]);
-                    msg.append("<tr><td>" + financialAnalyst + "</td>");    //the FA
-                    msg.append("<td><a href='" + projUrl + "'>" + tokens[1] + "</a></td>");
+                    msg.append("<tr><td>" + PageFlowUtil.filter(financialAnalyst) + "</td>");    //the FA
+                    msg.append("<td><a href='" + PageFlowUtil.filter(projUrl) + "'>" + PageFlowUtil.filter(tokens[1]) + "</a></td>");
 
                     String accountUrl = null;
                     Container financeContainer = EHR_BillingManager.get().getBillingContainer(containerMap.get(category));
@@ -476,22 +476,22 @@ public class BillingNotification extends AbstractNotification
 
                     if (accountUrl != null)
                     {
-                        msg.append("<td><a href='" + accountUrl + "'>" + tokens[2] + "</a></td>");
+                        msg.append("<td><a href='" + PageFlowUtil.filter(accountUrl) + "'>" + PageFlowUtil.filter(tokens[2]) + "</a></td>");
                     }
                     else
                     {
-                        msg.append("<td>" + (tokens[2]) + "</td>");
+                        msg.append("<td>" + PageFlowUtil.filter(tokens[2]) + "</td>");
                     }
 
-                    msg.append("<td>" + (tokens[3]) + "</td>");
-                    msg.append("<td>" + category + "</td>");
+                    msg.append("<td>" + PageFlowUtil.filter(tokens[3]) + "</td>");
+                    msg.append("<td>" + PageFlowUtil.filter(category) + "</td>");
 
                     for (FieldDescriptor fd : foundCols)
                     {
                         if (totals.containsKey(fd.getFieldName()))
                         {
                             String url = projUrl + fd.getFilter();
-                            msg.append("<td" + (fd.isShouldHighlight() ? " style='background-color: yellow;'" : "") + "><a href='" + url + "'>" + totals.get(fd.getFieldName()) + "</a></td>");
+                            msg.append("<td" + (fd.isShouldHighlight() ? " style='background-color: yellow;'" : "") + "><a href='" + PageFlowUtil.filter(url) + "'>" + totals.get(fd.getFieldName()) + "</a></td>");
                         }
                         else
                         {


### PR DESCRIPTION
## Rationale

BillingNotification.createChargeSummaryReport built its per-financial-analyst tables by concatenating editor-entered database values (investigator, project, debitedAccount, projectNumber, category) and their derived URLs directly into HTML with no escaping. That HTML is rendered verbatim into the LDK RunNotificationAction admin preview via HtmlString.unsafe and is also sent as the HTML email body, so a stored payload in any of those project/alias fields executed in the browser of any user who previewed the notification or received the email — a stored XSS with privilege-escalation potential toward admins. The adjacent Charge Summary category table already escaped its values with PageFlowUtil.filter; this loop was simply never given the same treatment.

## Related Pull Requests

None.

## Changes

- Wrap every editor-entered value (investigator, project, account, project number, category) in PageFlowUtil.filter before rendering it into the charge summary tables.
- Filter the derived href URLs (project, account, and per-field-descriptor links), which embed those same tainted values.