### PR TITLE
Fix longstanding query typo

### DIFF
--- a/Viral_Load_Assay/resources/assay/Viral_Loads/queries/Viral_Load_Summary.sql
+++ b/Viral_Load_Assay/resources/assay/Viral_Loads/queries/Viral_Load_Summary.sql
@@ -23,7 +23,7 @@ count(*) as replicates,
 stddev(viralLoad) as stdDeviation,
 group_concat(distinct v.qcflag, ';') as qcflags,
 group_concat(distinct v.comment, ';') as comments,
-cast(min(v.well) as varchar) as lowestWell,~
+cast(min(v.well) as varchar) as lowestWell,
 v.run,
 v.folder,
 v.workbook


### PR DESCRIPTION
In 26.7 I noticed some error logs on our server. It's cause by this query no longer parsing correctly. I dont know why it's just now being reported (maybe LK tightened some query syntax in 26.7). Nonetheless, I think this is an obvious (and old) typo. 