### PR TITLE
GH Issue 1186: Show validation indicator whenever validation disables the submit buttons

### DIFF
--- a/ehr/resources/web/ehr/panel/DataEntryPanel.js
+++ b/ehr/resources/web/ehr/panel/DataEntryPanel.js
@@ -379,16 +379,6 @@ Ext4.define('EHR.panel.DataEntryPanel', {
 
         this.add(toAdd);
         this.hasStoreCollectionLoaded = true;
-
-        // Load-time validation requests start before the form renders, so 'validationstart' has already fired (and
-        // was suppressed) and 'beforevalidation' never fires for them. If they are still in flight once the form is
-        // visible, show the indicator directly; 'validationcomplete' will hide it when they drain.
-        // Ext4.defer(function(){
-        //     if (this.storeCollection && this.storeCollection.validationRequestsInFlight > 0){
-        //         this.validationInProgress = true;
-        //         this.setValidationIndicatorVisible(true);
-        //     }
-        // }, this.storeCollection.clientDataChangeBuffer * 2, this);
     },
 
     updateMinWidth: function(minWidth){

--- a/ehr/resources/web/ehr/panel/DataEntryPanel.js
+++ b/ehr/resources/web/ehr/panel/DataEntryPanel.js
@@ -113,6 +113,12 @@ Ext4.define('EHR.panel.DataEntryPanel', {
                 }, this);
             }
         }
+
+        // Show the indicator here rather than relying solely on 'validationstart', which only fires when the in-flight
+        // request count transitions 0 -> 1. That transition can happen during initial load (where the indicator is
+        // suppressed) and won't fire again for validations queued behind those requests, leaving the buttons disabled
+        // with no indicator. Initial-load validation doesn't fire 'beforevalidation', so this stays quiet during load.
+        this.onValidationStart();
     },
 
     onValidationStart: function(){
@@ -147,6 +153,11 @@ Ext4.define('EHR.panel.DataEntryPanel', {
         if (this.storeCollection && this.storeCollection.validationRequestsInFlight > 0){
             return;
         }
+
+        // A validate cycle can send no requests (nothing produced commands), in which case 'validationcomplete' never
+        // fires. Clear the indicator whenever buttons are recalculated with no requests in flight.
+        this.validationInProgress = false;
+        this.setValidationIndicatorVisible(false);
 
         var maxSeverity = sc.getMaxErrorSeverity();
 
@@ -368,6 +379,16 @@ Ext4.define('EHR.panel.DataEntryPanel', {
 
         this.add(toAdd);
         this.hasStoreCollectionLoaded = true;
+
+        // Load-time validation requests start before the form renders, so 'validationstart' has already fired (and
+        // was suppressed) and 'beforevalidation' never fires for them. If they are still in flight once the form is
+        // visible, show the indicator directly; 'validationcomplete' will hide it when they drain.
+        // Ext4.defer(function(){
+        //     if (this.storeCollection && this.storeCollection.validationRequestsInFlight > 0){
+        //         this.validationInProgress = true;
+        //         this.setValidationIndicatorVisible(true);
+        //     }
+        // }, this.storeCollection.clientDataChangeBuffer * 2, this);
     },
 
     updateMinWidth: function(minWidth){


### PR DESCRIPTION
## Rationale

[GH Issue 1186](https://github.com/LabKey/internal-issues/issues/1186). The Validating... indicator added in the original submit-button work relied solely on the 'validationstart' event, which only fires when the in-flight validation request count transitions from 0 to 1. That transition can happen during initial form load, where the indicator is deliberately suppressed, and it does not fire again for validations queued behind those still-pending requests — leaving the submit buttons disabled with no indicator.

## Related Pull Requests

- https://github.com/LabKey/ehrModules/pull/1113

## Changes

- Show the indicator from 'beforevalidation' (the same event that disables the submit buttons) so the indicator and button state stay in sync by construction; the existing initial-load suppression is preserved since load-time validation does not fire 'beforevalidation'.
- Clear the indicator whenever the buttons are recalculated with no validation requests in flight, since a validate cycle that produces no commands sends no requests and never fires 'validationcomplete', which would otherwise leave the indicator stuck.