### PR TITLE
Add shared treatment link display column factory

### DIFF
--- a/ehr/api-src/org/labkey/api/ehr/table/TreatmentLinkConfig.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/TreatmentLinkConfig.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.labkey.api.ehr.table;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A center's vocabulary for the treatment links rendered by {@link TreatmentLinkDisplayColumnFactory}: which data entry
+ * form each treatment category routes to, what the link says, and which report the user returns to.
+ *
+ * The builder starts from the values shared by most centers, so a center only names what differs for it.
+ */
+public class TreatmentLinkConfig
+{
+    /**
+     * The data entry forms a category routes to. A row carrying a caseid goes to a rounds-style form scoped to that
+     * case; a row without one goes to a standalone entry form.
+     */
+    public record FormTypes(String withCase, String withoutCase) {}
+
+    private final String _orderIdParam;
+    private final String _linkText;
+    private final String _returnReport;
+    private final Map<String, FormTypes> _formTypesByCategory;
+    private final FormTypes _defaultFormTypes;
+
+    private TreatmentLinkConfig(Builder builder)
+    {
+        _orderIdParam = builder._orderIdParam;
+        _linkText = builder._linkText;
+        _returnReport = builder._returnReport;
+        _formTypesByCategory = Map.copyOf(builder._formTypesByCategory);
+        _defaultFormTypes = builder._defaultFormTypes;
+    }
+
+    /** Name of the URL parameter carrying the treatment order's objectid. */
+    public String getOrderIdParam()
+    {
+        return _orderIdParam;
+    }
+
+    public String getLinkText()
+    {
+        return _linkText;
+    }
+
+    /** The animalHistory report the data entry form returns to. */
+    public String getReturnReport()
+    {
+        return _returnReport;
+    }
+
+    /** Category match is case-sensitive, matching the behavior of the per-center code this replaced. */
+    public FormTypes getFormTypes(String category)
+    {
+        return _formTypesByCategory.getOrDefault(category, _defaultFormTypes);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    /** Starts from an existing config, for centers that need a variant of one they have already declared. */
+    public static Builder builder(TreatmentLinkConfig base)
+    {
+        return new Builder(base);
+    }
+
+    public static class Builder
+    {
+        private String _orderIdParam = "treatmentid";
+        private String _linkText = "Record Treatment";
+        private String _returnReport = "clinMedicationSchedule";
+        private final Map<String, FormTypes> _formTypesByCategory = new LinkedHashMap<>();
+        private FormTypes _defaultFormTypes = new FormTypes("Clinical Rounds", "medicationTreatment");
+
+        private Builder()
+        {
+            _formTypesByCategory.put("Behavior", new FormTypes("Behavioral Rounds", "Bulk Behavior Entry"));
+        }
+
+        private Builder(TreatmentLinkConfig base)
+        {
+            _orderIdParam = base._orderIdParam;
+            _linkText = base._linkText;
+            _returnReport = base._returnReport;
+            _formTypesByCategory.putAll(base._formTypesByCategory);
+            _defaultFormTypes = base._defaultFormTypes;
+        }
+
+        public Builder orderIdParam(String orderIdParam)
+        {
+            _orderIdParam = orderIdParam;
+            return this;
+        }
+
+        public Builder linkText(String linkText)
+        {
+            _linkText = linkText;
+            return this;
+        }
+
+        public Builder returnReport(String returnReport)
+        {
+            _returnReport = returnReport;
+            return this;
+        }
+
+        public Builder formTypes(String category, String withCase, String withoutCase)
+        {
+            return formTypes(category, new FormTypes(withCase, withoutCase));
+        }
+
+        public Builder formTypes(String category, FormTypes formTypes)
+        {
+            _formTypesByCategory.put(category, formTypes);
+            return this;
+        }
+
+        /** Applies to any category without an explicit mapping. */
+        public Builder defaultFormTypes(String withCase, String withoutCase)
+        {
+            _defaultFormTypes = new FormTypes(withCase, withoutCase);
+            return this;
+        }
+
+        public TreatmentLinkConfig build()
+        {
+            return new TreatmentLinkConfig(this);
+        }
+    }
+}

--- a/ehr/api-src/org/labkey/api/ehr/table/TreatmentLinkConfig.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/TreatmentLinkConfig.java
@@ -12,7 +12,9 @@ import java.util.Map;
  * A center's vocabulary for the treatment links rendered by {@link TreatmentLinkDisplayColumnFactory}: which data entry
  * form each treatment category routes to, what the link says, and which report the user returns to.
  *
- * The builder starts from the values shared by most centers, so a center only names what differs for it.
+ * The builder defaults cover the link text, the order id parameter, the return report, and the forms that categories
+ * without a mapping of their own route to. Category-specific routing is never assumed: a center that treats a category
+ * differently must name it, so its routing is visible where the config is declared rather than inherited from here.
  */
 public class TreatmentLinkConfig
 {
@@ -81,7 +83,6 @@ public class TreatmentLinkConfig
 
         private Builder()
         {
-            _formTypesByCategory.put("Behavior", new FormTypes("Behavioral Rounds", "Bulk Behavior Entry"));
         }
 
         private Builder(TreatmentLinkConfig base)

--- a/ehr/api-src/org/labkey/api/ehr/table/TreatmentLinkDisplayColumnFactory.java
+++ b/ehr/api-src/org/labkey/api/ehr/table/TreatmentLinkDisplayColumnFactory.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 LabKey Corporation
+ *
+ * Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.labkey.api.ehr.table;
+
+import org.labkey.api.data.ColumnInfo;
+import org.labkey.api.data.DataColumn;
+import org.labkey.api.data.DisplayColumn;
+import org.labkey.api.data.DisplayColumnFactory;
+import org.labkey.api.data.RenderContext;
+import org.labkey.api.ehr.security.EHRClinicalEntryPermission;
+import org.labkey.api.query.FieldKey;
+import org.labkey.api.query.UserSchema;
+import org.labkey.api.util.DateUtil;
+import org.labkey.api.util.LinkBuilder;
+import org.labkey.api.view.ActionURL;
+import org.labkey.api.writer.HtmlWriter;
+
+import java.util.Date;
+import java.util.Set;
+
+/**
+ * Renders a link from a treatment order row to the data entry form for that order.
+ *
+ * Use {@link #forSchedule} on tables whose date column is the scheduled slot being recorded (study.treatmentSchedule):
+ * the row's date is passed as scheduledDate so each slot is recorded against its own time. Use {@link #forOrder} on
+ * tables whose date column is the order's start date (study.treatment_order), where passing it as scheduledDate would
+ * make every recording against the order look like the first one.
+ */
+public class TreatmentLinkDisplayColumnFactory implements DisplayColumnFactory
+{
+    private final TreatmentLinkConfig _config;
+    private final boolean _includeScheduledDate;
+
+    private TreatmentLinkDisplayColumnFactory(TreatmentLinkConfig config, boolean includeScheduledDate)
+    {
+        _config = config;
+        _includeScheduledDate = includeScheduledDate;
+    }
+
+    /** For tables whose date is the treatment order's start date. Does not pass scheduledDate. */
+    public static TreatmentLinkDisplayColumnFactory forOrder(TreatmentLinkConfig config)
+    {
+        return new TreatmentLinkDisplayColumnFactory(config, false);
+    }
+
+    /** For tables whose date is the scheduled slot being recorded. Passes that date as scheduledDate. */
+    public static TreatmentLinkDisplayColumnFactory forSchedule(TreatmentLinkConfig config)
+    {
+        return new TreatmentLinkDisplayColumnFactory(config, true);
+    }
+
+    @Override
+    public DisplayColumn createRenderer(final ColumnInfo colInfo)
+    {
+        return new DataColumn(colInfo)
+        {
+            @Override
+            public void renderGridCellContents(RenderContext ctx, HtmlWriter out)
+            {
+                UserSchema schema = colInfo.getParentTable().getUserSchema();
+                if (schema == null || !schema.getContainer().hasPermission(schema.getUser(), EHRClinicalEntryPermission.class))
+                    return;
+
+                String category = (String)ctx.get("category");
+                if (category == null)
+                    return;
+
+                String objectid = (String)getBoundColumn().getValue(ctx);
+                String caseid = (String)ctx.get("caseid");
+                Date date = (Date)ctx.get("date");
+
+                TreatmentLinkConfig.FormTypes formTypes = _config.getFormTypes(category);
+                ActionURL url = new ActionURL("ehr", "dataEntryForm", schema.getContainer());
+                if (caseid != null)
+                {
+                    url.addParameter("formType", formTypes.withCase());
+                    url.addParameter("caseid", caseid);
+                }
+                else
+                {
+                    url.addParameter("formType", formTypes.withoutCase());
+                }
+
+                url.addParameter(_config.getOrderIdParam(), objectid);
+                if (_includeScheduledDate && date != null)
+                    url.addParameter("scheduledDate", DateUtil.formatIsoDateShortTime(date));
+
+                String returnUrl = new ActionURL("ehr", "animalHistory", schema.getContainer())
+                        + "#inputType:none&showReport:0&activeReport:" + _config.getReturnReport();
+                url.addParameter("returnUrl", returnUrl);
+
+                out.write(LinkBuilder.labkeyLink(_config.getLinkText(), url).target("_blank"));
+            }
+
+            @Override
+            public void addQueryFieldKeys(Set<FieldKey> keys)
+            {
+                super.addQueryFieldKeys(keys);
+                keys.add(getBoundColumn().getFieldKey());
+                keys.add(FieldKey.fromString("date"));
+                keys.add(FieldKey.fromString("caseid"));
+                keys.add(FieldKey.fromString("category"));
+            }
+
+            @Override
+            public boolean isSortable()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isFilterable()
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isEditable()
+            {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Rationale

Give the EHR centers one implementation of the treatment order links instead of a copy per center. The renderer was duplicated across three centers, so a recent fix to how the scheduled date is passed had to be made and reviewed once in each. The variation between centers turned out to be small and entirely vocabulary — which data entry form each treatment category routes to, what the link says, and where it returns to — so it is now supplied as configuration.

## Related Pull Requests

- https://github.com/LabKey/nircEHRModules/pull/736
- https://github.com/LabKey/nbriEHRModules/pull/10
- https://github.com/LabKey/johnsHopkinsEHRModules/pull/672

## Changes

- Adds a shared display column factory for the treatment order links, with each center's form type vocabulary supplied as configuration.
- Separates links rendered from a scheduled slot from those rendered from the order itself, which is the distinction the recent scheduled-date fix depends on.
- Additive only. Nothing in this repo changes behavior until the center modules adopt it.