### PR TITLE
Fix bulk add writing wrong values and dropping rows and columns

### DIFF
--- a/ehr/resources/web/ehr/data/DataEntryServerStore.js
+++ b/ehr/resources/web/ehr/data/DataEntryServerStore.js
@@ -64,9 +64,17 @@ Ext4.define('EHR.data.DataEntryServerStore', {
                 }
             }, this);
 
-            if (ret){
-                return ret;
-            }
+            // An empty key cannot identify an existing record, so stop here rather than falling
+            // through to findExact() below -- an empty value matches ANY earlier unsaved record
+            // whose key is likewise empty, so the 2nd and later new rows all resolve to the 1st
+            // and collapse onto it, leaving only the last row's values. Returning nothing lets
+            // processServerRecords() create a server record bound to this client model instead.
+            //
+            // Only tables keyed on a server-assigned identity column hit this: study datasets key
+            // on objectid, which is generated client-side per row and so is never empty. A table
+            // whose sole key is a SERIAL (nbri_ehr.Conception.rowId) has an empty key on every new
+            // row, making it impossible to add more than one row per save.
+            return ret;
         }
 
         var idx = this.findExact(fieldName, value);

--- a/ehr/resources/web/ehr/window/FormBulkAddWindow.js
+++ b/ehr/resources/web/ehr/window/FormBulkAddWindow.js
@@ -55,6 +55,24 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return f.name;
         });
 
+        // A header matching no field silently drops its whole column, so keep the full set of recognized
+        // names to check the pasted header row against. Built from allConfigs rather than fieldConfigs so
+        // the fields the importer itself skips (hidden, taskid, qcstate) count as known but not importable
+        // and are passed over without complaint.
+        this.knownHeaders = {};
+        const addKnownHeader = (name) => {
+            const key = this.normalizeHeader(name);
+            if (key) {
+                this.knownHeaders[key] = true;
+            }
+        };
+        allConfigs.forEach((f) => {
+            addKnownHeader(f.name);
+            (Ext4.isArray(f.importAliases) ? f.importAliases : []).forEach(addKnownHeader);
+        });
+        // processRow() handles these directly, whether or not the section declares them.
+        ['Id', 'date', 'project'].forEach(addKnownHeader);
+
         this.items = [{
             html : 'This allows you to import data using a simple Excel or TSV file.  To import, cut/paste the contents of the Excel or TSV file (Ctl + A is a good way to select all) into the box below and hit submit. The limit for import is 250 rows.',
             style: 'padding-bottom: 10px;'
@@ -130,17 +148,24 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             errors.push('Row Count - ' + dataRowCount + ': Import maximum is 250 rows.  Please split your import into multiple uploads and submit the form between each upload.');
         }
         else {
+            const headerMap = this.buildHeaderMap(parsed[0]);
+            this.checkHeaders(parsed[0], errors);
 
-            for (let i = 1; i < parsed.length; i++) {
-                const row = parsed[i];
-                if (!row || row.length < this.requiredFieldNames.length) {
-                    errors.push('Row ' + i + ': not enough items in row');
-                    continue;
-                }
+            // Only parse rows once the header row is sound. A misspelled header for a required column
+            // otherwise reports as a missing value on every one of up to 250 rows, burying the one error
+            // that explains all of them.
+            if (!errors.length) {
+                for (let i = 1; i < parsed.length; i++) {
+                    const row = parsed[i];
+                    if (!row || row.length < this.requiredFieldNames.length) {
+                        errors.push('Row ' + i + ': not enough items in row');
+                        continue;
+                    }
 
-                const newRow = this.processRow(parsed[0], row, errors, i);
-                if (newRow) {
-                    records.push(this.targetStore.createModel(newRow));
+                    const newRow = this.processRow(headerMap, row, errors, i);
+                    if (newRow) {
+                        records.push(this.targetStore.createModel(newRow));
+                    }
                 }
             }
 
@@ -167,7 +192,58 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         return Ext4.isString(value) ? Ext4.String.trim(value) : value;
     },
 
-    resolveDate: function(field, value, errors, rowIdx){
+    // Header cells carry the same stray whitespace and casing drift as any other pasted cell, and a header
+    // that fails to match drops its whole column, so normalize both sides before comparing them.
+    normalizeHeader: function(header){
+        return Ext4.isString(header) ? Ext4.String.trim(header).toLowerCase() : '';
+    },
+
+    // Maps each normalized header to its column index, first occurrence winning as indexOf() did. Keyed on
+    // pasted text, so membership is tested against own properties only rather than anything Object supplies.
+    buildHeaderMap: function(headers){
+        const map = {};
+        Ext4.each(headers, function(header, idx){
+            const key = this.normalizeHeader(header);
+            if (key && !Object.prototype.hasOwnProperty.call(map, key)) {
+                map[key] = idx;
+            }
+        }, this);
+
+        return map;
+    },
+
+    getHeaderIndex: function(headerMap, name){
+        const key = this.normalizeHeader(name);
+
+        return key && Object.prototype.hasOwnProperty.call(headerMap, key) ? headerMap[key] : -1;
+    },
+
+    // A header the form does not recognize, or two headers naming the same field, means a column is either
+    // dropped or read from the wrong place. Report both rather than importing part of the source silently.
+    // Reported without a row number, since each is a property of the header row as a whole.
+    checkHeaders: function(headers, errors){
+        const seen = {};
+        Ext4.each(headers, function(header){
+            const key = this.normalizeHeader(header);
+            // Trailing empty cells are a routine artifact of a spreadsheet copy and name no column.
+            if (!key) {
+                return;
+            }
+
+            const encoded = Ext4.util.Format.htmlEncode(Ext4.String.trim(header));
+            if (seen[key] === true) {
+                errors.push('Duplicate column: ' + encoded + '. Remove one so it is unambiguous which is imported.');
+            }
+            else {
+                seen[key] = true;
+                if (this.knownHeaders[key] !== true) {
+                    errors.push('Unrecognized column: ' + encoded + '. It matches no field in this form and would not be imported.');
+                }
+            }
+        }, this);
+    },
+
+    resolveDate: function(fieldName, value, errors, rowIdx){
         value = this.normalizeValue(value);
 
         const parsed = LDK.ConvertUtils.parseDate(value);
@@ -175,7 +251,7 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         // parseDate returns null for anything it cannot match. Report it rather than letting the
         // column silently arrive empty, which only surfaces at all when the field is required.
         if (Ext4.isEmpty(parsed) && !Ext4.isEmpty(value)) {
-            errors.push('Row ' + rowIdx + ': unable to parse date for ' + field.name + ': ' + Ext4.util.Format.htmlEncode(value));
+            errors.push('Row ' + rowIdx + ': unable to parse date for ' + fieldName + ': ' + Ext4.util.Format.htmlEncode(value));
         }
 
         return parsed;
@@ -240,28 +316,47 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         return value;
     },
 
-    processRow: function(headers, row, errors, rowIdx){
-        const obj = {
-            Id: this.upperCaseAnimalId ? row[headers.indexOf('Id')].toUpperCase() : row[headers.indexOf('Id')],
-            date: LDK.ConvertUtils.parseDate(row[headers.indexOf('date')]),
-            project: this.resolveProjectByName(row[headers.indexOf('project')], errors, rowIdx)
+    processRow: function(headerMap, row, errors, rowIdx){
+        const obj = {};
+
+        // Seeded only when the column was actually pasted, so that a field this method does not handle is
+        // left for the loop below to match on its own name or import alias.
+        const idIdx = this.getHeaderIndex(headerMap, 'Id');
+        if (idIdx !== -1) {
+            // A row shorter than the header row leaves this undefined, which checkRequired() reports.
+            obj.Id = this.upperCaseAnimalId && Ext4.isString(row[idIdx]) ? row[idIdx].toUpperCase() : row[idIdx];
+        }
+
+        const dateIdx = this.getHeaderIndex(headerMap, 'date');
+        if (dateIdx !== -1) {
+            obj.date = this.resolveDate('date', row[dateIdx], errors, rowIdx);
+        }
+
+        const projectIdx = this.getHeaderIndex(headerMap, 'project');
+        if (projectIdx !== -1) {
+            obj.project = this.resolveProjectByName(row[projectIdx], errors, rowIdx);
         }
 
         Ext4.each(this.fieldConfigs, function(field) {
-            if (!obj[field.name]) {
-                let index = headers.indexOf(field.name);
-                if (index === -1 && field.importAliases?.[0]) {
-                    index = headers.indexOf(field.importAliases?.[0]);
-                }
-                if (index !== -1) {
-                    // Every date column needs parseDate, not just the one named 'date'. Left to the
-                    // raw string, an Ext date field applies JS new Date() semantics, and ES5+ parses a
-                    // bare yyyy-MM-dd as UTC -- so '1965-04-01' lands as the previous day in any
-                    // negative-offset timezone, and '1970-01-01' becomes 0 and is discarded as empty.
-                    obj[field.name] = field.jsonType === 'date'
-                        ? this.resolveDate(field, row[index], errors, rowIdx)
-                        : this.resolveLookup(field, row[index], errors, rowIdx);
-                }
+            // Skip by name rather than by truthiness: a column handled above whose value came back null --
+            // an unknown project, an unparsable date -- must not be resolved a second time here, or the one
+            // cell is reported twice by two paths that match on different columns and disagree.
+            if (obj.hasOwnProperty(field.name)) {
+                return;
+            }
+
+            let index = this.getHeaderIndex(headerMap, field.name);
+            if (index === -1 && field.importAliases?.[0]) {
+                index = this.getHeaderIndex(headerMap, field.importAliases?.[0]);
+            }
+            if (index !== -1) {
+                // Every date column needs parseDate, not just the one named 'date'. Left to the
+                // raw string, an Ext date field applies JS new Date() semantics, and ES5+ parses a
+                // bare yyyy-MM-dd as UTC -- so '1965-04-01' lands as the previous day in any
+                // negative-offset timezone, and '1970-01-01' becomes 0 and is discarded as empty.
+                obj[field.name] = field.jsonType === 'date'
+                    ? this.resolveDate(field.name, row[index], errors, rowIdx)
+                    : this.resolveLookup(field, row[index], errors, rowIdx);
             }
         }, this);
 
@@ -290,12 +385,21 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return null;
         }
 
-        projectName = Ext4.String.leftPad(projectName, 4, '0');
+        // Same load-state check as resolveLookup(): an unloaded store matches nothing, and blaming the
+        // pasted value for that sends the user looking for a problem their source file does not have. The
+        // store is autoLoad, so a submit can race it. Reported without a row number so every row's copy
+        // collapses to one line.
+        if (this.projectStore.isLoading() || !this.projectStore.getCount()){
+            errors.push('No projects are loaded yet. Please retry the import.');
+            return null;
+        }
 
         // find() shares findRecord()'s prefix-match default, so '0123' would otherwise resolve to an
         // unrelated project named '01234'. Require an exact (still case-insensitive) match.
-        const recIdx = this.projectStore.find('name', projectName, 0, false, false, true);
+        const recIdx = this.projectStore.find('name', Ext4.String.leftPad(projectName, 4, '0'), 0, false, false, true);
         if (recIdx === -1){
+            // Echo what was pasted rather than the zero-padded form, so the message names something the
+            // user can find in their source file.
             errors.push('Row ' + rowIdx + ': unknown project ' + Ext4.util.Format.htmlEncode(projectName));
             return null;
         }

--- a/ehr/resources/web/ehr/window/FormBulkAddWindow.js
+++ b/ehr/resources/web/ehr/window/FormBulkAddWindow.js
@@ -159,7 +159,19 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         this.close();
     },
 
-    resolveLookup: function(field, value, errors){
+    resolveDate: function(field, value, errors, rowIdx){
+        const parsed = LDK.ConvertUtils.parseDate(value);
+
+        // parseDate returns null for anything it cannot match. Report it rather than letting the
+        // column silently arrive empty, which only surfaces at all when the field is required.
+        if (Ext4.isEmpty(parsed) && !Ext4.isEmpty(value)) {
+            errors.push('Row ' + rowIdx + ': unable to parse date for ' + field.name + ': ' + value);
+        }
+
+        return parsed;
+    },
+
+    resolveLookup: function(field, value, errors, rowIdx){
         if (!field || !field.lookup)
             return value;
 
@@ -181,6 +193,12 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         const lookupRecord = field.lookup.store.findRecord(field.lookup.displayColumn, value, 0, false, false, true);
         if (lookupRecord) {
             return lookupRecord.data[field.lookup.keyColumn];
+        }
+
+        // Report rather than silently storing the raw text in place of the lookup's key. Skip an
+        // unloaded store, which would otherwise fail every row while its records are still in flight.
+        if (!Ext4.isEmpty(value) && field.lookup.store.getCount()) {
+            errors.push('Row ' + rowIdx + ': unrecognized value for ' + field.name + ': ' + value);
         }
 
         return value;
@@ -205,8 +223,8 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
                     // bare yyyy-MM-dd as UTC -- so '1965-04-01' lands as the previous day in any
                     // negative-offset timezone, and '1970-01-01' becomes 0 and is discarded as empty.
                     obj[field.name] = field.jsonType === 'date'
-                        ? LDK.ConvertUtils.parseDate(row[index])
-                        : this.resolveLookup(field, row[index], errors);
+                        ? this.resolveDate(field, row[index], errors, rowIdx)
+                        : this.resolveLookup(field, row[index], errors, rowIdx);
                 }
             }
         }, this);
@@ -237,7 +255,9 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
 
         projectName = Ext4.String.leftPad(projectName, 4, '0');
 
-        const recIdx = this.projectStore.find('name', projectName);
+        // find() shares findRecord()'s prefix-match default, so '0123' would otherwise resolve to an
+        // unrelated project named '01234'. Require an exact (still case-insensitive) match.
+        const recIdx = this.projectStore.find('name', projectName, 0, false, false, true);
         if (recIdx === -1){
             errors.push('Row ' + rowIdx + ': unknown project ' + projectName);
             return null;

--- a/ehr/resources/web/ehr/window/FormBulkAddWindow.js
+++ b/ehr/resources/web/ehr/window/FormBulkAddWindow.js
@@ -174,7 +174,11 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             }
         }
 
-        const lookupRecord = field.lookup.store.findRecord(field.lookup.displayColumn, value);
+        // findRecord(fieldName, value, startIndex, anyMatch, caseSensitive, exactMatch) defaults to a
+        // PREFIX match, which silently resolves a code to any record whose display value merely starts
+        // with it -- e.g. source 'LABS' matched the record whose meaning is 'LABSINDO' and stored
+        // 'LABSINDO'. Require an exact (still case-insensitive) match.
+        const lookupRecord = field.lookup.store.findRecord(field.lookup.displayColumn, value, 0, false, false, true);
         if (lookupRecord) {
             return lookupRecord.data[field.lookup.keyColumn];
         }
@@ -196,7 +200,13 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
                     index = headers.indexOf(field.importAliases?.[0]);
                 }
                 if (index !== -1) {
-                    obj[field.name] = this.resolveLookup(field, row[index], errors);
+                    // Every date column needs parseDate, not just the one named 'date'. Left to the
+                    // raw string, an Ext date field applies JS new Date() semantics, and ES5+ parses a
+                    // bare yyyy-MM-dd as UTC -- so '1965-04-01' lands as the previous day in any
+                    // negative-offset timezone, and '1970-01-01' becomes 0 and is discarded as empty.
+                    obj[field.name] = field.jsonType === 'date'
+                        ? LDK.ConvertUtils.parseDate(row[index])
+                        : this.resolveLookup(field, row[index], errors);
                 }
             }
         }, this);

--- a/ehr/resources/web/ehr/window/FormBulkAddWindow.js
+++ b/ehr/resources/web/ehr/window/FormBulkAddWindow.js
@@ -55,10 +55,13 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return f.name;
         });
 
-        // Headers are resolved against every field the section declares, not just the importable ones, so a
-        // header naming a field the importer skips (hidden, taskid, qcstate) is recognized and then ignored
-        // rather than reported as unknown.
+        // Header resolution needs both halves of the section separately: the importable fields decide first,
+        // and the ones the importer skips (hidden, taskid, qcstate) are consulted only to tell a header this
+        // form knows but will not import from one it does not recognize at all.
         this.allFieldConfigs = allConfigs;
+        this.skippedFieldConfigs = allConfigs.filter((f) => {
+            return this.fieldConfigs.indexOf(f) === -1;
+        });
 
         this.items = [{
             html : 'This allows you to import data using a simple Excel or TSV file.  To import, cut/paste the contents of the Excel or TSV file (Ctl + A is a good way to select all) into the box below and hit submit. The limit for import is 250 rows.',
@@ -109,7 +112,13 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return;
         }
 
-        const parsed = LDK.Utils.CSVToArray(Ext4.String.trim(text), '\t');
+        // Spaces and line endings are trimmed off the block, but never tabs. Ext4.String.trim() counts a tab
+        // as whitespace, so it stripped the last row's trailing tabs along with them, dropping that row's empty
+        // final cells and leaving it narrower than the rest -- which then read as a truncated row even though
+        // every value in it was correct. Spaces still have to go: a stray one after the final newline would
+        // otherwise parse as a junk one-cell row, and one on a leading blank line would be read as the header
+        // row itself. Individual cells are trimmed downstream by normalizeValue() and buildHeaderMap().
+        const parsed = LDK.Utils.CSVToArray(text.replace(/^[ \r\n]+|[ \r\n]+$/g, ''), '\t');
         if (!parsed){
             Ext4.Msg.alert('Error', 'There was an error parsing the data.');
             return;
@@ -141,10 +150,12 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             // otherwise reports as a missing value on every one of up to 250 rows, burying the one error
             // that explains all of them.
             if (!errors.length) {
+                const columnCount = this.getRequiredColumnCount(headerMap);
+
                 for (let i = 1; i < parsed.length; i++) {
                     const row = parsed[i];
-                    if (!row || row.length < this.requiredFieldNames.length) {
-                        errors.push('Row ' + i + ': not enough items in row');
+                    if (!row || row.length < columnCount) {
+                        errors.push('Row ' + i + ': not enough items in row -- has ' + (row ? row.length : 0) + ', needs at least ' + columnCount);
                         continue;
                     }
 
@@ -179,19 +190,56 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
     },
 
     // Identifies the field a pasted header names, which is what LABKEY.ext4.Util.resolveFieldNameFromLabel()
-    // exists for: it compares case-insensitively against a field's name, label, caption and every import
-    // alias, and accepts importAliases as either an array or a comma-separated string. Matching only the name
-    // and the first alias, as this window used to, drops the column for any other spelling.
+    // exists for: it compares case-insensitively against a field's name, the display names the UI shows for it
+    // (label, caption, shortCaption) and every one of its import aliases. Matching only the name and the first
+    // alias, as this window used to, drops the column for any other spelling.
     //
-    // An exact name match is tried first because the helper stops at its first name/caption/label hit, so a
-    // field whose LABEL matches this header could otherwise win over the field this header actually names,
-    // purely on config order. Only the broader spellings are left to the helper.
+    // Two things are decided here rather than left to the helper, because it breaks out of its search on the
+    // first name or display-name hit: it cannot distinguish one match from several, and so resolves a shared
+    // display name to whichever field is declared first.
     resolveHeaderToFieldName: function(header){
-        const exact = this.allFieldConfigs.find((f) => {
-            return Ext4.isString(f.name) && f.name.toLowerCase() === header.toLowerCase();
-        });
+        // An exact name match wins outright, so the field this header actually names cannot lose to another
+        // field that merely shares its display name. Importable fields are searched first here for the same
+        // reason they are below: a section can declare one name in two queries, and letting the skipped copy
+        // win would drop the column in silence.
+        const exact = this.findFieldByExactName(this.fieldConfigs, header)
+                || this.findFieldByExactName(this.skippedFieldConfigs, header);
+        if (exact) {
+            return exact.name;
+        }
 
-        return exact ? exact.name : LABKEY.ext4.Util.resolveFieldNameFromLabel(header, this.allFieldConfigs);
+        // Several fields answering to one display name is undecidable, and guessing is how a column lands in
+        // the wrong field. Report it instead by resolving to nothing.
+        if (this.countDisplayNameClaimants(this.fieldConfigs, header) > 1) {
+            return null;
+        }
+
+        // Importable fields resolve before the skipped ones so a header cannot be captured by a field the
+        // importer ignores that happens to share its display name -- that would drop the column silently,
+        // since a header resolving to a skipped field is deliberately not reported.
+        return LABKEY.ext4.Util.resolveFieldNameFromLabel(header, this.fieldConfigs)
+                || LABKEY.ext4.Util.resolveFieldNameFromLabel(header, this.skippedFieldConfigs);
+    },
+
+    findFieldByExactName: function(configs, header){
+        const lower = header.toLowerCase();
+
+        return configs.find((f) => {
+            return Ext4.isString(f.name) && f.name.toLowerCase() === lower;
+        });
+    },
+
+    // Counts the fields answering to this header by one of the names the helper treats as identifying. Import
+    // aliases are deliberately excluded: the helper does gather every alias match and rejects an ambiguous one
+    // on its own, so only the display names need counting here.
+    countDisplayNameClaimants: function(configs, header){
+        const lower = header.toLowerCase();
+
+        return configs.filter((f) => {
+            return [f.name, f.label, f.caption, f.shortCaption].some((n) => {
+                return Ext4.isString(n) && n.toLowerCase() === lower;
+            });
+        }).length;
     },
 
     // Maps each field named by the header row to the column holding its values, and reports any header that
@@ -229,11 +277,41 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             map[fieldName] = idx;
         }, this);
 
+        if (!Object.keys(map).length) {
+            // Every cell of an entirely blank header row was skipped above without comment, so say what is
+            // wrong rather than reporting a missing value on all 250 rows that follow.
+            if (!errors.length) {
+                errors.push('The first row must name the columns being imported.');
+            }
+
+            return map;
+        }
+
+        // A required field with no column at all is a property of the header row, not of each row, so report it
+        // once here rather than as a missing value repeated down every row.
+        Ext4.each(this.requiredFieldNames, function(fieldName){
+            if (this.getFieldIndex(map, fieldName) === -1) {
+                errors.push('Missing required column: ' + Ext4.util.Format.htmlEncode(fieldName) + '.');
+            }
+        }, this);
+
         return map;
     },
 
     getFieldIndex: function(headerMap, fieldName){
         return Object.prototype.hasOwnProperty.call(headerMap, fieldName) ? headerMap[fieldName] : -1;
+    },
+
+    // How wide a data row has to be: far enough to reach the last column a REQUIRED field was mapped to.
+    // Measuring against every mapped column instead would reject a row whose only absent cells were empty in
+    // the source anyway, which is an ordinary shape -- the last row of a spreadsheet selection often leaves an
+    // optional trailing cell blank.
+    getRequiredColumnCount: function(headerMap){
+        return this.requiredFieldNames.reduce((count, fieldName) => {
+            const idx = this.getFieldIndex(headerMap, fieldName);
+
+            return idx === -1 ? count : Math.max(count, idx + 1);
+        }, 0);
     },
 
     resolveDate: function(fieldName, value, errors, rowIdx){

--- a/ehr/resources/web/ehr/window/FormBulkAddWindow.js
+++ b/ehr/resources/web/ehr/window/FormBulkAddWindow.js
@@ -55,23 +55,10 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return f.name;
         });
 
-        // A header matching no field silently drops its whole column, so keep the full set of recognized
-        // names to check the pasted header row against. Built from allConfigs rather than fieldConfigs so
-        // the fields the importer itself skips (hidden, taskid, qcstate) count as known but not importable
-        // and are passed over without complaint.
-        this.knownHeaders = {};
-        const addKnownHeader = (name) => {
-            const key = this.normalizeHeader(name);
-            if (key) {
-                this.knownHeaders[key] = true;
-            }
-        };
-        allConfigs.forEach((f) => {
-            addKnownHeader(f.name);
-            (Ext4.isArray(f.importAliases) ? f.importAliases : []).forEach(addKnownHeader);
-        });
-        // processRow() handles these directly, whether or not the section declares them.
-        ['Id', 'date', 'project'].forEach(addKnownHeader);
+        // Headers are resolved against every field the section declares, not just the importable ones, so a
+        // header naming a field the importer skips (hidden, taskid, qcstate) is recognized and then ignored
+        // rather than reported as unknown.
+        this.allFieldConfigs = allConfigs;
 
         this.items = [{
             html : 'This allows you to import data using a simple Excel or TSV file.  To import, cut/paste the contents of the Excel or TSV file (Ctl + A is a good way to select all) into the box below and hit submit. The limit for import is 250 rows.',
@@ -148,8 +135,7 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             errors.push('Row Count - ' + dataRowCount + ': Import maximum is 250 rows.  Please split your import into multiple uploads and submit the form between each upload.');
         }
         else {
-            const headerMap = this.buildHeaderMap(parsed[0]);
-            this.checkHeaders(parsed[0], errors);
+            const headerMap = this.buildHeaderMap(parsed[0], errors);
 
             // Only parse rows once the header row is sound. A misspelled header for a required column
             // otherwise reports as a missing value on every one of up to 250 rows, burying the one error
@@ -192,55 +178,62 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         return Ext4.isString(value) ? Ext4.String.trim(value) : value;
     },
 
-    // Header cells carry the same stray whitespace and casing drift as any other pasted cell, and a header
-    // that fails to match drops its whole column, so normalize both sides before comparing them.
-    normalizeHeader: function(header){
-        return Ext4.isString(header) ? Ext4.String.trim(header).toLowerCase() : '';
+    // Identifies the field a pasted header names, which is what LABKEY.ext4.Util.resolveFieldNameFromLabel()
+    // exists for: it compares case-insensitively against a field's name, label, caption and every import
+    // alias, and accepts importAliases as either an array or a comma-separated string. Matching only the name
+    // and the first alias, as this window used to, drops the column for any other spelling.
+    //
+    // An exact name match is tried first because the helper stops at its first name/caption/label hit, so a
+    // field whose LABEL matches this header could otherwise win over the field this header actually names,
+    // purely on config order. Only the broader spellings are left to the helper.
+    resolveHeaderToFieldName: function(header){
+        const exact = this.allFieldConfigs.find((f) => {
+            return Ext4.isString(f.name) && f.name.toLowerCase() === header.toLowerCase();
+        });
+
+        return exact ? exact.name : LABKEY.ext4.Util.resolveFieldNameFromLabel(header, this.allFieldConfigs);
     },
 
-    // Maps each normalized header to its column index, first occurrence winning as indexOf() did. Keyed on
-    // pasted text, so membership is tested against own properties only rather than anything Object supplies.
-    buildHeaderMap: function(headers){
+    // Maps each field named by the header row to the column holding its values, and reports any header that
+    // resolves to no field or to a field another header already claimed -- either way a column would be read
+    // from the wrong place or not at all. Keyed on the resolved field name rather than the pasted text, so
+    // this is the single answer to "which column holds this field" that processRow() then reads.
+    //
+    // Reported without a row number, since each is a property of the header row as a whole.
+    buildHeaderMap: function(headers, errors){
         const map = {};
+        const claimedBy = {};
+
         Ext4.each(headers, function(header, idx){
-            const key = this.normalizeHeader(header);
-            if (key && !Object.prototype.hasOwnProperty.call(map, key)) {
-                map[key] = idx;
+            const text = Ext4.isString(header) ? Ext4.String.trim(header) : '';
+            // A spreadsheet copy routinely leaves empty cells past the last real column.
+            if (!text) {
+                return;
             }
+
+            const encoded = Ext4.util.Format.htmlEncode(text);
+            const fieldName = this.resolveHeaderToFieldName(text);
+            if (!fieldName) {
+                // The helper reports nothing both for a header no field claims and for an alias several
+                // fields share, so the message cannot promise which of the two it was.
+                errors.push('Unrecognized column: ' + encoded + '. It matches no field in this form, or matches more than one.');
+                return;
+            }
+
+            if (Object.prototype.hasOwnProperty.call(claimedBy, fieldName)) {
+                errors.push('Duplicate column: ' + encoded + ' names the same field as ' + Ext4.util.Format.htmlEncode(claimedBy[fieldName]) + '. Remove one so it is unambiguous which is imported.');
+                return;
+            }
+
+            claimedBy[fieldName] = text;
+            map[fieldName] = idx;
         }, this);
 
         return map;
     },
 
-    getHeaderIndex: function(headerMap, name){
-        const key = this.normalizeHeader(name);
-
-        return key && Object.prototype.hasOwnProperty.call(headerMap, key) ? headerMap[key] : -1;
-    },
-
-    // A header the form does not recognize, or two headers naming the same field, means a column is either
-    // dropped or read from the wrong place. Report both rather than importing part of the source silently.
-    // Reported without a row number, since each is a property of the header row as a whole.
-    checkHeaders: function(headers, errors){
-        const seen = {};
-        Ext4.each(headers, function(header){
-            const key = this.normalizeHeader(header);
-            // Trailing empty cells are a routine artifact of a spreadsheet copy and name no column.
-            if (!key) {
-                return;
-            }
-
-            const encoded = Ext4.util.Format.htmlEncode(Ext4.String.trim(header));
-            if (seen[key] === true) {
-                errors.push('Duplicate column: ' + encoded + '. Remove one so it is unambiguous which is imported.');
-            }
-            else {
-                seen[key] = true;
-                if (this.knownHeaders[key] !== true) {
-                    errors.push('Unrecognized column: ' + encoded + '. It matches no field in this form and would not be imported.');
-                }
-            }
-        }, this);
+    getFieldIndex: function(headerMap, fieldName){
+        return Object.prototype.hasOwnProperty.call(headerMap, fieldName) ? headerMap[fieldName] : -1;
     },
 
     resolveDate: function(fieldName, value, errors, rowIdx){
@@ -320,19 +313,19 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         const obj = {};
 
         // Seeded only when the column was actually pasted, so that a field this method does not handle is
-        // left for the loop below to match on its own name or import alias.
-        const idIdx = this.getHeaderIndex(headerMap, 'Id');
+        // left for the loop below.
+        const idIdx = this.getFieldIndex(headerMap, 'Id');
         if (idIdx !== -1) {
             // A row shorter than the header row leaves this undefined, which checkRequired() reports.
             obj.Id = this.upperCaseAnimalId && Ext4.isString(row[idIdx]) ? row[idIdx].toUpperCase() : row[idIdx];
         }
 
-        const dateIdx = this.getHeaderIndex(headerMap, 'date');
+        const dateIdx = this.getFieldIndex(headerMap, 'date');
         if (dateIdx !== -1) {
             obj.date = this.resolveDate('date', row[dateIdx], errors, rowIdx);
         }
 
-        const projectIdx = this.getHeaderIndex(headerMap, 'project');
+        const projectIdx = this.getFieldIndex(headerMap, 'project');
         if (projectIdx !== -1) {
             obj.project = this.resolveProjectByName(row[projectIdx], errors, rowIdx);
         }
@@ -345,10 +338,9 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
                 return;
             }
 
-            let index = this.getHeaderIndex(headerMap, field.name);
-            if (index === -1 && field.importAliases?.[0]) {
-                index = this.getHeaderIndex(headerMap, field.importAliases?.[0]);
-            }
+            // Every spelling the header row might have used was resolved to a field name up front, so a
+            // label or any import alias the user pasted is already accounted for by this one lookup.
+            const index = this.getFieldIndex(headerMap, field.name);
             if (index !== -1) {
                 // Every date column needs parseDate, not just the one named 'date'. Left to the
                 // raw string, an Ext date field applies JS new Date() semantics, and ES5+ parses a

--- a/ehr/resources/web/ehr/window/FormBulkAddWindow.js
+++ b/ehr/resources/web/ehr/window/FormBulkAddWindow.js
@@ -55,10 +55,8 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return f.name;
         });
 
-        // Header resolution needs both halves of the section separately: the importable fields decide first,
-        // and the ones the importer skips (hidden, taskid, qcstate) are consulted only to tell a header this
-        // form knows but will not import from one it does not recognize at all.
-        this.allFieldConfigs = allConfigs;
+        // The fields the importer skips (hidden, taskid, qcstate) are still consulted during header
+        // resolution, but only to tell a header this form knows from one it does not recognize at all.
         this.skippedFieldConfigs = allConfigs.filter((f) => {
             return this.fieldConfigs.indexOf(f) === -1;
         });
@@ -112,12 +110,11 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return;
         }
 
-        // Spaces and line endings are trimmed off the block, but never tabs. Ext4.String.trim() counts a tab
-        // as whitespace, so it stripped the last row's trailing tabs along with them, dropping that row's empty
-        // final cells and leaving it narrower than the rest -- which then read as a truncated row even though
-        // every value in it was correct. Spaces still have to go: a stray one after the final newline would
-        // otherwise parse as a junk one-cell row, and one on a leading blank line would be read as the header
-        // row itself. Individual cells are trimmed downstream by normalizeValue() and buildHeaderMap().
+        // Trim spaces and line endings off the block but never tabs: Ext4.String.trim() treats a tab as
+        // whitespace, so it stripped the last row's trailing tabs and left that row looking truncated when
+        // every value in it was correct. Spaces still have to go -- a stray one after the final newline parses
+        // as a junk one-cell row, and one on a leading blank line becomes the header row. Cells are trimmed
+        // later by normalizeValue() and buildHeaderMap(), blank rows dropped by isEmptyRow().
         const parsed = LDK.Utils.CSVToArray(text.replace(/^[ \r\n]+|[ \r\n]+$/g, ''), '\t');
         if (!parsed){
             Ext4.Msg.alert('Error', 'There was an error parsing the data.');
@@ -139,23 +136,30 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         //first get global values:
         Ext4.Msg.wait('Processing...');
 
-        const dataRowCount = parsed.length - 1;
+        // Only the rows that will actually be read, since blank ones are skipped below -- counting every
+        // parsed row would turn away a paste of exactly 250 rows that ends in a tab-only line.
+        const dataRowCount = parsed.slice(1).filter((row) => {
+            return !this.isEmptyRow(row);
+        }).length;
         if (dataRowCount > 250) {
             errors.push('Row Count - ' + dataRowCount + ': Import maximum is 250 rows.  Please split your import into multiple uploads and submit the form between each upload.');
         }
         else {
             const headerMap = this.buildHeaderMap(parsed[0], errors);
 
-            // Only parse rows once the header row is sound. A misspelled header for a required column
-            // otherwise reports as a missing value on every one of up to 250 rows, burying the one error
-            // that explains all of them.
+            // Only read rows once the header row is sound: a misspelled header for a required column
+            // otherwise reports as a missing value on all 250 rows, burying the one error that explains them.
             if (!errors.length) {
                 const columnCount = this.getRequiredColumnCount(headerMap);
 
                 for (let i = 1; i < parsed.length; i++) {
                     const row = parsed[i];
-                    if (!row || row.length < columnCount) {
-                        errors.push('Row ' + i + ': not enough items in row -- has ' + (row ? row.length : 0) + ', needs at least ' + columnCount);
+                    if (this.isEmptyRow(row)) {
+                        continue;
+                    }
+
+                    if (row.length < columnCount) {
+                        errors.push('Row ' + i + ': not enough items in row -- has ' + row.length + ', needs at least ' + columnCount);
                         continue;
                     }
 
@@ -170,8 +174,8 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         }
 
         if (errors.length){
-            // A condition that holds for a whole column rather than a single row is reported without a
-            // row number, so the identical copy pushed by every row collapses to one line here.
+            // Column-wide problems are pushed without a row number, so every row's identical copy collapses
+            // to one line here.
             Ext4.Msg.alert('Error', 'There following errors were found:<p>' + Ext4.Array.unique(errors).join('<br>'));
             return;
         }
@@ -183,25 +187,28 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         this.close();
     },
 
-    // Cells pasted out of a spreadsheet routinely carry stray whitespace, which no exact match would
-    // survive. Trim before parsing or matching so a padded cell resolves and a blank one reads as empty.
+    // Pasted cells routinely carry stray whitespace, which no exact match would survive.
     normalizeValue: function(value){
         return Ext4.isString(value) ? Ext4.String.trim(value) : value;
     },
 
-    // Identifies the field a pasted header names, which is what LABKEY.ext4.Util.resolveFieldNameFromLabel()
-    // exists for: it compares case-insensitively against a field's name, the display names the UI shows for it
-    // (label, caption, shortCaption) and every one of its import aliases. Matching only the name and the first
-    // alias, as this window used to, drops the column for any other spelling.
-    //
-    // Two things are decided here rather than left to the helper, because it breaks out of its search on the
-    // first name or display-name hit: it cannot distinguish one match from several, and so resolves a shared
-    // display name to whichever field is declared first.
+    // A row with no value in any cell has nothing to import, so it is skipped rather than reported as missing
+    // every required field. Now that trimming preserves tabs, a spreadsheet selection one row too tall
+    // arrives here as a line of empty cells instead of vanishing with the trailing whitespace.
+    isEmptyRow: function(row){
+        return !row || !row.some((cell) => {
+            return !Ext4.isEmpty(this.normalizeValue(cell));
+        });
+    },
+
+    // Identifies the field a pasted header names. LABKEY.ext4.Util.resolveFieldNameFromLabel() does the
+    // matching -- case-insensitively against name, label, caption, shortCaption and every import alias --
+    // where this window used to try only the name and the first alias, dropping the column for any other
+    // spelling. Ambiguity is decided here instead, since the helper breaks out of its search on the first
+    // name or display-name hit and so cannot tell one match from several.
     resolveHeaderToFieldName: function(header){
-        // An exact name match wins outright, so the field this header actually names cannot lose to another
-        // field that merely shares its display name. Importable fields are searched first here for the same
-        // reason they are below: a section can declare one name in two queries, and letting the skipped copy
-        // win would drop the column in silence.
+        // An exact name match wins outright, so a field cannot lose the header it actually names to another
+        // that merely shares its display name.
         const exact = this.findFieldByExactName(this.fieldConfigs, header)
                 || this.findFieldByExactName(this.skippedFieldConfigs, header);
         if (exact) {
@@ -209,14 +216,14 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         }
 
         // Several fields answering to one display name is undecidable, and guessing is how a column lands in
-        // the wrong field. Report it instead by resolving to nothing.
+        // the wrong field. Resolve to nothing so buildHeaderMap() reports it.
         if (this.countDisplayNameClaimants(this.fieldConfigs, header) > 1) {
             return null;
         }
 
-        // Importable fields resolve before the skipped ones so a header cannot be captured by a field the
-        // importer ignores that happens to share its display name -- that would drop the column silently,
-        // since a header resolving to a skipped field is deliberately not reported.
+        // Importable before skipped, so a header cannot be captured by a field the importer ignores that
+        // happens to share its display name -- that would drop the column silently, since a header resolving
+        // to a skipped field is deliberately not reported.
         return LABKEY.ext4.Util.resolveFieldNameFromLabel(header, this.fieldConfigs)
                 || LABKEY.ext4.Util.resolveFieldNameFromLabel(header, this.skippedFieldConfigs);
     },
@@ -229,9 +236,8 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         });
     },
 
-    // Counts the fields answering to this header by one of the names the helper treats as identifying. Import
-    // aliases are deliberately excluded: the helper does gather every alias match and rejects an ambiguous one
-    // on its own, so only the display names need counting here.
+    // Counts the fields answering to this header by a display name. Import aliases are excluded on purpose:
+    // the helper gathers every alias match and rejects an ambiguous one itself.
     countDisplayNameClaimants: function(configs, header){
         const lower = header.toLowerCase();
 
@@ -242,12 +248,11 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         }).length;
     },
 
-    // Maps each field named by the header row to the column holding its values, and reports any header that
-    // resolves to no field or to a field another header already claimed -- either way a column would be read
-    // from the wrong place or not at all. Keyed on the resolved field name rather than the pasted text, so
-    // this is the single answer to "which column holds this field" that processRow() then reads.
-    //
-    // Reported without a row number, since each is a property of the header row as a whole.
+    // Maps each field named by the header row to the column holding its values, and reports a header that
+    // resolves to no field or to one another header already claimed -- either way a column would be read from
+    // the wrong place or not at all. Keyed on the resolved field name, so this is the single answer to "which
+    // column holds this field" that processRow() reads. Reported without a row number, since each is a
+    // property of the header row as a whole.
     buildHeaderMap: function(headers, errors){
         const map = {};
         const claimedBy = {};
@@ -262,8 +267,8 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             const encoded = Ext4.util.Format.htmlEncode(text);
             const fieldName = this.resolveHeaderToFieldName(text);
             if (!fieldName) {
-                // The helper reports nothing both for a header no field claims and for an alias several
-                // fields share, so the message cannot promise which of the two it was.
+                // Resolution yields nothing whether no field claims the header or several do, so the message
+                // has to cover both.
                 errors.push('Unrecognized column: ' + encoded + '. It matches no field in this form, or matches more than one.');
                 return;
             }
@@ -287,8 +292,7 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return map;
         }
 
-        // A required field with no column at all is a property of the header row, not of each row, so report it
-        // once here rather than as a missing value repeated down every row.
+        // A required field with no column at all is a property of the header row, not of each row.
         Ext4.each(this.requiredFieldNames, function(fieldName){
             if (this.getFieldIndex(map, fieldName) === -1) {
                 errors.push('Missing required column: ' + Ext4.util.Format.htmlEncode(fieldName) + '.');
@@ -303,9 +307,8 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
     },
 
     // How wide a data row has to be: far enough to reach the last column a REQUIRED field was mapped to.
-    // Measuring against every mapped column instead would reject a row whose only absent cells were empty in
-    // the source anyway, which is an ordinary shape -- the last row of a spreadsheet selection often leaves an
-    // optional trailing cell blank.
+    // Measuring against every mapped column would reject a row whose only absent cells were empty in the
+    // source anyway -- the last row of a spreadsheet selection often leaves an optional trailing cell blank.
     getRequiredColumnCount: function(headerMap){
         return this.requiredFieldNames.reduce((count, fieldName) => {
             const idx = this.getFieldIndex(headerMap, fieldName);
@@ -319,8 +322,8 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
 
         const parsed = LDK.ConvertUtils.parseDate(value);
 
-        // parseDate returns null for anything it cannot match. Report it rather than letting the
-        // column silently arrive empty, which only surfaces at all when the field is required.
+        // parseDate() yields nothing for a value it cannot match. Report that rather than letting the column
+        // silently arrive empty, which only surfaces at all when the field is required.
         if (Ext4.isEmpty(parsed) && !Ext4.isEmpty(value)) {
             errors.push('Row ' + rowIdx + ': unable to parse date for ' + fieldName + ': ' + Ext4.util.Format.htmlEncode(value));
         }
@@ -329,6 +332,10 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
     },
 
     resolveLookup: function(field, value, errors, rowIdx){
+        // Normalized here rather than beside the matching below, because every non-date column arrives here:
+        // returning early for a plain one would leave it the only value written through untrimmed.
+        value = this.normalizeValue(value);
+
         if (!field || !field.lookup)
             return value;
 
@@ -343,7 +350,6 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             }
         }
 
-        value = this.normalizeValue(value);
         if (Ext4.isEmpty(value)) {
             return value;
         }
@@ -358,22 +364,17 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         }
 
         // A store holding no records cannot resolve anything, so say so rather than writing the raw text
-        // through as though it had resolved. getCount() on its own is not a load-state check -- it reads
-        // 0 both while records are still in flight and for a store that loaded no rows, and neither can
-        // produce a match. Reported without a row number so every row's copy collapses to one line.
+        // through as though it had resolved. getCount() is not a load-state check on its own -- it reads 0
+        // both while records are in flight and for a store that loaded none, and neither can produce a match.
         if (field.lookup.store.isLoading() || !field.lookup.store.getCount()) {
             errors.push('No lookup values are loaded for ' + field.name + '. Please retry the import.');
             return value;
         }
 
-        // findRecord(fieldName, value, startIndex, anyMatch, caseSensitive, exactMatch) defaults to a
-        // PREFIX match, which silently resolves a code to any record whose display value merely starts
-        // with it -- e.g. source 'LABS' matched the record whose meaning is 'LABSINDO' and stored
-        // 'LABSINDO'. Require an exact (still case-insensitive) match.
-        //
-        // Try the display value first, then the key. A pasted cell legitimately holds either, and before
-        // an exact match was required a pasted key still resolved by falling through as raw text.
-        // EHR.form.field.ProjectEntryField resolves the same two ways.
+        // findRecord(fieldName, value, startIndex, anyMatch, caseSensitive, exactMatch) defaults to a PREFIX
+        // match, which silently resolved 'LABS' to the record whose display value is 'LABSINDO'. Require an
+        // exact -- still case-insensitive -- match, trying the display value then the key, since a pasted
+        // cell legitimately holds either. EHR.form.field.ProjectEntryField resolves the same two ways.
         for (let i = 0; i < columns.length; i++) {
             const lookupRecord = field.lookup.store.findRecord(columns[i], value, 0, false, false, true);
             if (lookupRecord) {
@@ -390,12 +391,15 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
     processRow: function(headerMap, row, errors, rowIdx){
         const obj = {};
 
-        // Seeded only when the column was actually pasted, so that a field this method does not handle is
-        // left for the loop below.
+        // Id, date and project are resolved by name here; the loop below handles every other field and skips
+        // whatever this seeded.
         const idIdx = this.getFieldIndex(headerMap, 'Id');
         if (idIdx !== -1) {
-            // A row shorter than the header row leaves this undefined, which checkRequired() reports.
-            obj.Id = this.upperCaseAnimalId && Ext4.isString(row[idIdx]) ? row[idIdx].toUpperCase() : row[idIdx];
+            // Trimmed like every other cell, and for one reason more: a form that accepts an animal not yet
+            // in the study creates it, so a padded id would silently register a second animal that no query
+            // matching the real id would find. A row too short leaves this undefined for checkRequired().
+            const id = this.normalizeValue(row[idIdx]);
+            obj.Id = this.upperCaseAnimalId && Ext4.isString(id) ? id.toUpperCase() : id;
         }
 
         const dateIdx = this.getFieldIndex(headerMap, 'date');
@@ -409,21 +413,20 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         }
 
         Ext4.each(this.fieldConfigs, function(field) {
-            // Skip by name rather than by truthiness: a column handled above whose value came back null --
-            // an unknown project, an unparsable date -- must not be resolved a second time here, or the one
-            // cell is reported twice by two paths that match on different columns and disagree.
+            // Skip by name, not by truthiness: a field seeded above whose value came back null -- an unknown
+            // project, an unparsable date -- must not be resolved again here, or the same cell is reported
+            // twice, once by each resolver.
             if (obj.hasOwnProperty(field.name)) {
                 return;
             }
 
-            // Every spelling the header row might have used was resolved to a field name up front, so a
-            // label or any import alias the user pasted is already accounted for by this one lookup.
+            // Every spelling the header row might have used was resolved up front, so this one lookup by
+            // field name already accounts for a pasted label or import alias.
             const index = this.getFieldIndex(headerMap, field.name);
             if (index !== -1) {
-                // Every date column needs parseDate, not just the one named 'date'. Left to the
-                // raw string, an Ext date field applies JS new Date() semantics, and ES5+ parses a
-                // bare yyyy-MM-dd as UTC -- so '1965-04-01' lands as the previous day in any
-                // negative-offset timezone, and '1970-01-01' becomes 0 and is discarded as empty.
+                // Every date column needs parseDate, not just the one named 'date'. Left as a raw string an
+                // Ext date field applies new Date() semantics, and ES5+ reads a bare yyyy-MM-dd as UTC, so
+                // '1965-04-01' lands a day early in any negative-offset zone and '1970-01-01' becomes 0.
                 obj[field.name] = field.jsonType === 'date'
                     ? this.resolveDate(field.name, row[index], errors, rowIdx)
                     : this.resolveLookup(field, row[index], errors, rowIdx);
@@ -455,10 +458,9 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             return null;
         }
 
-        // Same load-state check as resolveLookup(): an unloaded store matches nothing, and blaming the
-        // pasted value for that sends the user looking for a problem their source file does not have. The
-        // store is autoLoad, so a submit can race it. Reported without a row number so every row's copy
-        // collapses to one line.
+        // Same load-state check as resolveLookup(): an unloaded store matches nothing, and blaming the pasted
+        // value sends the user hunting a problem their source file does not have. The store is autoLoad, so a
+        // submit can race it.
         if (this.projectStore.isLoading() || !this.projectStore.getCount()){
             errors.push('No projects are loaded yet. Please retry the import.');
             return null;

--- a/ehr/resources/web/ehr/window/FormBulkAddWindow.js
+++ b/ehr/resources/web/ehr/window/FormBulkAddWindow.js
@@ -148,7 +148,9 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         }
 
         if (errors.length){
-            Ext4.Msg.alert('Error', 'There following errors were found:<p>' + errors.join('<br>'));
+            // A condition that holds for a whole column rather than a single row is reported without a
+            // row number, so the identical copy pushed by every row collapses to one line here.
+            Ext4.Msg.alert('Error', 'There following errors were found:<p>' + Ext4.Array.unique(errors).join('<br>'));
             return;
         }
 
@@ -159,13 +161,21 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         this.close();
     },
 
+    // Cells pasted out of a spreadsheet routinely carry stray whitespace, which no exact match would
+    // survive. Trim before parsing or matching so a padded cell resolves and a blank one reads as empty.
+    normalizeValue: function(value){
+        return Ext4.isString(value) ? Ext4.String.trim(value) : value;
+    },
+
     resolveDate: function(field, value, errors, rowIdx){
+        value = this.normalizeValue(value);
+
         const parsed = LDK.ConvertUtils.parseDate(value);
 
         // parseDate returns null for anything it cannot match. Report it rather than letting the
         // column silently arrive empty, which only surfaces at all when the field is required.
         if (Ext4.isEmpty(parsed) && !Ext4.isEmpty(value)) {
-            errors.push('Row ' + rowIdx + ': unable to parse date for ' + field.name + ': ' + value);
+            errors.push('Row ' + rowIdx + ': unable to parse date for ' + field.name + ': ' + Ext4.util.Format.htmlEncode(value));
         }
 
         return parsed;
@@ -186,20 +196,46 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
             }
         }
 
+        value = this.normalizeValue(value);
+        if (Ext4.isEmpty(value)) {
+            return value;
+        }
+
+        // Some client-side lookup configs declare only a key column, so neither of these is guaranteed.
+        // With nothing to match on, pass the value through as the missing-store case above does.
+        const columns = Ext4.Array.unique([field.lookup.displayColumn, field.lookup.keyColumn]).filter(function(c){
+            return !Ext4.isEmpty(c);
+        });
+        if (!columns.length) {
+            return value;
+        }
+
+        // A store holding no records cannot resolve anything, so say so rather than writing the raw text
+        // through as though it had resolved. getCount() on its own is not a load-state check -- it reads
+        // 0 both while records are still in flight and for a store that loaded no rows, and neither can
+        // produce a match. Reported without a row number so every row's copy collapses to one line.
+        if (field.lookup.store.isLoading() || !field.lookup.store.getCount()) {
+            errors.push('No lookup values are loaded for ' + field.name + '. Please retry the import.');
+            return value;
+        }
+
         // findRecord(fieldName, value, startIndex, anyMatch, caseSensitive, exactMatch) defaults to a
         // PREFIX match, which silently resolves a code to any record whose display value merely starts
         // with it -- e.g. source 'LABS' matched the record whose meaning is 'LABSINDO' and stored
         // 'LABSINDO'. Require an exact (still case-insensitive) match.
-        const lookupRecord = field.lookup.store.findRecord(field.lookup.displayColumn, value, 0, false, false, true);
-        if (lookupRecord) {
-            return lookupRecord.data[field.lookup.keyColumn];
+        //
+        // Try the display value first, then the key. A pasted cell legitimately holds either, and before
+        // an exact match was required a pasted key still resolved by falling through as raw text.
+        // EHR.form.field.ProjectEntryField resolves the same two ways.
+        for (let i = 0; i < columns.length; i++) {
+            const lookupRecord = field.lookup.store.findRecord(columns[i], value, 0, false, false, true);
+            if (lookupRecord) {
+                return lookupRecord.data[field.lookup.keyColumn];
+            }
         }
 
-        // Report rather than silently storing the raw text in place of the lookup's key. Skip an
-        // unloaded store, which would otherwise fail every row while its records are still in flight.
-        if (!Ext4.isEmpty(value) && field.lookup.store.getCount()) {
-            errors.push('Row ' + rowIdx + ': unrecognized value for ' + field.name + ': ' + value);
-        }
+        // Report rather than silently storing the raw text in place of the lookup's key.
+        errors.push('Row ' + rowIdx + ': unrecognized value for ' + field.name + ': ' + Ext4.util.Format.htmlEncode(value));
 
         return value;
     },
@@ -249,6 +285,7 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
     },
 
     resolveProjectByName: function(projectName, errors, rowIdx){
+        projectName = this.normalizeValue(projectName);
         if (!projectName){
             return null;
         }
@@ -259,7 +296,7 @@ Ext4.define('EHR.window.FormBulkAddWindow', {
         // unrelated project named '01234'. Require an exact (still case-insensitive) match.
         const recIdx = this.projectStore.find('name', projectName, 0, false, false, true);
         if (recIdx === -1){
-            errors.push('Row ' + rowIdx + ': unknown project ' + projectName);
+            errors.push('Row ' + rowIdx + ': unknown project ' + Ext4.util.Format.htmlEncode(projectName));
             return null;
         }
 


### PR DESCRIPTION
## Rationale

Fixes a set of bugs that let the EHR bulk add importer write wrong or incomplete data without reporting anything, in the UI, the browser console, or the server log.

Because nothing fails, the damage is only discoverable by diffing the loaded data back against the source, so an import can appear clean while carrying shifted dates, missing dates, lookup values swapped for unrelated ones, animal ids carrying stray whitespace, whole columns absent because their header was spelled differently, and — on tables whose key is assigned by the server — only the last of the pasted rows. The reporting added here echoes pasted text back to the user, so it is escaped; an import commonly starts from a spreadsheet someone else produced.

## Related Pull Requests

- [LabKey/johnsHopkinsEHRModules#670](https://github.com/LabKey/johnsHopkinsEHRModules/pull/670) — Selenium coverage for these fixes. Both branches share the name `26.7_fb_bulk_add_date_parse`.

## Changes

- Every date column is parsed like the form's primary date field. The others were read as UTC, so they landed a day early in a negative-offset timezone, and a date on the epoch was dropped as empty.
- Lookup and project values require an exact match rather than a leading substring, so a value can no longer resolve to an unrelated record that merely starts with the same text. Matching stays case-insensitive and accepts either the display value or the key.
- Every pasted cell is trimmed. A padded animal id previously went in as pasted, registering a second animal on forms that create the animals they name.
- A value that resolves to no lookup, project, or date is reported against its row instead of being written through as raw text or left empty, and the import stops so the source can be corrected first.
- Pasted text is escaped wherever it appears in an error message.
- Headers are matched by a field's name, label, or any import alias, as the rest of the product does. Only the exact name and a single alias were tried before, so any other spelling dropped the column silently.
- An unrecognized or duplicated header stops the import before any row is read. Note the behavior change: a spreadsheet carrying extra columns the form does not have must have them removed, where previously they were ignored.
- Trimming the pasted block no longer strips tabs, which were the final row's empty trailing cells and made an otherwise correct row look truncated.
- A line holding no values is skipped rather than reported as missing every required field, and no longer counts toward the 250-row limit.
- A row is measured against the last column a required field occupies rather than the number of required fields, so a row missing only optional trailing cells is no longer rejected.
- A problem belonging to the header row is reported once rather than restated on every one of up to 250 rows.
- Several rows pasted into a table keyed on a server-assigned column stay separate records instead of collapsing onto the last one.
