### PR TITLE
Collapse Clinpath request links after mergesync module removal

### DIFF
--- a/ehr/resources/web/ehr/panel/EnterDataPanel.js
+++ b/ehr/resources/web/ehr/panel/EnterDataPanel.js
@@ -269,14 +269,9 @@ Ext4.define('EHR.panel.EnterDataPanel', {
                     width: 200
                 },{
                     xtype: 'ldk-linkbutton',
-                    text: 'Requests With Manual Results',
+                    text: 'Requests',
                     linkCls: 'labkey-text-link',
-                    href: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'study', 'query.queryName': 'Clinpath Runs', 'query.viewName': 'Requests', 'query.QCState/Label~startswith': 'Request:', 'query.servicerequested/chargetype~eq': 'Clinpath', 'query.mergeSyncInfo/automaticresults~eq': false})
-                },{
-                    xtype: 'ldk-linkbutton',
-                    text: 'Requests With Automatic Results',
-                    linkCls: 'labkey-text-link',
-                    href: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'study', 'query.queryName': 'Clinpath Runs', 'query.viewName': 'Requests', 'query.QCState/Label~startswith': 'Request:', 'query.servicerequested/chargetype~eq': 'Clinpath', 'query.mergeSyncInfo/automaticresults~eq': true})
+                    href: LABKEY.ActionURL.buildURL('query', 'executeQuery', null, {schemaName: 'study', 'query.queryName': 'Clinpath Runs', 'query.viewName': 'Requests', 'query.QCState/Label~startswith': 'Request:', 'query.servicerequested/chargetype~eq': 'Clinpath'})
                 }]
             },{
                 layout: 'hbox',


### PR DESCRIPTION
## Rationale

The Enter Data panel's "Requests With Manual Results" and "Requests With Automatic Results" links filtered on `mergeSyncInfo/automaticresults`, a column supplied by the mergesync module's table customizer. With that module retired the two sets are no longer distinguishable.

## Related Pull Requests

- https://github.com/LabKey/onprcEHRModules/pull/1839

## Changes

- Replaces the two Clinpath request links with a single "Requests" link that drops the removed filter.
